### PR TITLE
docs(ui): entry launcher, review tabs, resizable layout and states

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 > Duetlens 是 [better-review](https://github.com/xieziyu/better-review) 的 **2.0 全重写**:把 code review 从"人消费 agent 一次吐出的 findings"变成"**人与 agent 协同对话式** review"。
 >
-> 状态:设计定稿 · 关键技术假设已验证 · 骨架开发前 · 最后更新 2026-07-18
+> 状态:设计定稿 · 关键技术假设已验证 · 骨架开发前 · 最后更新 2026-07-19
 
 本索引是所有设计文档的**统一入口**。单篇文档只聚焦一个关注点,便于按需 recall。新增设计(如 UI 细化、持久化 schema、提示词系统)时新建分册并在下方"文档地图"登记一行。
 
@@ -15,7 +15,7 @@
 | [design/data-model.md](design/data-model.md) | Review / codex thread / discussion / findings 的数据结构与状态 | 改 schema / 数据流前 |
 | [design/findings-submit.md](design/findings-submit.md) | findings 筛选(保留/剔除)与提交到 GitHub PR review 的流程 | 碰提交流程 / finding 状态前 |
 | [design/codex-integration.md](design/codex-integration.md) | app-server 协议验证结论、MCP HTTP 注入、elicitation/sandbox/审批 | 碰 codex 集成 / MCP / 审批前 |
-| [design/ui.md](design/ui.md) | UI 方向(三栏 + 内联 discussion);后续扩充 | 做界面前 |
+| [design/ui.md](design/ui.md) | UI 方向 + 主题两轴 + 主入口/review 三 tab/扫描态/栏宽等屏与状态 | 做界面前 |
 | [design/open-questions.md](design/open-questions.md) | 待解决 / 风险点(开发中复审) | 遇到坑 / 排优先级时 |
 
 ## 命名约定(易踩)

--- a/docs/design/ui.md
+++ b/docs/design/ui.md
@@ -2,7 +2,7 @@
 
 > 返回 [文档索引](../README.md)
 >
-> 状态:方向已定,细化待补(后续可拆出线框/交互/组件分册)。
+> 状态:方向已定 + 主入口/review 三 tab/扫描态/栏宽已落地(见「屏与状态」);空态/错误态、finding 就地编辑器待补。
 
 - 整体重新设计。
 - **diff review 是主场**——用户交互最多的界面。
@@ -12,9 +12,9 @@
 
 ## 视觉标识:duet 双声道
 
-用**两套色语言**贯穿全局区分说话方:**agent(codex)= 靛蓝**,**human(你)= 琥珀**。作用于代码行 gutter 锚点、finding/discussion 卡片、消息头像、文件树徽标。这是 Duetlens 的记忆点,也让"谁发起的"一眼可辨。
+用**两套色语言**贯穿全局区分说话方:**agent(codex)= 天蓝**(对齐 better-review brand,oklch hue 245;深 `.72` / 浅 `.52`),**human(你)= 琥珀**。作用于代码行 gutter 锚点、finding/discussion 卡片、消息头像、文件树徽标。这是 Duetlens 的记忆点,也让"谁发起的"一眼可辨。实心按钮用深一档 `--accent-solid` + 白字(蓝底黑字已否决)。
 
-字体:wordmark 用 Instrument Serif(人文衬线,点"对话"),工具体 IBM Plex Sans / Plex Mono(工程感),避开通用 AI 味。
+字体:全站 **IBM Plex Sans + IBM Plex Mono**(工程感,去手写体/衬线,避开通用 AI 味);wordmark 为 mono 小写 `duetlens_`(含闪烁光标),结构标签用 mono。
 
 ## 主题:两个正交轴
 
@@ -38,9 +38,40 @@
 - **duet 双声道 accent(agent 靛蓝 / human 琥珀)属于 chrome、跨配色主题恒定**,是品牌标识;仅随明暗取不同深浅(浅色下加深以保证对比度)。
 - mockup `mockup/diff-review.html` 已实装四组合(dark/light × Duetlens/GitHub),顶栏可实时切换,可作实现基线。
 
+## 屏与状态(2026-07-19 落地,以 mockup 为准)
+
+除核心 diff review 外,本轮定下主入口与 review 内的运行时视图。每屏的锚点决策如下,实现时以 mockup 细节为准。
+
+### 主入口 / launcher(`mockup/entry.html`)
+
+- **全屏落地屏**(非命令面板),app 无活动会话时进入。一屏三块:wordmark hero → 发起审核卡片 → 最近的审核(会话历史)。
+- **发起审核卡片**:顶部来源 segmented **GitHub PR / 本地分支 / GitButler** 切换输入区;下方是共享的「附加上下文 + 单一「开始审核」CTA」。三源的列表项**点击=选中**(不各自起审),由底部唯一 CTA 发起。
+- **GitHub 为主路径**:大输入框粘贴 PR 链接 / `owner/repo#123`,**粘贴即解析**出精简预览卡(标题 + 作者 + diffstat)。下方「或从最近 open PR 中选择」浏览列表。
+- **可选本地仓库路径**(仅 GitHub source):填了让 agent 读全量代码,留空则临时 checkout。
+- **可选附加上下文**:折叠 textarea,随首轮机审注入 codex,全程可见,不改 read-only sandbox。入口要显眼(整行带图标控件,非纯文字链接)。
+- **会话历史**直接进首页(不单独开页):source badge + 标题 + findings/discussion 摘要 + 状态(审核中 / 已提交 / 已完成),点行恢复;右上留「全部历史 →」入口。
+
+### 首轮机审衔接态(review 右栏初始态)
+
+- 机审耗时长,**不能用打断心智的 overlay**;「开始审核」直接切到 review 屏,进度在**右栏内联**展示。
+- 右栏显示纵向 **timeline**(拉 diff → 注入 per-thread MCP → 通读 N/M files → 就绪)+ **实时流入的 findings 卡**(可点跳 diff);左侧 diff 全程可读,扫描期可点 finding / 框选提问,无需等待机审结束。
+- 扫描结束自动切回 Discussion / Findings tab。(mockup 顶栏有 `扫描中 / 已完成` demo 开关。)
+
+### review 右栏三 tab
+
+- **Discussion**:当前锚点的对话线程(追问 codex / 框选发起),含 composer。
+- **Findings**:运行时 triage 列表 —— 按严重度分组(可切按文件)+ tally;每行 sev·category / 标题 / `file:line` / origin(◆ agent vs ● 你·提升) / `◇ suggestion` 标记 / triage:保留(天蓝左条)· 剔除(虚线 + 删除线 + 恢复) / submitted passive(绿左条,锁定不可改);底部「＋ 手动新增 finding」。点行跳 diff / 开 discussion。
+- **Summary**:codex 审核总结 —— 结论卡(codex 建议的 review event,标注「仅建议 · 最终 event 在提交时确认」)+ 统计条(high/med/low + 保留/已提交/讨论)+ **可编辑的 codex 生成正文**(即提交屏 review body 的来源)+ 关注主题(按 category 聚合,点击筛 findings)+ 覆盖度行 + 「提交 review →」直达 [findings-submit](findings-submit.md)。
+
+### 布局与栏宽
+
+- 三栏:文件树 / diff(主区,`minmax(0,1fr)` 自适应)/ 会话栏。
+- **左右栏可拖动调宽**:两条分隔线拖拽,带 min/max 约束(文件树 180–420 / 会话栏 300–560),双击复位;由 CSS var `--left-w` / `--right-w` 驱动。**栏宽应按用户持久化**(实现项)。
+
 ## 已有 mockup
 
-- `mockup/diff-review.html` —— 核心屏:三栏 + 内联 discussion + 两轴配色切换。
+- `mockup/entry.html` —— 主入口 / launcher:三源发起 + 粘贴解析 + 会话历史。
+- `mockup/diff-review.html` —— 核心屏:三栏(可调宽)+ 内联 discussion + 右栏三 tab(Discussion/Findings/Summary)+ 首轮机审扫描态 + 两轴配色切换。
 - `mockup/submit-to-github.html` —— findings 筛选与提交到 GitHub 的流程屏(见 [findings-submit](findings-submit.md))。
 
-> 迭代界面时按偏好用 HTML mockup 对齐(而非 ASCII 预览)。后续细化(线框、状态机、组件清单、空态/加载态)在本目录新增分册,并在 [文档索引](../README.md) 登记。
+> 迭代界面时按偏好用 HTML mockup 对齐(而非 ASCII 预览)。后续细化(线框、状态机、组件清单、空态/错误态、finding 就地编辑器)在本目录新增分册,并在 [文档索引](../README.md) 登记。

--- a/docs/design/ui.md
+++ b/docs/design/ui.md
@@ -2,7 +2,7 @@
 
 > 返回 [文档索引](../README.md)
 >
-> 状态:方向已定 + 主入口/review 三 tab/扫描态/栏宽已落地(见「屏与状态」);空态/错误态、finding 就地编辑器待补。
+> 状态:方向已定 + 主入口/review 三 tab/扫描态/栏宽/空态错误态已落地(见「屏与状态」);finding 就地编辑器、Summary 编辑态待补。
 
 - 整体重新设计。
 - **diff review 是主场**——用户交互最多的界面。
@@ -68,10 +68,18 @@
 - 三栏:文件树 / diff(主区,`minmax(0,1fr)` 自适应)/ 会话栏。
 - **左右栏可拖动调宽**:两条分隔线拖拽,带 min/max 约束(文件树 180–420 / 会话栏 300–560),双击复位;由 CSS var `--left-w` / `--right-w` 驱动。**栏宽应按用户持久化**(实现项)。
 
+### 空态 / 错误态(entry,`mockup/entry.html` 顶栏「预览态」可切)
+
+- **首次无历史**:会话历史区显示引导空态(还没有审核记录 + 如何开始),隐藏计数与「全部历史」。
+- **gh 未登录**:GitHub 面板替换为提示卡 —— 说明 Duetlens 依赖 `gh` CLI + `gh auth login` 命令 + 「已登录,重试 / 安装」,并提示**本地分支 / GitButler 来源无需 gh**;此时 CTA 禁用。
+- **PR 解析失败**:输入框标红 + 预览卡转错误态(不存在 / 无权限,附格式提示);CTA 禁用。
+- **仓库路径不匹配**:本地路径的 remote 与 PR 不符 —— **软警告、不阻断**(琥珀提示,继续则忽略本地路径改用临时 checkout),CTA 仍可用。
+- 原则:**硬错误(gh 未登录 / PR 解析失败)禁用 CTA;软警告(路径不匹配)放行**。
+
 ## 已有 mockup
 
 - `mockup/entry.html` —— 主入口 / launcher:三源发起 + 粘贴解析 + 会话历史。
 - `mockup/diff-review.html` —— 核心屏:三栏(可调宽)+ 内联 discussion + 右栏三 tab(Discussion/Findings/Summary)+ 首轮机审扫描态 + 两轴配色切换。
 - `mockup/submit-to-github.html` —— findings 筛选与提交到 GitHub 的流程屏(见 [findings-submit](findings-submit.md))。
 
-> 迭代界面时按偏好用 HTML mockup 对齐(而非 ASCII 预览)。后续细化(线框、状态机、组件清单、空态/错误态、finding 就地编辑器)在本目录新增分册,并在 [文档索引](../README.md) 登记。
+> 迭代界面时按偏好用 HTML mockup 对齐(而非 ASCII 预览)。后续细化(线框、状态机、组件清单、finding 就地编辑器、Summary 编辑态)在本目录新增分册,并在 [文档索引](../README.md) 登记。

--- a/mockup/diff-review.html
+++ b/mockup/diff-review.html
@@ -319,9 +319,41 @@ body.scan .convo .scanview{display:flex}
 .convo[data-tab="summary"] .anchor-ref,.convo[data-tab="summary"] .thread,.convo[data-tab="summary"] .composer{display:none}
 .findings-panel,.summary-panel{display:none}
 .convo[data-tab="findings"] .findings-panel{display:flex;flex-direction:column;min-height:0;flex:1}
-.convo[data-tab="summary"] .summary-panel{display:flex;flex:1;align-items:center;justify-content:center}
+.convo[data-tab="summary"] .summary-panel{display:flex;flex-direction:column;flex:1;min-height:0}
 body.scan .convo .findings-panel,body.scan .convo .summary-panel{display:none!important}
-.sum-stub{font-family:var(--mono);font-size:12px;color:var(--text-faint)}
+.sum-scroll{flex:1;overflow:auto;padding:14px 14px 10px}
+.sum-verdict{border:1px solid var(--border);border-radius:11px;padding:12px 13px;margin-bottom:14px}
+.sum-verdict.rc{border-color:var(--del-gutter);background:color-mix(in oklab,var(--del) 7%,var(--surface))}
+.sv-head{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-dim)}
+.sv-head b{color:var(--text);font-weight:600}
+.sv-ic{width:21px;height:21px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:12px;flex:none;background:var(--del-bg);color:var(--sev-high);border:1px solid var(--del-gutter)}
+.sv-body{font-size:12.5px;color:var(--text-dim);line-height:1.6;margin-top:9px}
+.sv-meta{font-size:11px;color:var(--text-faint);margin-top:9px;font-family:var(--mono);display:flex;align-items:center;gap:6px}
+.sum-stats{display:flex;align-items:center;border:1px solid var(--border);border-radius:11px;background:var(--surface-2);padding:11px 6px;margin-bottom:16px}
+.sum-stats .st{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px}
+.sum-stats .st-n{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--text);line-height:1}
+.sum-stats .st-l{font-size:10px;color:var(--text-faint);font-family:var(--mono)}
+.sum-stats .st-div{width:1px;align-self:stretch;background:var(--border);margin:1px 7px}
+.sum-block{margin-bottom:16px}
+.sb-head{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-faint);margin-bottom:9px}
+.sb-head .sb-edit{color:var(--agent-2);cursor:pointer;text-transform:none;letter-spacing:0}
+.sb-head .sb-by{margin-left:auto;color:var(--text-faint);text-transform:none;letter-spacing:0;display:inline-flex;align-items:center;gap:5px}
+.sb-head .sb-by .gl{width:11px;height:11px;border-radius:3px;background:conic-gradient(from 210deg,var(--agent),var(--agent-2),var(--agent));box-shadow:0 0 0 1px var(--agent-line) inset}
+.sb-prose{font-size:12.5px;color:var(--text-dim);line-height:1.65;border:1px solid var(--border);border-radius:10px;background:var(--surface);padding:11px 12px}
+.sb-prose p{margin-bottom:8px} .sb-prose p:last-child{margin-bottom:0}
+.sb-prose strong{color:var(--text);font-weight:600}
+.sb-prose code{font-family:var(--mono);font-size:11.5px;background:var(--surface-3);padding:1px 5px;border-radius:4px;color:var(--agent-2)}
+.theme{display:flex;align-items:center;gap:9px;padding:8px 10px;border:1px solid var(--border);border-radius:9px;background:var(--surface);margin-bottom:7px;cursor:pointer}
+.theme:hover{border-color:var(--agent-line);background:var(--surface-2)}
+.theme .th-dot{width:8px;height:8px;border-radius:3px;flex:none}
+.theme .th-dot.high{background:var(--sev-high)} .theme .th-dot.med{background:var(--sev-med)} .theme .th-dot.low{background:var(--sev-low)}
+.theme .th-cat{font-family:var(--mono);font-size:11.5px;color:var(--text);font-weight:500}
+.theme .th-note{font-size:11.5px;color:var(--text-faint);flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.theme .th-n{font-family:var(--mono);font-size:10px;color:var(--text-faint);background:var(--surface-3);border:1px solid var(--border);border-radius:5px;padding:0 6px;flex:none}
+.sum-cov{font-family:var(--mono);font-size:10.5px;color:var(--text-faint);padding:2px 2px 4px;line-height:1.7}
+.sum-foot{border-top:1px solid var(--border);padding:12px 14px}
+.sum-submit{width:100%;background:var(--accent-solid);color:var(--on-solid);font-weight:600;border:0;border-radius:10px;padding:11px;cursor:pointer;font-size:13px;text-decoration:none;display:flex;align-items:center;justify-content:center;gap:7px}
+.sum-submit:hover{filter:brightness(1.08)}
 .sev.med{color:var(--sev-med);background:var(--human-soft);border:1px solid var(--human-line)}
 .sev.low{color:var(--sev-low);background:var(--agent-soft);border:1px solid var(--agent-line)}
 .fp-toolbar{display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1px solid var(--border-soft)}
@@ -640,9 +672,47 @@ counter.<span class="fn">fetch_add</span>(<span class="n">1</span>, <span class=
         <button class="add-finding">＋ 手动新增 finding</button>
       </div>
 
-      <!-- Summary tab:占位,待单独设计 -->
+      <!-- Summary tab:codex 对整个 PR 的审核总结 -->
       <div class="summary-panel">
-        <div class="sum-stub">Summary（审核总结）· 下一屏设计</div>
+        <div class="sum-scroll">
+
+          <div class="sum-verdict rc">
+            <div class="sv-head"><span class="sv-ic">✕</span> codex 建议 <b>Request changes</b></div>
+            <div class="sv-body">并行 transcode 的方向可行,但共享状态的线程安全必须收口后再合并。</div>
+            <div class="sv-meta">◇ 仅建议 · 最终 event 在提交时确认</div>
+          </div>
+
+          <div class="sum-stats">
+            <div class="st"><span class="st-n" style="color:var(--sev-high)">1</span><span class="st-l">high</span></div>
+            <div class="st"><span class="st-n" style="color:var(--sev-med)">2</span><span class="st-l">med</span></div>
+            <div class="st"><span class="st-n" style="color:var(--sev-low)">1</span><span class="st-l">low</span></div>
+            <div class="st-div"></div>
+            <div class="st"><span class="st-n">3</span><span class="st-l">保留</span></div>
+            <div class="st"><span class="st-n">1</span><span class="st-l">已提交</span></div>
+            <div class="st"><span class="st-n">2</span><span class="st-l">讨论</span></div>
+          </div>
+
+          <div class="sum-block">
+            <div class="sb-head">总结 <span class="sb-edit">✎ 编辑</span> <span class="sb-by"><span class="gl"></span>codex 生成</span></div>
+            <div class="sb-prose">
+              <p>本 PR 将 transcode 从串行改为基于 <code>JoinSet</code> 的并行 encode,吞吐提升明显,方向正确。</p>
+              <p>主要风险集中在<strong>共享状态的并发安全</strong>:进度计数用了非线程安全的 <code>Cell</code>(实则编译不过),需改 <code>Arc&lt;AtomicUsize&gt;</code>;错误处理上 <code>join_next</code> 的 <code>unwrap</code> 会把单段 panic 放大为整体崩溃。</p>
+              <p>建议合并前处理 2 处 concurrency / error-handling 问题;资源占用(<code>JoinSet</code> 无背压)可后续跟进。</p>
+            </div>
+          </div>
+
+          <div class="sum-block">
+            <div class="sb-head">关注主题 <span class="sb-by">点击筛选 findings</span></div>
+            <div class="theme"><span class="th-dot high"></span><span class="th-cat">concurrency</span><span class="th-note">Cell 跨 spawn 数据竞争</span><span class="th-n">1</span></div>
+            <div class="theme"><span class="th-dot med"></span><span class="th-cat">error-handling</span><span class="th-note">join_next 的 panic 被放大</span><span class="th-n">1</span></div>
+            <div class="theme"><span class="th-dot med"></span><span class="th-cat">resource</span><span class="th-note">JoinSet 无背压 · 已提交</span><span class="th-n">1</span></div>
+          </div>
+
+          <div class="sum-cov">覆盖 6/6 文件 · +188 −41 · gpt-5.1-codex · ctx 82k · read-only sandbox</div>
+        </div>
+        <div class="sum-foot">
+          <a class="sum-submit" href="submit-to-github.html">提交 review · 保留 3 条 <span style="font-size:15px;line-height:1">→</span></a>
+        </div>
       </div>
 
     </div>

--- a/mockup/diff-review.html
+++ b/mockup/diff-review.html
@@ -90,7 +90,7 @@ body{
   background-image:radial-gradient(1200px 600px at 78% -10%, var(--glow1), transparent 60%),
                    radial-gradient(900px 500px at 5% 108%, var(--glow2), transparent 55%);
 }
-:root{--mono:"IBM Plex Mono",ui-monospace,monospace;--sans:"IBM Plex Sans",system-ui,sans-serif;--r:8px}
+:root{--mono:"IBM Plex Mono",ui-monospace,monospace;--sans:"IBM Plex Sans",system-ui,sans-serif;--r:8px;--left-w:236px;--right-w:380px}
 ::selection{background:var(--sel)}
 .topbar,.tree,.diff,.convo,.card,.file-header,.src,.bubble,.composer .box,.mini,.btn,.status,.pr-chip,.seg,.syntax-sel select{
   transition:background-color .25s ease,color .2s ease,border-color .25s ease,box-shadow .2s ease}
@@ -133,14 +133,17 @@ body{
 .submit-cta .cta-badge{font-family:var(--mono);font-size:10px;background:rgba(255,255,255,.22);padding:1px 6px;border-radius:6px}
 
 /* ---------- main grid ---------- */
-.main{display:grid; grid-template-columns:236px minmax(0,1fr) 380px; min-height:0}
+.main{display:grid; grid-template-columns:var(--left-w) 5px minmax(0,1fr) 5px var(--right-w); min-height:0}
+.resizer{position:relative;cursor:col-resize;z-index:6}
+.resizer::before{content:"";position:absolute;left:50%;top:0;bottom:0;width:1px;transform:translateX(-50%);background:var(--border);transition:background .15s,width .15s,box-shadow .15s}
+.resizer:hover::before,.resizer.drag::before{width:2px;background:var(--agent);box-shadow:0 0 0 2px var(--agent-soft)}
 .pane{min-height:0; overflow:auto}
 .pane::-webkit-scrollbar{width:10px;height:10px}
 .pane::-webkit-scrollbar-thumb{background:var(--scroll);border-radius:6px;border:2px solid transparent;background-clip:content-box}
 .pane::-webkit-scrollbar-thumb:hover{background:var(--scroll-h);background-clip:content-box}
 
 /* ---------- left: file tree ---------- */
-.tree{background:var(--surface);border-right:1px solid var(--border)}
+.tree{background:var(--surface)}
 .tree .head{display:flex;align-items:center;justify-content:space-between;padding:12px 14px 8px;position:sticky;top:0;background:var(--surface);z-index:2}
 .tree .head h3{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-faint);font-weight:600}
 .tree .head .count{font-family:var(--mono);font-size:11px;color:var(--text-faint)}
@@ -229,7 +232,7 @@ body{
 .reply-hint{margin-left:auto;font-size:11px;color:var(--text-faint);align-self:center}
 
 /* ---------- right: conversation ---------- */
-.convo{background:var(--surface);border-left:1px solid var(--border);display:flex;flex-direction:column;min-height:0}
+.convo{background:var(--surface);display:flex;flex-direction:column;min-height:0}
 .tabs{display:flex;gap:2px;padding:10px 12px 0;border-bottom:1px solid var(--border)}
 .tab{font-family:var(--mono);padding:7px 12px 9px;font-size:12px;font-weight:500;color:var(--text-faint);cursor:pointer;border-bottom:2px solid transparent}
 .tab.active{color:var(--text);border-bottom-color:var(--agent)}
@@ -455,6 +458,9 @@ body.scan .convo .findings-panel,body.scan .convo .summary-panel{display:none!im
       </div>
     </div>
 
+    <!-- 左侧 resizer -->
+    <div class="resizer" data-target="left" title="拖动调整文件树宽度 · 双击复位"></div>
+
     <!-- ---------- CENTER: diff ---------- -->
     <div class="pane diff">
       <div class="file-header">
@@ -530,6 +536,9 @@ body.scan .convo .findings-panel,body.scan .convo .summary-panel{display:none!im
       </div>
       <div class="expander" title="展开未改动代码"><span class="exic">↕</span> 展开下方 34 行 · 至文件末尾 <span class="rng">150–183</span></div>
     </div>
+
+    <!-- 右侧 resizer -->
+    <div class="resizer" data-target="right" title="拖动调整会话栏宽度 · 双击复位"></div>
 
     <!-- ---------- RIGHT: conversation ---------- -->
     <div class="pane convo" data-tab="discussion">
@@ -753,6 +762,26 @@ document.querySelectorAll('.grp-seg button').forEach(b=>b.onclick=()=>{
   b.parentElement.querySelectorAll('button').forEach(x=>x.classList.toggle('on',x===b));
 });
 document.querySelectorAll('.file').forEach(f=>f.onclick=()=>{document.querySelectorAll('.file').forEach(x=>x.classList.remove('active'));f.classList.add('active');});
+
+// 左右栏拖动(min/max 约束 + 双击复位)
+const LIM={left:[180,420],right:[300,560]},DEF={left:236,right:380};
+let drag=null,sx=0,sw=0;
+document.querySelectorAll('.resizer').forEach(r=>{
+  r.addEventListener('mousedown',e=>{
+    drag=r.dataset.target;sx=e.clientX;
+    sw=parseInt(getComputedStyle(root).getPropertyValue(drag==='left'?'--left-w':'--right-w'));
+    r.classList.add('drag');document.body.style.cursor='col-resize';document.body.style.userSelect='none';
+    e.preventDefault();
+  });
+  r.addEventListener('dblclick',()=>root.style.setProperty(r.dataset.target==='left'?'--left-w':'--right-w',DEF[r.dataset.target]+'px'));
+});
+window.addEventListener('mousemove',e=>{
+  if(!drag)return;
+  const [lo,hi]=LIM[drag],dx=e.clientX-sx;
+  const w=Math.min(hi,Math.max(lo,drag==='left'?sw+dx:sw-dx));
+  root.style.setProperty(drag==='left'?'--left-w':'--right-w',w+'px');
+});
+window.addEventListener('mouseup',()=>{if(drag){document.querySelectorAll('.resizer').forEach(r=>r.classList.remove('drag'));drag=null;document.body.style.cursor='';document.body.style.userSelect='';}});
 </script>
 </body>
 </html>

--- a/mockup/diff-review.html
+++ b/mockup/diff-review.html
@@ -267,6 +267,52 @@ body{
 .composer .scope b{color:var(--human)}
 .stagger{opacity:0;transform:translateY(6px);animation:rise .5s cubic-bezier(.2,.7,.3,1) forwards}
 @keyframes rise{to{opacity:1;transform:none}}
+
+/* ---------- 首轮机审进行中(右栏初始态)---------- */
+.phase-seg button{width:auto;padding:0 9px;font-family:var(--mono);font-size:11px}
+.scanview{display:none;flex-direction:column;min-height:0;flex:1;overflow:auto}
+body.scan .convo .tabs,
+body.scan .convo .anchor-ref,
+body.scan .convo .thread,
+body.scan .convo .composer{display:none}
+body.scan .convo .scanview{display:flex}
+.scan-head{display:flex;align-items:center;gap:11px;padding:14px 14px 12px;border-bottom:1px solid var(--border-soft)}
+.scan-head .sglyph{width:26px;height:26px;border-radius:8px;flex:none;position:relative;
+  background:conic-gradient(from 210deg,var(--agent),var(--agent-2),var(--agent));box-shadow:0 0 0 1px var(--agent-line) inset}
+.scan-head .sglyph::after{content:"";position:absolute;inset:0;border-radius:8px;animation:pulse 2s infinite}
+.scan-head .sh-t{display:flex;flex-direction:column;gap:2px}
+.scan-head .sh-t b{font-size:13px;color:var(--text)}
+.scan-head .sh-s{font-size:11px;color:var(--text-faint);font-family:var(--mono)}
+.timeline{padding:14px 16px 6px;position:relative}
+.tl{display:flex;align-items:center;gap:11px;padding:7px 0;font-size:12.5px;position:relative}
+.tl::before{content:"";position:absolute;left:6px;top:24px;bottom:-7px;width:1.5px;background:var(--border)}
+.tl:last-child::before{display:none}
+.tl .dot{width:13px;height:13px;border-radius:50%;flex:none;border:1.5px solid var(--border);background:var(--surface);z-index:1;position:relative}
+.tl.done .dot{background:var(--agent);border-color:var(--agent);box-shadow:0 0 0 2px var(--agent-soft)}
+.tl.done .dot::after{content:"✓";position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:8px;color:var(--on-solid)}
+.tl.done::before{background:var(--agent-line)}
+.tl.active .dot{border-color:var(--agent);background:var(--agent-soft);animation:pulse 1.6s infinite}
+.tl .tl-l{color:var(--text-dim)}
+.tl.done .tl-l,.tl.active .tl-l{color:var(--text)}
+.tl.pending{opacity:.55}
+.tl .tl-t{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--text-faint)}
+.tl.active .tl-t{color:var(--agent-2)}
+.scan-stream{padding:8px 14px 4px;border-top:1px solid var(--border-soft);margin-top:8px}
+.ss-head{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-faint);margin-bottom:10px}
+.ss-head .ss-n{background:var(--agent-soft);color:var(--agent-2);border:1px solid var(--agent-line);border-radius:5px;padding:0 6px;font-size:10px}
+.ss-head .typing{display:inline-flex;gap:3px;margin-left:2px}
+.ss-head .typing i{width:4px;height:4px;border-radius:50%;background:var(--agent);animation:blink 1.2s infinite}
+.ss-head .typing i:nth-child(2){animation-delay:.2s} .ss-head .typing i:nth-child(3){animation-delay:.4s}
+.sfind{display:flex;align-items:flex-start;gap:9px;padding:9px 10px;border:1px solid var(--border);border-radius:9px;background:var(--surface-2);margin-bottom:8px;cursor:pointer}
+.sfind:hover{border-color:var(--agent-line);background:var(--surface-3)}
+.sfind .m{flex:1;min-width:0}
+.sfind .ft{font-size:12px;color:var(--text);line-height:1.4}
+.sfind .fp{font-family:var(--mono);font-size:10.5px;color:var(--text-faint);margin-top:3px}
+.sfind .go{color:var(--text-faint);font-size:14px;flex:none;align-self:center}
+.sfind:hover .go{color:var(--agent-2)}
+.scan-foot{margin:6px 14px 16px;padding:10px 12px;border:1px dashed var(--agent-line);border-radius:9px;
+  background:color-mix(in oklab,var(--agent) 4%,transparent);font-size:11.5px;color:var(--text-dim);display:flex;gap:8px;align-items:flex-start}
+.scan-foot .ic{color:var(--agent-2)}
 </style>
 </head>
 <body>
@@ -286,6 +332,10 @@ body{
       <span class="status"><span class="pulse"></span> Reviewing</span>
       <a class="submit-cta" href="submit-to-github.html" title="进入筛选并提交 review 到 GitHub">提交 review <span class="cta-badge">3</span></a>
       <div class="switches">
+        <div class="seg phase-seg" id="phaseSeg" title="demo:切换首轮机审进行中 / 已完成">
+          <button data-phase-val="scan">扫描中</button>
+          <button data-phase-val="done" class="on">已完成</button>
+        </div>
         <div class="seg" id="themeSeg">
           <button data-theme-val="light" title="浅色">☀</button>
           <button data-theme-val="dark" class="on" title="深色">☾</button>
@@ -405,6 +455,35 @@ body{
 
     <!-- ---------- RIGHT: conversation ---------- -->
     <div class="pane convo">
+
+      <!-- 首轮机审进行中:右栏初始态(扫描很久,不打断看 diff;进度与对话共用此区) -->
+      <div class="scanview">
+        <div class="scan-head">
+          <span class="sglyph"></span>
+          <div class="sh-t"><b>首轮机审</b><span class="sh-s">codex 正在通读整个 PR · gpt-5.1-codex</span></div>
+        </div>
+        <div class="timeline">
+          <div class="tl done"><span class="dot"></span><span class="tl-l">拉取 diff 与源码树</span><span class="tl-t">1.2s</span></div>
+          <div class="tl done"><span class="dot"></span><span class="tl-l">注入 per-thread MCP · 建立会话</span><span class="tl-t">0.3s</span></div>
+          <div class="tl active"><span class="dot"></span><span class="tl-l">通读 PR,上报 findings</span><span class="tl-t">3/6 files</span></div>
+          <div class="tl pending"><span class="dot"></span><span class="tl-l">就绪 · 可自由追问 / 框选提问</span><span class="tl-t"></span></div>
+        </div>
+        <div class="scan-stream">
+          <div class="ss-head">实时 findings <span class="ss-n">2</span> <span class="typing"><i></i><i></i><i></i></span></div>
+          <div class="sfind stagger" style="animation-delay:.1s">
+            <span class="sev high">high · concurrency</span>
+            <div class="m"><div class="ft">Cell&lt;usize&gt; 跨 spawn 共享非线程安全</div><div class="fp">pipeline.rs:121</div></div>
+            <span class="go">→</span>
+          </div>
+          <div class="sfind stagger" style="animation-delay:.45s">
+            <span class="sev high" style="color:var(--sev-med);background:var(--human-soft);border-color:var(--human-line)">med · error-handling</span>
+            <div class="m"><div class="ft">unwrap() 会在 join 时把 panic 直接传播</div><div class="fp">pipeline.rs:146</div></div>
+            <span class="go">→</span>
+          </div>
+        </div>
+        <div class="scan-foot"><span class="ic">◆</span> 扫描会跑一会儿 —— 期间可点开任一 finding,或在左侧框选代码直接向 codex 提问,无需等待机审结束。</div>
+      </div>
+
       <div class="tabs">
         <div class="tab active">Discussion <span class="n">2</span></div>
         <div class="tab">Findings <span class="n">3</span></div>
@@ -469,6 +548,13 @@ document.querySelectorAll('#themeSeg button').forEach(b=>b.onclick=()=>{
   document.querySelectorAll('#themeSeg button').forEach(x=>x.classList.toggle('on',x===b));
 });
 document.getElementById('themeSel').onchange=e=>root.setAttribute('data-theme',e.target.value);
+document.querySelectorAll('#phaseSeg button').forEach(b=>b.onclick=()=>{
+  document.body.classList.toggle('scan',b.dataset.phaseVal==='scan');
+  document.querySelectorAll('#phaseSeg button').forEach(x=>x.classList.toggle('on',x===b));
+  if(b.dataset.phaseVal==='scan'){ // 重启 stagger,让扫描态 finding 入场
+    document.querySelectorAll('.scanview .stagger').forEach(el=>{el.style.animation='none';el.offsetHeight;el.style.animation='';});
+  }
+});
 document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));t.classList.add('active');});
 document.querySelectorAll('.file').forEach(f=>f.onclick=()=>{document.querySelectorAll('.file').forEach(x=>x.classList.remove('active'));f.classList.add('active');});
 </script>

--- a/mockup/diff-review.html
+++ b/mockup/diff-review.html
@@ -313,6 +313,52 @@ body.scan .convo .scanview{display:flex}
 .scan-foot{margin:6px 14px 16px;padding:10px 12px;border:1px dashed var(--agent-line);border-radius:9px;
   background:color-mix(in oklab,var(--agent) 4%,transparent);font-size:11.5px;color:var(--text-dim);display:flex;gap:8px;align-items:flex-start}
 .scan-foot .ic{color:var(--agent-2)}
+
+/* ---------- Findings tab:运行时列表 ---------- */
+.convo[data-tab="findings"] .anchor-ref,.convo[data-tab="findings"] .thread,.convo[data-tab="findings"] .composer,
+.convo[data-tab="summary"] .anchor-ref,.convo[data-tab="summary"] .thread,.convo[data-tab="summary"] .composer{display:none}
+.findings-panel,.summary-panel{display:none}
+.convo[data-tab="findings"] .findings-panel{display:flex;flex-direction:column;min-height:0;flex:1}
+.convo[data-tab="summary"] .summary-panel{display:flex;flex:1;align-items:center;justify-content:center}
+body.scan .convo .findings-panel,body.scan .convo .summary-panel{display:none!important}
+.sum-stub{font-family:var(--mono);font-size:12px;color:var(--text-faint)}
+.sev.med{color:var(--sev-med);background:var(--human-soft);border:1px solid var(--human-line)}
+.sev.low{color:var(--sev-low);background:var(--agent-soft);border:1px solid var(--agent-line)}
+.fp-toolbar{display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1px solid var(--border-soft)}
+.grp-seg{display:flex;background:var(--surface-3);border:1px solid var(--border);border-radius:7px;padding:2px}
+.grp-seg button{border:0;background:transparent;color:var(--text-faint);border-radius:5px;cursor:pointer;font-size:11px;padding:3px 10px;font-family:var(--mono)}
+.grp-seg button.on{background:var(--surface);color:var(--text);box-shadow:0 0 0 1px var(--agent-line) inset}
+.fp-tally{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--text-faint)}
+.fp-tally b{color:var(--agent-2)}
+.fp-list{overflow:auto;padding:8px 12px 10px;flex:1;min-height:0}
+.fgroup{margin-bottom:4px}
+.fg-head{display:flex;align-items:center;gap:8px;padding:7px 1px 7px;position:sticky;top:0;background:var(--surface);z-index:1}
+.fg-head .fg-n{font-family:var(--mono);font-size:10px;color:var(--text-faint);background:var(--surface-3);border:1px solid var(--border);border-radius:5px;padding:0 6px}
+.fg-head .fg-line{flex:1;height:1px;background:var(--border-soft)}
+.frow{border:1px solid var(--border);border-radius:10px;background:var(--surface);padding:10px 11px;margin-bottom:8px;cursor:pointer}
+.frow:hover{border-color:var(--agent-line);background:linear-gradient(180deg,var(--surface),color-mix(in oklab,var(--agent) 3%,var(--surface)))}
+.frow.kept{border-left:3px solid var(--agent)}
+.frow.submitted{border-left:3px solid var(--add)}
+.frow.dismissed{opacity:.5;border-style:dashed}
+.frow.dismissed .fr-title{text-decoration:line-through;color:var(--text-faint)}
+.fr-top{display:flex;align-items:center;gap:8px;margin-bottom:6px}
+.fr-top .origin{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--text-faint);display:inline-flex;align-items:center;gap:5px}
+.fr-top .origin .d{width:6px;height:6px;border-radius:50%}
+.fr-top .origin.agent .d{background:var(--agent)} .fr-top .origin.human .d{background:var(--human)}
+.fr-title{font-size:12.5px;font-weight:600;color:var(--text);line-height:1.4}
+.fr-foot{display:flex;align-items:center;gap:9px;margin-top:9px}
+.fr-foot .anchor{font-family:var(--mono);font-size:10.5px;color:var(--text-faint)}
+.fr-foot .anchor b{color:var(--text-dim);font-weight:500}
+.fr-foot .sugg-tag{font-family:var(--mono);font-size:10px;color:var(--agent-2)}
+.fr-foot .subm{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--add);border:1px solid var(--add-gutter);background:var(--add-bg);border-radius:5px;padding:1px 7px}
+.triage{margin-left:auto;display:inline-flex;gap:4px}
+.triage button{border:1px solid var(--border);background:var(--surface-2);color:var(--text-faint);border-radius:6px;font-size:10.5px;padding:3px 9px;cursor:pointer;font-family:var(--sans)}
+.triage button:hover{color:var(--text);border-color:var(--agent-line)}
+.triage .t-keep.on{background:var(--agent-soft);border-color:var(--agent-line);color:var(--agent-2)}
+.triage .t-drop.on{background:var(--del-bg);border-color:var(--del-gutter);color:var(--del)}
+.fr-restore{margin-left:auto;font-size:10.5px;color:var(--agent-2);border:1px solid var(--agent-line);background:var(--agent-soft);border-radius:6px;padding:3px 9px;cursor:pointer;font-family:var(--sans)}
+.add-finding{margin:0 12px 14px;border:1px dashed var(--border);border-radius:9px;background:transparent;color:var(--text-dim);font-size:12px;padding:9px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;font-family:var(--sans)}
+.add-finding:hover{border-color:var(--human-line);color:var(--human)}
 </style>
 </head>
 <body>
@@ -454,7 +500,7 @@ body.scan .convo .scanview{display:flex}
     </div>
 
     <!-- ---------- RIGHT: conversation ---------- -->
-    <div class="pane convo">
+    <div class="pane convo" data-tab="discussion">
 
       <!-- 首轮机审进行中:右栏初始态(扫描很久,不打断看 diff;进度与对话共用此区) -->
       <div class="scanview">
@@ -485,9 +531,9 @@ body.scan .convo .scanview{display:flex}
       </div>
 
       <div class="tabs">
-        <div class="tab active">Discussion <span class="n">2</span></div>
-        <div class="tab">Findings <span class="n">3</span></div>
-        <div class="tab">Summary</div>
+        <div class="tab active" data-tab="discussion">Discussion <span class="n">2</span></div>
+        <div class="tab" data-tab="findings">Findings <span class="n">4</span></div>
+        <div class="tab" data-tab="summary">Summary</div>
       </div>
       <div class="anchor-ref" title="跳到代码">
         <span class="bar"></span>
@@ -536,6 +582,69 @@ counter.<span class="fn">fetch_add</span>(<span class="n">1</span>, <span class=
         </div>
         <div class="scope">◆ 全局会话 · 已锚定 <b>pipeline.rs:121</b> · read-only sandbox</div>
       </div>
+
+      <!-- Findings tab:运行时列表(triage + 导航,submit 前的中心视图) -->
+      <div class="findings-panel">
+        <div class="fp-toolbar">
+          <div class="grp-seg"><button class="on">严重度</button><button>文件</button></div>
+          <span class="fp-tally">保留 <b>3</b> · 剔除 1</span>
+        </div>
+        <div class="fp-list">
+
+          <div class="fgroup">
+            <div class="fg-head"><span class="sev high">high</span><span class="fg-n">1</span><span class="fg-line"></span></div>
+            <div class="frow kept" title="跳到 diff / 打开 discussion">
+              <div class="fr-top"><span class="sev high">high · concurrency</span><span class="origin agent"><span class="d"></span>codex</span></div>
+              <div class="fr-title">Cell&lt;usize&gt; 跨 spawn 共享数据竞争</div>
+              <div class="fr-foot">
+                <span class="anchor">📍 <b>pipeline.rs</b>:121</span>
+                <span class="sugg-tag">◇ suggestion</span>
+                <span class="triage"><button class="t-keep on">保留</button><button class="t-drop">剔除</button></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="fgroup">
+            <div class="fg-head"><span class="sev med">med</span><span class="fg-n">2</span><span class="fg-line"></span></div>
+            <div class="frow kept" title="跳到 diff / 打开 discussion">
+              <div class="fr-top"><span class="sev med">med · error-handling</span><span class="origin human"><span class="d"></span>你 · 提升</span></div>
+              <div class="fr-title">join_next 的 panic 被 unwrap 直接放大</div>
+              <div class="fr-foot">
+                <span class="anchor">📍 <b>pipeline.rs</b>:146</span>
+                <span class="triage"><button class="t-keep on">保留</button><button class="t-drop">剔除</button></span>
+              </div>
+            </div>
+            <div class="frow submitted" title="已提交,不可再改">
+              <div class="fr-top"><span class="sev med">med · resource</span><span class="origin agent"><span class="d"></span>codex</span></div>
+              <div class="fr-title">JoinSet 无背压,超大 job 可能占满内存</div>
+              <div class="fr-foot">
+                <span class="anchor">📍 <b>handler.rs</b>:34</span>
+                <span class="subm">✓ 已提交 · #482</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="fgroup">
+            <div class="fg-head"><span class="sev low">low</span><span class="fg-n">1</span><span class="fg-line"></span></div>
+            <div class="frow dismissed" title="跳到 diff / 打开 discussion">
+              <div class="fr-top"><span class="sev low">low · style</span><span class="origin agent"><span class="d"></span>codex</span></div>
+              <div class="fr-title">变量名 c 可读性差</div>
+              <div class="fr-foot">
+                <span class="anchor">📍 <b>pipeline.rs</b>:123</span>
+                <button class="fr-restore">↩ 恢复</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <button class="add-finding">＋ 手动新增 finding</button>
+      </div>
+
+      <!-- Summary tab:占位,待单独设计 -->
+      <div class="summary-panel">
+        <div class="sum-stub">Summary（审核总结）· 下一屏设计</div>
+      </div>
+
     </div>
 
   </div>
@@ -555,7 +664,24 @@ document.querySelectorAll('#phaseSeg button').forEach(b=>b.onclick=()=>{
     document.querySelectorAll('.scanview .stagger').forEach(el=>{el.style.animation='none';el.offsetHeight;el.style.animation='';});
   }
 });
-document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));t.classList.add('active');});
+const convo=document.querySelector('.convo');
+document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
+  document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
+  t.classList.add('active');
+  convo.setAttribute('data-tab',t.dataset.tab);
+});
+// triage 保留/剔除
+document.querySelectorAll('.triage').forEach(tr=>tr.querySelectorAll('button').forEach(b=>b.onclick=e=>{
+  e.stopPropagation();
+  tr.querySelectorAll('button').forEach(x=>x.classList.remove('on'));
+  b.classList.add('on');
+  const row=tr.closest('.frow');
+  row.classList.toggle('kept',b.classList.contains('t-keep'));
+  row.classList.toggle('dismissed',b.classList.contains('t-drop'));
+}));
+document.querySelectorAll('.grp-seg button').forEach(b=>b.onclick=()=>{
+  b.parentElement.querySelectorAll('button').forEach(x=>x.classList.toggle('on',x===b));
+});
 document.querySelectorAll('.file').forEach(f=>f.onclick=()=>{document.querySelectorAll('.file').forEach(x=>x.classList.remove('active'));f.classList.add('active');});
 </script>
 </body>

--- a/mockup/entry.html
+++ b/mockup/entry.html
@@ -239,6 +239,50 @@ button{font-family:inherit}
 .footcta .gobtn{margin-left:auto}
 .gobtn{display:inline-flex;align-items:center;gap:8px;background:var(--accent-solid);color:var(--on-solid);border:0;border-radius:11px;padding:11px 20px;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
 .gobtn:hover{filter:brightness(1.08)}
+
+/* ---------- 空态 / 错误态(预览态切换)---------- */
+.resolved.err,.pathfield.warn,.path-warn,.gh-auth,.empty-history{display:none}
+/* PR 解析失败 */
+body[data-state="pr-error"] .resolved.ok{display:none}
+body[data-state="pr-error"] .resolved.err{display:flex}
+body[data-state="pr-error"] .gh-normal .field{border-color:var(--del-gutter);box-shadow:0 0 0 3px var(--del-bg)}
+body[data-state="pr-error"] .cardfoot .footcta{opacity:.45;pointer-events:none}
+.resolved.err{border-color:var(--del-gutter);background:color-mix(in oklab,var(--del) 6%,var(--surface-2))}
+.resolved .ok.err{background:var(--del-bg);color:var(--sev-high);border-color:var(--del-gutter)}
+.resolved.err .ttl{color:var(--text)}
+.resolved.err .l2{color:var(--text-faint)}
+.resolved.err .emsg{color:var(--sev-high)}
+.resolved.err code{font-family:var(--mono);font-size:11px;background:var(--surface-3);padding:1px 5px;border-radius:4px;color:var(--text-dim)}
+/* 路径不匹配(软警告,不阻断) */
+body[data-state="path-mismatch"] .pathfield.ok{display:none}
+body[data-state="path-mismatch"] .pathfield.warn{display:flex}
+body[data-state="path-mismatch"] .path-warn{display:block}
+.pathfield.warn{border-color:var(--human-line)}
+.pf-tag.warn{color:var(--human);border-color:var(--human-line);background:var(--human-soft)}
+.path-warn{margin-top:8px;font-size:11.5px;color:var(--text-dim);line-height:1.55;padding:9px 11px;border:1px solid var(--human-line);border-radius:9px;background:var(--human-soft)}
+.path-warn code{font-family:var(--mono);font-size:11px;color:var(--human)}
+/* gh 未登录 */
+body[data-state="gh-auth"] .gh-normal{display:none}
+body[data-state="gh-auth"] .gh-auth{display:block}
+body[data-state="gh-auth"] .cardfoot .footcta{opacity:.45;pointer-events:none}
+.gh-auth{border:1px solid var(--human-line);border-radius:12px;background:var(--human-soft);padding:16px}
+.ga-head{display:flex;align-items:center;gap:9px;font-size:13.5px;color:var(--text)}
+.ga-ic{width:22px;height:22px;border-radius:7px;display:flex;align-items:center;justify-content:center;background:color-mix(in oklab,var(--human) 20%,transparent);color:var(--human);border:1px solid var(--human-line);font-size:12px;flex:none}
+.ga-body{font-size:12.5px;color:var(--text-dim);margin-top:11px;line-height:1.6}
+.ga-body code{font-family:var(--mono);font-size:11.5px;color:var(--human)}
+.ga-cmd{margin-top:11px;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:9px 12px;font-family:var(--mono);font-size:12px;color:var(--agent-2)}
+.ga-actions{display:flex;align-items:center;gap:14px;margin-top:13px}
+.ga-retry{background:var(--accent-solid);color:var(--on-solid);border:0;border-radius:8px;padding:8px 15px;font-size:12px;font-weight:600;cursor:pointer}
+.ga-install{font-size:12px;color:var(--agent-2);text-decoration:none;cursor:pointer}
+.ga-alt{margin-top:13px;font-size:11.5px;color:var(--text-faint)}
+/* 首次无历史 */
+body[data-state="empty"] .recent{display:none}
+body[data-state="empty"] .section-head .count,body[data-state="empty"] .section-head .clear{display:none}
+body[data-state="empty"] .empty-history{display:flex}
+.empty-history{flex-direction:column;align-items:center;text-align:center;gap:7px;padding:34px 22px;border:1px dashed var(--border);border-radius:14px;background:var(--surface)}
+.empty-history .eh-ic{width:46px;height:46px;border-radius:13px;display:flex;align-items:center;justify-content:center;font-size:20px;background:var(--agent-soft);color:var(--agent-2);border:1px solid var(--agent-line);margin-bottom:3px}
+.empty-history .eh-t{font-size:14px;font-weight:600;color:var(--text)}
+.empty-history .eh-s{font-size:12.5px;color:var(--text-faint);max-width:360px;line-height:1.65}
 </style>
 </head>
 <body>
@@ -249,6 +293,15 @@ button{font-family:inherit}
     <div class="brand"><span class="mark">duet<i>lens</i><span class="cur">_</span></span></div>
     <div class="spacer"></div>
     <div class="switches">
+      <label class="syntax-sel">预览态
+        <select id="stateSel">
+          <option value="normal">正常</option>
+          <option value="empty">首次无历史</option>
+          <option value="gh-auth">gh 未登录</option>
+          <option value="pr-error">PR 解析失败</option>
+          <option value="path-mismatch">路径不匹配</option>
+        </select>
+      </label>
       <div class="seg" id="modeSeg">
         <button data-mode-val="light" title="浅色">☀</button>
         <button data-mode-val="dark" class="on" title="深色">☾</button>
@@ -296,6 +349,7 @@ button{font-family:inherit}
 
         <!-- GitHub panel -->
         <div class="panel" data-panel="github">
+         <div class="gh-normal">
           <div class="field">
             <span class="gh"><svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></span>
             <input value="github.com/xieziyu/podcast-go/pull/482" spellcheck="false">
@@ -303,7 +357,7 @@ button{font-family:inherit}
           </div>
 
           <!-- resolved preview(粘贴/解析后)· 精简 -->
-          <div class="resolved">
+          <div class="resolved ok">
             <span class="ok">✓</span>
             <div class="info">
               <div class="l1"><span class="num">#482</span> <span class="ttl">feat: streaming transcode</span></div>
@@ -314,12 +368,28 @@ button{font-family:inherit}
             </div>
           </div>
 
+          <!-- 解析失败态 -->
+          <div class="resolved err">
+            <span class="ok err">!</span>
+            <div class="info">
+              <div class="l1"><span class="ttl">无法解析这个 PR</span></div>
+              <div class="l2"><span class="emsg">该 PR 不存在,或你没有访问权限。</span> 确认链接,或用 <code>owner/repo#123</code> 格式重试。</div>
+            </div>
+          </div>
+
           <!-- 可选:本地仓库路径,让 agent 读全量代码 -->
-          <label class="pathfield">
+          <label class="pathfield ok">
             <span class="pf-ic">⌂</span>
             <input placeholder="本地仓库路径(可选)· 让 agent 读全量代码,留空则临时 checkout" value="~/Projects/podcast-go" spellcheck="false">
             <span class="pf-tag">已匹配 ✓</span>
           </label>
+          <!-- 路径不匹配态 -->
+          <label class="pathfield warn">
+            <span class="pf-ic">⌂</span>
+            <input value="~/Projects/other-service" spellcheck="false">
+            <span class="pf-tag warn">remote 不匹配 ⚠</span>
+          </label>
+          <div class="path-warn">该目录的 remote 不是 <code>xieziyu/podcast-go</code>。继续将忽略本地路径、改用临时 checkout;或选对目录以复用本地全量代码。</div>
 
           <div class="orline">或从最近的 open PR 中选择</div>
           <div class="reporow">
@@ -347,6 +417,16 @@ button{font-family:inherit}
               <div class="m"><div class="t">refactor: extract feed builder into module</div><div class="s"><span>@ryan · 1d</span><span><span class="a">+310</span> <span class="d">−212</span></span></div></div>
               <span class="go">→</span>
             </div>
+          </div>
+         </div>
+
+          <!-- gh 未登录态 -->
+          <div class="gh-auth">
+            <div class="ga-head"><span class="ga-ic">⚠</span> <b>未检测到 GitHub CLI 登录</b></div>
+            <div class="ga-body">Duetlens 通过 <code>gh</code> CLI 拉取 PR diff、并在提交时回写 review。请先在终端登录:</div>
+            <div class="ga-cmd">$ gh auth login</div>
+            <div class="ga-actions"><button class="ga-retry">已登录,重试</button><a class="ga-install">安装 GitHub CLI ↗</a></div>
+            <div class="ga-alt">◇ 本地分支 / GitButler 来源无需 gh,可直接开始。</div>
           </div>
         </div>
 
@@ -447,6 +527,12 @@ button{font-family:inherit}
             <span class="arrow">→</span>
           </div>
         </div>
+        <!-- 首次无历史空态 -->
+        <div class="empty-history">
+          <div class="eh-ic">◇</div>
+          <div class="eh-t">还没有审核记录</div>
+          <div class="eh-s">在上面粘贴一个 PR 链接,或选择本地分支 / GitButler 来源,开始你的第一次协同 review。完成的审核会留在这里,随时可以恢复。</div>
+        </div>
       </div>
 
       <div class="foot"><span class="glyph"></span> codex · gpt-5.1-codex <span class="dot"></span> read-only sandbox <span class="dot"></span> app-server 常驻会话</div>
@@ -464,6 +550,12 @@ document.querySelectorAll('#modeSeg button').forEach(b=>b.onclick=()=>{
 });
 // theme
 document.getElementById('themeSel').onchange=e=>root.setAttribute('data-theme',e.target.value);
+// 预览态(空态/错误态)。gh 相关态自动切到 GitHub tab
+document.getElementById('stateSel').onchange=e=>{
+  const v=e.target.value;
+  document.body.setAttribute('data-state',v);
+  if(['gh-auth','pr-error','path-mismatch'].includes(v))document.querySelector('#srcSeg button[data-src="github"]').click();
+};
 // source panels
 document.querySelectorAll('#srcSeg button').forEach(b=>b.onclick=()=>{
   document.querySelectorAll('#srcSeg button').forEach(x=>x.classList.toggle('on',x===b));

--- a/mockup/entry.html
+++ b/mockup/entry.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-mode="dark" data-theme="duetlens">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Duetlens — Entry / Launcher (mockup)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* 复用 diff-review 的两轴配色系统(data-mode × data-theme) —— 此屏无代码,故只保留 chrome 变量 */
+:root{
+  color-scheme:dark;
+  --bg:#0b0d12; --surface:#12151d; --surface-2:#171b24; --surface-3:#1c212c;
+  --border:#232834; --border-soft:#1b2028;
+  --text:#e7eaf1; --text-dim:#9aa3b2; --text-faint:#5f6877;
+  --agent:oklch(.72 .14 245); --agent-2:oklch(.82 .11 240);
+  --agent-soft:color-mix(in oklab,var(--agent) 14%,transparent); --agent-line:color-mix(in oklab,var(--agent) 38%,transparent);
+  --accent-solid:oklch(.585 .16 245); --on-solid:#fff;
+  --human:#e8a24d; --human-soft:rgba(232,162,77,.13); --human-line:rgba(232,162,77,.4);
+  --hover:rgba(255,255,255,.02);
+  --scroll:#262c38; --scroll-h:#323a48; --shadow:0 18px 48px -22px rgba(0,0,0,.75);
+  --glow1:color-mix(in oklab,var(--agent) 9%,transparent); --glow2:rgba(232,162,77,.05);
+  --add:#57e39a; --del:#ff7085;
+  --sev-high:#ff7085; --sev-med:#e8a24d; --sev-low:#8b9bff;
+  --mono:"IBM Plex Mono",ui-monospace,monospace; --sans:"IBM Plex Sans",system-ui,sans-serif; --r:10px;
+}
+:root[data-mode="light"]{
+  color-scheme:light;
+  --bg:#ffffff; --surface:#f6f8fa; --surface-2:#eef1f4; --surface-3:#e6eaee;
+  --border:#d6dde3; --border-soft:#e6eaee;
+  --text:#1f2328; --text-dim:#57606a; --text-faint:#8b949e;
+  --agent:oklch(.52 .13 245); --agent-2:oklch(.46 .14 246);
+  --agent-soft:color-mix(in oklab,var(--agent) 10%,transparent); --agent-line:color-mix(in oklab,var(--agent) 28%,transparent);
+  --accent-solid:oklch(.52 .15 245); --on-solid:#fff;
+  --human:#b7791f; --human-soft:rgba(183,121,31,.12); --human-line:rgba(183,121,31,.35);
+  --hover:rgba(31,35,40,.03);
+  --scroll:#d0d7de; --scroll-h:#b9c1ca; --shadow:0 20px 50px -26px rgba(31,35,40,.32);
+  --glow1:color-mix(in oklab,var(--agent) 6%,transparent); --glow2:rgba(183,121,31,.05);
+  --add:#1a7f37; --del:#cf222e;
+  --sev-high:#cf222e; --sev-med:#9a6700; --sev-low:#4f57d6;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html,body{height:100%}
+body{font-family:var(--sans);background:var(--bg);color:var(--text);font-size:13px;line-height:1.5;
+  overflow:hidden;-webkit-font-smoothing:antialiased;
+  background-image:radial-gradient(1200px 640px at 82% -12%,var(--glow1),transparent 60%),
+                   radial-gradient(900px 520px at -4% 110%,var(--glow2),transparent 55%)}
+::selection{background:color-mix(in oklab,var(--agent) 28%,transparent)}
+@keyframes blink{0%,60%,100%{opacity:.25}30%{opacity:1}}
+@keyframes pulse{0%{box-shadow:0 0 0 0 var(--agent-line)}70%{box-shadow:0 0 0 6px transparent}100%{box-shadow:0 0 0 0 transparent}}
+@keyframes rise{to{opacity:1;transform:none}}
+.stagger{opacity:0;transform:translateY(8px);animation:rise .5s cubic-bezier(.2,.7,.3,1) forwards}
+.app{display:grid;grid-template-rows:auto 1fr;height:100vh}
+button{font-family:inherit}
+
+/* ---------- top bar ---------- */
+.topbar{display:flex;align-items:center;gap:14px;height:48px;padding:0 16px;
+  background:linear-gradient(180deg,var(--surface-2),var(--surface));border-bottom:1px solid var(--border)}
+.brand{display:flex;align-items:center;gap:2px}
+.brand .mark{font-family:var(--mono);font-size:15px;font-weight:600;letter-spacing:-.3px;color:var(--text);display:flex;align-items:center}
+.brand .mark i{font-style:normal;color:var(--agent-2)}
+.brand .mark .cur{color:var(--human);font-weight:400;margin-left:1px;animation:blink 1.15s step-end infinite}
+.spacer{flex:1}
+/* demo-only 状态切换 */
+.demo-toggle{display:flex;background:var(--surface-3);border:1px solid var(--border);border-radius:8px;padding:2px}
+.demo-toggle button{border:0;background:transparent;color:var(--text-faint);border-radius:6px;cursor:pointer;font-size:11px;font-family:var(--mono);padding:4px 10px}
+.demo-toggle button.on{background:var(--agent-soft);color:var(--agent-2);box-shadow:0 0 0 1px var(--agent-line) inset}
+.switches{display:flex;align-items:center;gap:9px;padding-left:13px;margin-left:2px;border-left:1px solid var(--border)}
+.seg{display:flex;background:var(--surface-3);border:1px solid var(--border);border-radius:8px;padding:2px}
+.seg button{width:26px;height:22px;border:0;background:transparent;color:var(--text-faint);border-radius:6px;cursor:pointer;font-size:12px}
+.seg button.on{background:var(--agent-soft);color:var(--agent-2);box-shadow:0 0 0 1px var(--agent-line) inset}
+.syntax-sel{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--text-faint)}
+.syntax-sel select{font-family:var(--mono);font-size:11px;background:var(--surface-3);color:var(--text-dim);border:1px solid var(--border);border-radius:7px;padding:4px 7px;cursor:pointer;outline:none}
+
+/* ---------- scroll shell ---------- */
+.scroll{overflow:auto;min-height:0}
+.scroll::-webkit-scrollbar{width:10px}
+.scroll::-webkit-scrollbar-thumb{background:var(--scroll);border-radius:6px;border:2px solid transparent;background-clip:content-box}
+.scroll::-webkit-scrollbar-thumb:hover{background:var(--scroll-h);background-clip:content-box}
+.wrap{max-width:780px;margin:0 auto;padding:46px 24px 60px}
+
+/* ---------- hero ---------- */
+.hero{text-align:center;margin-bottom:26px}
+.hero .logo{font-family:var(--mono);font-size:30px;font-weight:600;letter-spacing:-1px;display:inline-flex;align-items:center}
+.hero .logo i{font-style:normal;color:var(--agent-2)}
+.hero .logo .cur{color:var(--human);font-weight:400;margin-left:2px;animation:blink 1.15s step-end infinite}
+.hero .tag{margin-top:9px;color:var(--text-dim);font-size:13.5px}
+.hero .tag .a{color:var(--agent-2);font-weight:500} .hero .tag .h{color:var(--human);font-weight:500}
+
+/* ---------- new-review card ---------- */
+.card{background:var(--surface);border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow);overflow:hidden}
+.card-top{display:flex;align-items:center;gap:12px;padding:14px 16px;border-bottom:1px solid var(--border-soft);
+  background:linear-gradient(180deg,color-mix(in oklab,var(--agent) 5%,var(--surface)),var(--surface))}
+.card-top h2{font-size:13px;font-weight:600;color:var(--text)}
+.card-top .sub{font-size:11.5px;color:var(--text-faint)}
+/* source segmented */
+.srcseg{display:flex;gap:2px;margin-left:auto;background:var(--surface-3);border:1px solid var(--border);border-radius:9px;padding:3px}
+.srcseg button{display:flex;align-items:center;gap:6px;border:0;background:transparent;color:var(--text-dim);border-radius:6px;cursor:pointer;font-size:12px;font-weight:500;padding:5px 11px}
+.srcseg button svg{width:13px;height:13px;opacity:.8}
+.srcseg button.on{background:var(--surface);color:var(--text);box-shadow:0 1px 2px rgba(0,0,0,.25),0 0 0 1px var(--agent-line) inset}
+.srcseg button.on svg{opacity:1;color:var(--agent-2)}
+
+.panel{padding:16px}
+.panel[hidden]{display:none}
+
+/* github: input row */
+.inputrow{display:flex;gap:10px;align-items:stretch}
+.field{flex:1;display:flex;align-items:center;gap:9px;background:var(--surface-2);border:1px solid var(--border);border-radius:11px;padding:0 12px;min-height:46px}
+.field:focus-within{border-color:var(--agent-line);box-shadow:0 0 0 3px var(--agent-soft)}
+.field .gh{color:var(--text-faint);display:flex}
+.field input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--mono);font-size:13px;outline:none}
+.field input::placeholder{color:var(--text-faint);font-family:var(--sans)}
+.field .paste{font-family:var(--mono);font-size:10.5px;color:var(--text-faint);border:1px solid var(--border);border-radius:6px;padding:3px 7px;cursor:pointer}
+.field .paste:hover{color:var(--agent-2);border-color:var(--agent-line)}
+.gobtn{display:flex;align-items:center;gap:8px;background:var(--accent-solid);color:var(--on-solid);border:0;border-radius:11px;padding:0 18px;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
+.gobtn:hover{filter:brightness(1.08)}
+.gobtn:disabled{opacity:.45;cursor:not-allowed;filter:none}
+
+/* resolved PR preview */
+.resolved{margin-top:12px;border:1px solid var(--agent-line);border-radius:12px;background:color-mix(in oklab,var(--agent) 5%,var(--surface-2));padding:12px 13px;display:flex;gap:12px;align-items:flex-start}
+.resolved .ok{width:20px;height:20px;border-radius:6px;background:var(--agent-soft);color:var(--agent-2);border:1px solid var(--agent-line);display:flex;align-items:center;justify-content:center;font-size:12px;flex:none;margin-top:1px}
+.resolved .info{flex:1;min-width:0}
+.resolved .l1{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.resolved .num{font-family:var(--mono);font-weight:600;color:var(--agent-2)}
+.resolved .ttl{font-weight:600;color:var(--text)}
+.resolved .l2{margin-top:5px;display:flex;align-items:center;gap:12px;font-size:11.5px;color:var(--text-faint);flex-wrap:wrap}
+.resolved .l2 .av{width:16px;height:16px;border-radius:50%;background:linear-gradient(135deg,#c98,#a76);display:inline-block;vertical-align:-3px;margin-right:4px}
+.resolved .l2 code{font-family:var(--mono);color:var(--text-dim)}
+.resolved .l2 .a{color:var(--add)} .resolved .l2 .d{color:var(--del)}
+.resolved .l2 .base{font-family:var(--mono);color:var(--text-dim)}
+.resolved .l2 .chk{color:var(--add)}
+
+/* browse list */
+.orline{display:flex;align-items:center;gap:12px;margin:18px 2px 10px;color:var(--text-faint);font-size:11px;font-family:var(--mono);text-transform:uppercase;letter-spacing:.05em}
+.orline::before,.orline::after{content:"";flex:1;height:1px;background:var(--border-soft)}
+.reporow{display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:11.5px;color:var(--text-faint)}
+.reporow select{font-family:var(--mono);font-size:12px;background:var(--surface-2);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:5px 9px;outline:none;cursor:pointer}
+.reporow select:hover{border-color:var(--agent-line)}
+.reporow .refresh{margin-left:auto;font-size:11px;color:var(--text-faint);cursor:pointer;display:flex;align-items:center;gap:5px}
+.reporow .refresh:hover{color:var(--agent-2)}
+.prlist{border:1px solid var(--border);border-radius:11px;overflow:hidden}
+.pritem{display:flex;align-items:center;gap:11px;padding:10px 12px;cursor:pointer;border-bottom:1px solid var(--border-soft)}
+.pritem:last-child{border-bottom:0}
+.pritem:hover{background:var(--surface-2)}
+.pritem .num{font-family:var(--mono);font-size:12px;color:var(--agent-2);font-weight:600;min-width:44px}
+.pritem .m{flex:1;min-width:0}
+.pritem .t{color:var(--text);font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.pritem .s{font-size:11px;color:var(--text-faint);margin-top:2px;display:flex;gap:10px;font-family:var(--mono)}
+.pritem .s .a{color:var(--add)} .pritem .s .d{color:var(--del)}
+.pritem .go{color:var(--text-faint);font-size:15px;flex:none}
+.pritem:hover .go{color:var(--agent-2)}
+
+/* local / gitbutler shared list */
+.branchrow{display:flex;align-items:center;gap:11px;padding:11px 12px;border:1px solid var(--border);border-radius:11px;margin-bottom:9px;cursor:pointer}
+.branchrow:hover{border-color:var(--agent-line);background:var(--surface-2)}
+.branchrow .ic{width:30px;height:30px;border-radius:8px;display:flex;align-items:center;justify-content:center;flex:none}
+.branchrow .ic.b{background:var(--agent-soft);color:var(--agent-2);border:1px solid var(--agent-line)}
+.branchrow .ic.v{background:var(--human-soft);color:var(--human);border:1px solid var(--human-line)}
+.branchrow .m{flex:1;min-width:0}
+.branchrow .bn{font-family:var(--mono);font-size:12.5px;color:var(--text);font-weight:600}
+.branchrow .bd{font-size:11px;color:var(--text-faint);margin-top:2px}
+.branchrow .cmp{font-family:var(--mono);font-size:11px;color:var(--text-dim);background:var(--surface-3);border:1px solid var(--border);padding:3px 8px;border-radius:7px}
+.local-head{display:flex;align-items:center;gap:9px;margin-bottom:12px}
+.local-head .lbl{font-size:11.5px;color:var(--text-faint)}
+.local-head select{font-family:var(--mono);font-size:12px;background:var(--surface-2);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:6px 10px;outline:none;cursor:pointer}
+.local-head select:hover{border-color:var(--agent-line)}
+.gb-hint{display:flex;align-items:center;gap:8px;font-size:11.5px;color:var(--text-faint);margin-bottom:12px;padding:8px 11px;border:1px dashed var(--human-line);border-radius:9px;background:var(--human-soft)}
+.gb-hint b{color:var(--human)}
+
+/* ---------- recent reviews ---------- */
+.section{margin-top:34px}
+.section-head{display:flex;align-items:center;gap:10px;margin-bottom:12px;padding:0 2px}
+.section-head h3{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.07em;color:var(--text-faint);font-weight:600}
+.section-head .count{font-family:var(--mono);font-size:11px;color:var(--text-faint)}
+.section-head .clear{margin-left:auto;font-size:11px;color:var(--text-faint);cursor:pointer}
+.section-head .clear:hover{color:var(--text-dim)}
+.recent{display:flex;flex-direction:column;gap:9px}
+.rev{display:flex;align-items:center;gap:13px;padding:12px 14px;background:var(--surface);border:1px solid var(--border);border-radius:12px;cursor:pointer;position:relative}
+.rev:hover{border-color:var(--agent-line);background:linear-gradient(180deg,var(--surface),color-mix(in oklab,var(--agent) 4%,var(--surface)))}
+.rev .srcbadge{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-size:11px;font-weight:600;padding:4px 9px;border-radius:999px;border:1px solid var(--border);background:var(--surface-3);color:var(--text-dim);flex:none}
+.rev .srcbadge svg{width:12px;height:12px}
+.rev .srcbadge.gh b{color:var(--agent-2)}
+.rev .srcbadge.local{color:var(--text-dim)}
+.rev .srcbadge.gb{color:var(--human)}
+.rev .m{flex:1;min-width:0}
+.rev .t{color:var(--text);font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.rev .meta{font-size:11px;color:var(--text-faint);margin-top:3px;display:flex;align-items:center;gap:9px;flex-wrap:wrap;font-family:var(--mono)}
+.rev .meta .dot{width:3px;height:3px;border-radius:50%;background:var(--text-faint)}
+.rev .meta .find{color:var(--sev-high)} .rev .meta .find.zero{color:var(--text-faint)}
+.rev .meta .sub{color:var(--add)}
+.rev .stat{display:flex;align-items:center;gap:6px;font-size:11px;flex:none}
+.rev .stat .pulse{width:7px;height:7px;border-radius:50%;background:var(--agent);animation:pulse 2s infinite}
+.rev .stat.review{color:var(--agent-2)}
+.rev .stat.done{color:var(--text-faint)}
+.rev .stat.submitted{color:var(--add)}
+.rev .arrow{color:var(--text-faint);font-size:16px;flex:none}
+.rev:hover .arrow{color:var(--agent-2)}
+
+/* footer */
+.foot{margin-top:30px;text-align:center;font-size:11px;color:var(--text-faint);font-family:var(--mono);display:flex;align-items:center;justify-content:center;gap:10px}
+.foot .glyph{width:14px;height:14px;border-radius:4px;background:conic-gradient(from 210deg,var(--agent),var(--agent-2),var(--agent));box-shadow:0 0 0 1px var(--agent-line) inset;display:inline-block}
+.foot .dot{width:3px;height:3px;border-radius:50%;background:var(--text-faint)}
+
+/* selected state for pickable rows */
+.pritem.sel,.branchrow.sel{background:color-mix(in oklab,var(--agent) 7%,var(--surface-2));box-shadow:inset 2px 0 0 var(--agent)}
+.branchrow.sel{border-color:var(--agent-line)}
+.pritem.sel .num,.branchrow.sel .bn{color:var(--agent-2)}
+
+/* optional local repo path */
+.pathfield{display:flex;align-items:center;gap:9px;margin-top:10px;background:var(--surface-2);border:1px solid var(--border);border-radius:10px;padding:0 11px;min-height:40px}
+.pathfield:focus-within{border-color:var(--agent-line)}
+.pathfield .pf-ic{color:var(--text-faint);font-size:13px}
+.pathfield input{flex:1;border:0;background:transparent;color:var(--text-dim);font-family:var(--mono);font-size:12px;outline:none}
+.pathfield input::placeholder{color:var(--text-faint);font-family:var(--sans)}
+.pathfield .pf-tag{font-family:var(--mono);font-size:10px;color:var(--add);border:1px solid color-mix(in oklab,var(--add) 40%,transparent);background:color-mix(in oklab,var(--add) 10%,transparent);border-radius:6px;padding:2px 7px}
+
+/* ---------- shared card footer: context + CTA ---------- */
+.cardfoot{border-top:1px solid var(--border-soft);padding:13px 16px 16px;background:color-mix(in oklab,var(--agent) 2%,var(--surface))}
+.ctxtoggle{display:flex;width:100%;align-items:center;gap:10px;background:var(--surface-2);border:1px solid var(--border);border-radius:10px;color:var(--text-dim);font-size:12.5px;cursor:pointer;padding:10px 12px;font-family:inherit}
+.ctxtoggle:hover{border-color:var(--agent-line);color:var(--text)}
+.ctxtoggle.open{border-color:var(--agent-line);border-bottom-left-radius:0;border-bottom-right-radius:0;color:var(--text)}
+.ctxtoggle .ci{width:22px;height:22px;flex:none;display:flex;align-items:center;justify-content:center;border-radius:6px;background:var(--agent-soft);color:var(--agent-2);border:1px solid var(--agent-line);font-size:12px}
+.ctxtoggle .cl{flex:1;text-align:left;font-weight:500}
+.ctxtoggle .opt{color:var(--text-faint);font-weight:400;font-family:var(--mono);font-size:10.5px;margin-left:4px;border:1px solid var(--border);border-radius:5px;padding:1px 6px}
+.ctxtoggle .chev{font-size:10px;color:var(--text-faint);transition:transform .18s}
+.ctxtoggle.open .chev{transform:rotate(90deg);color:var(--agent-2)}
+.ctxbox{margin-top:-1px;border:1px solid var(--agent-line);border-top:0;border-radius:0 0 10px 10px;padding:11px 12px 12px;background:var(--surface-2)}
+.ctxbox[hidden]{display:none}
+.ctxbox textarea{width:100%;min-height:76px;resize:vertical;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:9px 11px;color:var(--text);font-family:var(--sans);font-size:12.5px;line-height:1.55;outline:none}
+.ctxbox textarea:focus{border-color:var(--agent-line)}
+.ctxbox textarea::placeholder{color:var(--text-faint)}
+.ctxhint{margin-top:7px;font-size:11px;color:var(--text-faint);font-family:var(--mono)}
+.footcta{display:flex;align-items:center;gap:14px;margin-top:14px}
+.footcta .target{font-size:12px;color:var(--text-faint)}
+.footcta .target b{font-family:var(--mono);color:var(--agent-2);font-weight:600}
+.footcta .target .tsep{margin:0 3px;color:var(--text-faint)}
+.footcta #tgtTitle{color:var(--text-dim)}
+.footcta .gobtn{margin-left:auto}
+.gobtn{display:inline-flex;align-items:center;gap:8px;background:var(--accent-solid);color:var(--on-solid);border:0;border-radius:11px;padding:11px 20px;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
+.gobtn:hover{filter:brightness(1.08)}
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- ============ TOP BAR ============ -->
+  <div class="topbar">
+    <div class="brand"><span class="mark">duet<i>lens</i><span class="cur">_</span></span></div>
+    <div class="spacer"></div>
+    <div class="switches">
+      <div class="seg" id="modeSeg">
+        <button data-mode-val="light" title="浅色">☀</button>
+        <button data-mode-val="dark" class="on" title="深色">☾</button>
+      </div>
+      <label class="syntax-sel">配色
+        <select id="themeSel">
+          <option value="duetlens">Duetlens</option>
+          <option value="github">GitHub</option>
+        </select>
+      </label>
+    </div>
+  </div>
+
+  <!-- ============ HOME ============ -->
+  <div class="scroll">
+    <div class="wrap">
+
+      <div class="hero">
+        <div class="logo">duet<i>lens</i><span class="cur">_</span></div>
+        <div class="tag">人与 <span class="a">agent</span> 协同的 code review<span class="h"> ·</span> 从一个 PR 开始</div>
+      </div>
+
+      <!-- ---- new review card ---- -->
+      <div class="card stagger" style="animation-delay:.05s">
+        <div class="card-top">
+          <div>
+            <h2>发起一次审核</h2>
+            <div class="sub">选择来源 · Duetlens 会拉取 diff 并启动 codex 会话做首轮机审</div>
+          </div>
+          <div class="srcseg" id="srcSeg">
+            <button data-src="github" class="on">
+              <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+              GitHub PR
+            </button>
+            <button data-src="local">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.4 6.6C13 6.6 18 6 18 10.5"/></svg>
+              本地分支
+            </button>
+            <button data-src="gitbutler">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v18M6 8l6-5 6 5M6 16l6 5 6-5"/></svg>
+              GitButler
+            </button>
+          </div>
+        </div>
+
+        <!-- GitHub panel -->
+        <div class="panel" data-panel="github">
+          <div class="field">
+            <span class="gh"><svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></span>
+            <input value="github.com/xieziyu/podcast-go/pull/482" spellcheck="false">
+            <span class="paste">⌘V</span>
+          </div>
+
+          <!-- resolved preview(粘贴/解析后)· 精简 -->
+          <div class="resolved">
+            <span class="ok">✓</span>
+            <div class="info">
+              <div class="l1"><span class="num">#482</span> <span class="ttl">feat: streaming transcode</span></div>
+              <div class="l2">
+                <span><span class="av"></span>@ryan</span>
+                <span><span class="a">+188</span> <span class="d">−41</span> · 6 files</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 可选:本地仓库路径,让 agent 读全量代码 -->
+          <label class="pathfield">
+            <span class="pf-ic">⌂</span>
+            <input placeholder="本地仓库路径(可选)· 让 agent 读全量代码,留空则临时 checkout" value="~/Projects/podcast-go" spellcheck="false">
+            <span class="pf-tag">已匹配 ✓</span>
+          </label>
+
+          <div class="orline">或从最近的 open PR 中选择</div>
+          <div class="reporow">
+            <span>仓库</span>
+            <select>
+              <option>xieziyu/podcast-go</option>
+              <option>xieziyu/Duetlens</option>
+              <option>xieziyu/better-review</option>
+            </select>
+            <span class="refresh">⟳ 刷新</span>
+          </div>
+          <div class="prlist">
+            <div class="pritem sel" data-target="GitHub #482" data-title="feat: streaming transcode">
+              <span class="num">#482</span>
+              <div class="m"><div class="t">feat: streaming transcode</div><div class="s"><span>@ryan · 2h</span><span><span class="a">+188</span> <span class="d">−41</span></span></div></div>
+              <span class="go">→</span>
+            </div>
+            <div class="pritem" data-target="GitHub #479" data-title="fix: episode duration off-by-one">
+              <span class="num">#479</span>
+              <div class="m"><div class="t">fix: episode duration off-by-one on live cutover</div><div class="s"><span>@mia · 5h</span><span><span class="a">+24</span> <span class="d">−9</span></span></div></div>
+              <span class="go">→</span>
+            </div>
+            <div class="pritem" data-target="GitHub #475" data-title="refactor: extract feed builder">
+              <span class="num">#475</span>
+              <div class="m"><div class="t">refactor: extract feed builder into module</div><div class="s"><span>@ryan · 1d</span><span><span class="a">+310</span> <span class="d">−212</span></span></div></div>
+              <span class="go">→</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Local branch panel -->
+        <div class="panel" data-panel="local" hidden>
+          <div class="local-head">
+            <span class="lbl">仓库</span>
+            <select><option>~/Projects/podcast-go</option><option>~/Projects/Duetlens</option><option>选择其它目录…</option></select>
+            <span class="lbl" style="margin-left:6px">对比 base</span>
+            <select><option>main</option><option>develop</option><option>release/2.0</option></select>
+          </div>
+          <div class="branchrow sel" data-target="本地 feat/stream-transcode" data-title="← main">
+            <span class="ic b"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.4 6.6C13 6.6 18 6 18 10.5"/></svg></span>
+            <div class="m"><div class="bn">feat/stream-transcode</div><div class="bd">HEAD · 4 commits ahead · 更新于 12 分钟前</div></div>
+            <span class="cmp">← main</span>
+          </div>
+          <div class="branchrow" data-target="本地 fix/feed-encoding" data-title="← main">
+            <span class="ic b"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.4 6.6C13 6.6 18 6 18 10.5"/></svg></span>
+            <div class="m"><div class="bn">fix/feed-encoding</div><div class="bd">2 commits ahead · 更新于 3 小时前</div></div>
+            <span class="cmp">← main</span>
+          </div>
+        </div>
+
+        <!-- GitButler panel -->
+        <div class="panel" data-panel="gitbutler" hidden>
+          <div class="gb-hint">⎇ 检测到 GitButler workspace · <b>~/Projects/podcast-go</b> · 3 个 virtual branch</div>
+          <div class="branchrow sel" data-target="vbranch virtual/streaming" data-title="未提交改动">
+            <span class="ic v"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v18M6 8l6-5 6 5M6 16l6 5 6-5"/></svg></span>
+            <div class="m"><div class="bn">virtual/streaming</div><div class="bd">7 files · 未提交改动 · 归属 2 个 commit</div></div>
+            <span class="cmp">vbranch</span>
+          </div>
+          <div class="branchrow" data-target="vbranch virtual/api-cleanup" data-title="未提交改动">
+            <span class="ic v"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v18M6 8l6-5 6 5M6 16l6 5 6-5"/></svg></span>
+            <div class="m"><div class="bn">virtual/api-cleanup</div><div class="bd">3 files · 未提交改动</div></div>
+            <span class="cmp">vbranch</span>
+          </div>
+        </div>
+
+        <!-- ---- shared footer: 附加上下文 + 单一 CTA ---- -->
+        <div class="cardfoot">
+          <button class="ctxtoggle" id="ctxToggle">
+            <span class="ci">✎</span>
+            <span class="cl">给 agent 附加上下文 <span class="opt">可选</span></span>
+            <span class="chev">▸</span>
+          </button>
+          <div class="ctxbox" id="ctxBox" hidden>
+            <textarea placeholder="首轮机审前一并发给 codex,可留空。例如:&#10;· 重点关注并发安全与错误处理&#10;· 本 PR 依赖 encoder crate 的 v2 API&#10;· 忽略 generated/ 下的文件"></textarea>
+            <div class="ctxhint">随首轮机审注入,agent 全程可见 · 不改变 read-only sandbox</div>
+          </div>
+          <div class="footcta">
+            <span class="target">将审核 <b id="tgtName">GitHub #482</b> <span class="tsep">·</span> <span id="tgtTitle">feat: streaming transcode</span></span>
+            <button class="gobtn" id="startBtn">开始审核 <span style="font-size:15px;line-height:1">→</span></button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ---- recent reviews (会话历史) ---- -->
+      <div class="section stagger" style="animation-delay:.12s">
+        <div class="section-head">
+          <h3>最近的审核</h3><span class="count">4</span>
+          <span class="clear">全部历史 →</span>
+        </div>
+        <div class="recent">
+          <div class="rev">
+            <span class="srcbadge gh"><svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><b>#482</b></span>
+            <div class="m">
+              <div class="t">feat: streaming transcode</div>
+              <div class="meta"><span>podcast-go</span><span class="dot"></span><span class="find">3 findings</span><span class="dot"></span><span>2 discussions</span></div>
+            </div>
+            <span class="stat review"><span class="pulse"></span>审核中</span>
+            <span class="arrow">→</span>
+          </div>
+          <div class="rev">
+            <span class="srcbadge gh"><svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><b>#479</b></span>
+            <div class="m">
+              <div class="t">fix: episode duration off-by-one on live cutover</div>
+              <div class="meta"><span>podcast-go</span><span class="dot"></span><span class="find">5 findings</span><span class="dot"></span><span class="sub">4 已提交</span></div>
+            </div>
+            <span class="stat submitted">✓ 已提交</span>
+            <span class="arrow">→</span>
+          </div>
+          <div class="rev">
+            <span class="srcbadge local"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.4 6.6C13 6.6 18 6 18 10.5"/></svg>本地</span>
+            <div class="m">
+              <div class="t">fix/feed-encoding <span style="color:var(--text-faint);font-family:var(--mono);font-size:11px">← main</span></div>
+              <div class="meta"><span>podcast-go</span><span class="dot"></span><span class="find zero">0 findings</span><span class="dot"></span><span>本地导出 · 未提交</span></div>
+            </div>
+            <span class="stat done">已完成</span>
+            <span class="arrow">→</span>
+          </div>
+          <div class="rev">
+            <span class="srcbadge gb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v18M6 8l6-5 6 5M6 16l6 5 6-5"/></svg>vbranch</span>
+            <div class="m">
+              <div class="t">virtual/api-cleanup</div>
+              <div class="meta"><span>Duetlens</span><span class="dot"></span><span class="find">2 findings</span><span class="dot"></span><span>昨天</span></div>
+            </div>
+            <span class="stat done">已完成</span>
+            <span class="arrow">→</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="foot"><span class="glyph"></span> codex · gpt-5.1-codex <span class="dot"></span> read-only sandbox <span class="dot"></span> app-server 常驻会话</div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const root=document.documentElement;
+// mode
+document.querySelectorAll('#modeSeg button').forEach(b=>b.onclick=()=>{
+  root.setAttribute('data-mode',b.dataset.modeVal);
+  document.querySelectorAll('#modeSeg button').forEach(x=>x.classList.toggle('on',x===b));
+});
+// theme
+document.getElementById('themeSel').onchange=e=>root.setAttribute('data-theme',e.target.value);
+// source panels
+document.querySelectorAll('#srcSeg button').forEach(b=>b.onclick=()=>{
+  document.querySelectorAll('#srcSeg button').forEach(x=>x.classList.toggle('on',x===b));
+  document.querySelectorAll('.panel').forEach(p=>p.hidden=p.dataset.panel!==b.dataset.src);
+  const s=document.querySelector('.panel:not([hidden]) .sel'); if(s) s.click();
+});
+// 目标选取(点击列表项 = 选中,更新底部 CTA 目标)
+document.querySelectorAll('[data-target]').forEach(el=>el.onclick=()=>{
+  const panel=el.closest('.panel');
+  panel.querySelectorAll('[data-target]').forEach(x=>x.classList.remove('sel'));
+  el.classList.add('sel');
+  document.getElementById('tgtName').textContent=el.dataset.target;
+  document.getElementById('tgtTitle').textContent=el.dataset.title;
+});
+// 附加上下文折叠
+const ctxToggle=document.getElementById('ctxToggle'),ctxBox=document.getElementById('ctxBox');
+ctxToggle.onclick=()=>{const open=ctxBox.hidden;ctxBox.hidden=!open;ctxToggle.classList.toggle('open',open);};
+// 开始审核 → 直接切到 review 屏(进度 timeline 在 review 内联展示)
+document.getElementById('startBtn').onclick=()=>{location.href='diff-review.html'};
+document.querySelectorAll('.rev').forEach(r=>r.onclick=()=>{location.href='diff-review.html'});
+</script>
+</body>
+</html>


### PR DESCRIPTION
UI design mockups for the main entry flow and the review panel, plus design-doc updates so implementation can reference the decisions. Mockups only; no app code yet.

## Entry launcher (mockup/entry.html)

- Full-screen launcher: three sources (GitHub PR / local branch / GitButler), paste-to-resolve PR preview, optional local repo path, optional agent context, a single start CTA, and session history on the home screen.
- Empty and error states: first-run empty history, gh not authenticated (with a local/GitButler fallback note), PR resolve failure, and repo path mismatch. Hard errors disable the CTA; the path mismatch is a soft, non-blocking warning.

## Review pane (mockup/diff-review.html)

- First-review scan state in the right pane: progress timeline plus streaming findings, no blocking overlay.
- Findings tab: severity-grouped runtime list with triage (keep/dismiss), agent vs promoted origin, suggestion marker, submitted passive state, and manual add.
- Summary tab: codex review summary with a suggested verdict, findings stats, editable prose, themes by category, and a submit CTA.
- Left and right side panels are drag-resizable with min/max clamps and double-click reset.

## Docs

- Record these decisions in docs/design/ui.md and refresh the index.
- Fix stale brand color (sky-blue, not indigo) and font (IBM Plex, not serif).