### PR TITLE
feat(release): ship signed notarized macos builds with auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+# 打 tag 出正式包:签名 + 公证 + 传 GitHub Releases 草稿。
+# 草稿要人手点 publish 才对外 —— electron-updater 不读 draft,点之前老用户收不到推送。
+#
+# 需要的 secrets(逐条怎么拿见 docs/design/release.md):
+#   CSC_LINK / CSC_KEY_PASSWORD          Developer ID Application 证书(.p12 的 base64)与其密码
+#   APPLE_API_KEY_P8 / _ID / _ISSUER     公证用的 App Store Connect API key
+#   APPLE_TEAM_ID                        10 位 Team ID
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  # 手动跑一次验证链路;不打 tag 就只出包不发布
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    # macos-latest 自 macos-14 起是 arm64;只出 arm64 包,better-sqlite3 得按目标架构编
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # tag 与 package.json 对不上就别发:产物里的版本号来自 package.json,
+      # 发出去会得到一个「v0.2.0 的 release 里装着 0.1.0 的包」。
+      - name: check tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          pkg="$(node -p "require('./package.json').version")"
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$pkg" != "$tag" ]; then
+            echo "::error::tag $tag != package.json $pkg"
+            exit 1
+          fi
+
+      - run: npm run typecheck
+      - run: npm run lint
+
+      # electron-builder 的 notarize 只认文件路径,secret 是字符串,得先落盘
+      - name: write notarization key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          mkdir -p ~/private_keys
+          printf '%s' "$APPLE_API_KEY_P8" > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+
+      - name: build, sign, notarize, publish
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export APPLE_API_KEY=~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+          # 非 tag 的手动跑只出包,不往 Releases 传
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            npm run release
+          else
+            npm run dist
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: duetlens-macos-arm64
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/latest-mac.yml
+          if-no-files-found: warn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,14 @@ Electron 桌面应用:人与 codex agent 协同对话式的 code review。主进
 | 强度显示名 / 代价文案 | `shared/domain.ts` 的 `INTENSITY_LABELS` / `INTENSITY_HINTS` |
 | 改动面计量 | `but diff <branch>`(入口卡片与 `GitButlerSource.getDiff` 同一条命令,数由构造相等) |
 | 仓库 / issue / 作者外链 | `src/shared/links.ts`(package.json 不重复一份) |
+| 客户端版本号 | `package.json` 的 `version` → 构建期 define 注入 `src/shared/version.ts`;发给 app-server / MCP 的 clientInfo 一律取 `APP_VERSION`,别再写字面量 |
 
 ## 运行与自查
 
 - **ABI 二选一**:app(`npm start`)先 `npm run rebuild:electron`;spike(tsx/Node)先 `npm run rebuild:node`。切换后对方失效,跑完 spike 记得切回。
 - 实机:`npm start`。前提 `codex login`(烧 token);github-pr source 另需 `gh auth login`。
 - 前端自查(不需 Electron):`npm run preview:ui` → 开 `/preview.html?screen=entry|review|submit|prompt|settings|history|onboarding`(dev server 已把 `/` 302 过去)。明暗在 rail 底部切,配色在设置屏。
-- 出包:`npm run package` / `npm run dist`。本地无 Developer ID,必须 ad-hoc 签名(`identity: "-"` + `disable-library-validation`)—— electron-builder 在签名前翻 fuses,不重签的 app 一启动就被 SIGKILL。
+- 出包:本地自查用 `npm run package`(ad-hoc 签名,命令行覆盖);正式包打 `v<version>` tag 交 CI,见 [release](docs/design/release.md)。electron-builder 在签名前翻 fuses,不重签的 app 一启动就被 SIGKILL,所以任何一条路都不能出未签名的包。
 - 直接读写本地库走系统 `/usr/bin/sqlite3`,**别为此 rebuild**(会弄坏正开着的 app)。库在 `~/Library/Application Support/Duetlens{,-dev}/duetlens.db`。
 - `mockup/` **已冻结**:改 UI 只改 `src/renderer/`,分歧一律以实现为准。看稿用 `python3 -m http.server -d mockup`(不能走 `preview:ui`)。
 

--- a/build/entitlements.mac.dev.plist
+++ b/build/entitlements.mac.dev.plist
@@ -2,14 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <!-- 发布用(Developer ID + 公证)。这三条是 Electron 在 hardened runtime 下的最小集,少了起不来。 -->
+    <!-- 只给本地 ad-hoc 构建(npm run package)用,与发布版仅差最后一条。发布版见 entitlements.mac.plist。 -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
-    <!-- 刻意不放 disable-library-validation:Developer ID 下 Electron 框架与 better_sqlite3.node
-         都由同一 Team ID 重签,库校验能过。本地 ad-hoc 构建过不了,那条路走 entitlements.mac.dev.plist。 -->
+    <!-- ad-hoc 签名下 app 与 Electron 预编译框架的 Team ID 不一致,不关掉库校验会起不来 -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ codex app-server 把「一次常驻会话」本身称作 `thread`。为避免冲
 | [findings-submit.md](design/findings-submit.md) | findings 筛选与提交 PR review / 导出 Markdown,422 失效锚点 | 碰提交流程 / finding 状态前 |
 | [ui.md](design/ui.md) | 各屏的锚点决策与易踩约束 | 做界面前 |
 | [design-system.md](design/design-system.md) | tokens 语义、表面与文字阶梯、对比度规则、品牌标记 | 改配色 / 抽组件前 |
+| [release.md](design/release.md) | 出包 / 签名 / 公证 / 自动更新的形态与理由,证书与 secrets 准备 | 发版前 |
 | [open-questions.md](design/open-questions.md) | 尚未收口的风险与空缺 | 排优先级时 |
 
 ## 已拍板决策

--- a/docs/design/open-questions.md
+++ b/docs/design/open-questions.md
@@ -4,8 +4,7 @@
 >
 > 只留**仍未解决**的。已经拍板的写进了对应分册,不在这里堆已完成项。
 
-- **发布链路空缺**:出包能力已有,但没有 Developer ID 签名 / 公证、没有 `publish` 目标、没有 electron-updater、没有 CI 出包工作流。当前产物只能手工分发,用户装完不会收到更新。发布前需一并决定:分发渠道、是否公证(未公证的 zip 在他人机器上会被 Gatekeeper 拦)、以及预发布版本的升级路径。
-- **版本号多处硬编码**:`package.json` 之外,发给 app-server 的客户端标识在三四处各自写死了同一字面量,发版时不会跟随,会静默不一致。修法是构建期注入或从 `app.getVersion()` 取(spike 脚本跑在 Node 下拿不到 `app`,需另走注入)。
+- **发布链路尚未真跑过一次**:签名 / 公证 / CI / updater 的形态已定并落地(见 [release](release.md)),但证书与 secrets 还没配、仓库还没转 public,所以整条链一次都没端到端跑通过。第一次发版要按 release.md 的准备清单走一遍,并预期在公证那步撞到没预料的拒绝理由。
 - **MCP 通道的生命周期未严格对齐 review 生命周期**:HTTP transport + 每会话独立 Server + bearer 令牌已就位,仍待做的是令牌隔离与 dispose 的严格对齐。
 - **app-server API 仍标 experimental**,可能无预告 breaking change。缓解手段是 `ConversationalAgent` 薄封装 + schema 导出做升级回归。
 - **运行时 / 异常态大部分未落地**(turn 中断、反向审批卡、追问 turn 失败、连接断、压缩),见 [ui](ui.md#尚未落地的运行时--异常态)。

--- a/docs/design/release.md
+++ b/docs/design/release.md
@@ -1,0 +1,61 @@
+# 发布链路
+
+> 返回 [文档索引](../README.md)
+>
+> 决策与理由在这里;命令与配置以 `electron-builder.yml`、`.github/workflows/release.yml` 为准。
+
+## 形态
+
+打 `v<version>` tag → GitHub Actions 在 macOS runner 上出包、用 Developer ID 签名、送 Apple 公证、
+传成 GitHub Releases **草稿**。人过一眼再点 publish,那一刻起旧版本才开始收到更新推送。
+
+草稿这一环不是多余的:`electron-updater` 不读 draft release,所以「包已经出好了」与「用户开始升级」
+之间留了一个可反悔的位置。出了问题删掉草稿即可,不用发一个撤回版本。
+
+## 拍板过的几件事
+
+**分发走公开仓库的 GitHub Releases。** 私有仓库的 release 资产要 token 才读得到,而 updater 跑在
+每个用户机器上 —— 那等于把一个能读私有仓库的凭据发出去。公开仓库是唯一不用自建服务器又能自动更新的路。
+
+**只出 arm64。** 受众是 macOS 上用 codex 的开发者,Intel Mac 已停产多年;双架构要为每个架构分别
+编 better-sqlite3,收益不抵成本。真有需求再加 runner。
+
+**dmg + zip 两个产物。** dmg 给人下载,zip 给 updater —— 少一个更新链就断了。
+
+**公证凭据用 App Store Connect API key**,不用 Apple ID + 专用密码:可单独撤销、不牵连账号密码、
+CI 里只是三个字符串加一个文件。
+
+**版本号只写在 `package.json`。** 构建期 define 注入,发给 app-server / MCP 的 clientInfo 一律取
+`APP_VERSION`(见 [CLAUDE.md](../../CLAUDE.md) 单一来源表)。CI 会校验 tag 与它一致后才发布,
+免得出现「v0.2.0 的 release 里装着 0.1.0 的包」。
+
+## 签名的两条路不能混
+
+发布版从钥匙串自动发现 Developer ID Application,开 hardened runtime + 公证。
+本地 `npm run package` 在命令行覆盖成 ad-hoc(`identity: "-"`)、关公证、换一份 entitlements。
+
+两份 entitlements 只差 `disable-library-validation` 一条:ad-hoc 签名下 app 与 Electron 预编译框架的
+Team ID 对不上,不关掉库校验起不来;Developer ID 下所有二进制由同一 Team ID 重签,校验能过,
+所以发布版不带这条。
+
+**任何情况下都不能出未签名的包** —— electron-builder 在签名前翻 fuses,翻过之后原签名失效,
+不重签的 app 一启动就被 SIGKILL。`forceCodeSigning: true` 让这种情况直接构建失败,而不是出一个
+跑不起来的包。
+
+## 一次性准备(换机器或换证书时重来)
+
+1. **Developer ID Application 证书**:Xcode → Settings → Accounts → Manage Certificates → `+`。
+   注意不是 "Apple Development" 也不是 "Mac App Distribution",那两个签出来的包在别人机器上照样起不来。
+2. **导出 `.p12`** 给 CI:钥匙串里右键证书导出,设个密码。`base64 -i cert.p12 | pbcopy` 后存进
+   仓库 secrets 的 `CSC_LINK`,密码存 `CSC_KEY_PASSWORD`。
+3. **App Store Connect API key**:App Store Connect → Users and Access → Integrations →
+   生成 **Developer** 角色的 key。`.p8` 只能下载一次。三个 secret:`APPLE_API_KEY_P8`(文件全文)、
+   `APPLE_API_KEY_ID`、`APPLE_API_ISSUER`。
+4. **`APPLE_TEAM_ID`**:developer.apple.com 的 Membership details 里那 10 位。
+
+配完可以先 `workflow_dispatch` 手动跑一次 —— 非 tag 触发只出包不发布,正好验签名和公证这段通不通。
+
+## 首次公开前必须先做
+
+仓库转 public 之前扫一遍 git 历史里有没有 token / `.env` / 私密路径。转公开的那一刻全部历史都可见,
+删了也已经被爬走。

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,14 +23,32 @@ electronFuses:
   enableEmbeddedAsarIntegrityValidation: true
   onlyLoadAppFromAsar: true
 
+# 不签名的产物一启动就被 SIGKILL(fuses 翻过之后原签名失效),与其出个跑不起来的包不如直接失败
+forceCodeSigning: true
+
 mac:
-  target: zip
+  # dmg 给人下载,zip 给 electron-updater —— 少一个更新链就断了。
+  # 只出 arm64:Intel Mac 不在受众里,双架构要为每个架构重编 better-sqlite3。
+  target:
+    - target: dmg
+      arch: [arm64]
+    - target: zip
+      arch: [arm64]
   category: public.app-category.developer-tools
   # 各尺寸美术不同(128+ 带镜外代码 / 64-32 只留镜片 / 16 再砍一条行),
   # 所以自带 icns 而不是让 electron-builder 从单张 png 缩,改图跑 npm run icons:gen
   icon: build/icon.icns
-  # 发布用的 Developer ID 签名/公证留到发布阶段(见 docs/design/open-questions.md)。
-  # 本地必须 ad-hoc 签(identity "-"):翻过 fuses 的二进制会失去原签名,不重签会被系统 SIGKILL。
-  identity: "-"
+  # 不写 identity:从钥匙串自动发现 Developer ID Application。
+  # 本地 `npm run package` 在命令行覆盖成 ad-hoc,见 package.json。
+  hardenedRuntime: true
+  notarize: true
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+
+# 草稿发布:CI 出完包不直接对外,人过一眼再点 publish。
+# electron-updater 不读 draft,所以点之前老用户不会收到推送。
+publish:
+  provider: github
+  owner: xieziyu
+  repo: duetlens
+  releaseType: draft

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,11 +2,13 @@ import { defineConfig } from 'electron-vite';
 import { mergeConfig } from 'vite';
 import path from 'node:path';
 import rendererConfig from './vite.renderer.config';
+import { appVersionDefine } from './scripts/app-version-define';
 
 // renderer 的 root 固定在项目根(见 vite.renderer.config.ts),入口沿用根目录的 index.html;
 // 三段产物分别落在 out/{main,preload,renderer}, package.json 的 main 指向 out/main/index.js。
 export default defineConfig({
   main: {
+    define: appVersionDefine(__dirname),
     build: {
       rollupOptions: {
         input: { index: path.resolve(__dirname, 'src/main.ts') },
@@ -20,6 +22,7 @@ export default defineConfig({
     },
   },
   preload: {
+    define: appVersionDefine(__dirname),
     build: {
       rollupOptions: {
         input: { index: path.resolve(__dirname, 'src/preload.ts') },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "duetlens",
-  "version": "2.0.0-dev",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "2.0.0-dev",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.11.1",
+        "electron-updater": "^6.8.9",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -3151,7 +3152,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -3607,7 +3607,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4423,6 +4422,34 @@
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/electron-vite": {
       "version": "5.0.0",
@@ -6081,7 +6108,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6419,7 +6445,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7258,7 +7283,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7342,7 +7366,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -7365,7 +7388,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -7403,6 +7425,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -8960,7 +8995,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9641,6 +9675,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9965,7 +10005,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "2.0.0-dev",
-  "description": "Conversational code review — human and agent reviewing together (2.0 rewrite of better-review)",
+  "version": "0.1.0",
+  "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,
   "scripts": {
     "start": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "package": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder",
+    "package": "npm run build && electron-builder --dir --arm64 -c.mac.identity=- -c.mac.notarize=false -c.mac.entitlements=build/entitlements.mac.dev.plist -c.mac.entitlementsInherit=build/entitlements.mac.dev.plist",
+    "dist": "npm run build && electron-builder --mac",
+    "release": "npm run build && electron-builder --mac --publish always",
     "preview:ui": "vite --config vite.preview.config.ts --port 5177 --strictPort",
     "db:snapshot": "bash scripts/db-snapshot.sh",
     "icons:gen": "tsx scripts/gen-icons.ts",
@@ -74,6 +75,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.11.1",
+    "electron-updater": "^6.8.9",
     "zod": "^4.4.3"
   }
 }

--- a/scripts/app-version-define.ts
+++ b/scripts/app-version-define.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * 把 package.json 的 version 注入成 `__APP_VERSION__`,供 src/shared/version.ts 取用。
+ * root 由调用方传自己的 `__dirname` —— vite 打包配置时本模块的 `__dirname` 不可靠。
+ */
+export function appVersionDefine(root: string): Record<string, string> {
+  const pkg = JSON.parse(readFileSync(path.resolve(root, 'package.json'), 'utf8')) as {
+    version: string;
+  };
+  return { __APP_VERSION__: JSON.stringify(pkg.version) };
+}

--- a/scripts/spike-codex.ts
+++ b/scripts/spike-codex.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { CodexAppServer } from '../src/backend/agent/codex/codex-app-server';
 import { CodexNotification, type McpToolCallItem } from '../src/backend/agent/codex/protocol';
 import { DuetlensMcpServer, type ReportedFinding } from '../src/backend/mcp/duetlens-mcp-server';
+import { APP_VERSION } from '../src/shared/version';
 
 const TURN_TIMEOUT_MS = 180_000;
 
@@ -121,7 +122,7 @@ async function main() {
   codex.start();
 
   try {
-    await codex.initialize({ name: 'duetlens', version: '2.0.0-dev' });
+    await codex.initialize({ name: 'duetlens', version: APP_VERSION });
     log('codex', 'initialized');
 
     const thread = await codex.threadStart({

--- a/src/backend/agent/codex/codex-agent.ts
+++ b/src/backend/agent/codex/codex-agent.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { CodexAppServer } from './codex-app-server';
+import { APP_VERSION } from '@shared/version';
 import {
   CodexItemType,
   CodexNotification,
@@ -71,7 +72,7 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
     const server = new CodexAppServer({ codexBin: opts.codexBin, codexHome: opts.codexHome, onLog: opts.onLog });
     try {
       server.start();
-      await server.initialize({ name: 'duetlens', version: '2.0.0-dev' });
+      await server.initialize({ name: 'duetlens', version: APP_VERSION });
       const models: CodexModel[] = [];
       let cursor: string | null | undefined;
       // 分页兜底:cursor 续取,上限防御异常服务端不收敛
@@ -117,7 +118,7 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
   /** 起子进程(带 MCP 令牌 env)并握手。 */
   private async launchServer(mcpToken?: string): Promise<void> {
     this.server.start(mcpToken ? { [MCP_TOKEN_ENV]: mcpToken } : undefined);
-    await this.server.initialize({ name: 'duetlens', version: '2.0.0-dev' });
+    await this.server.initialize({ name: 'duetlens', version: APP_VERSION });
   }
 
   /** per-thread config 覆盖:注入自建 MCP + reasoning effort(config.toml 形状透传)。 */

--- a/src/backend/env/environment-check.ts
+++ b/src/backend/env/environment-check.ts
@@ -12,6 +12,7 @@ import type {
 import { run } from '../source/exec';
 import { checkGhAuth } from '../source/source-discovery';
 import { CodexAppServer } from '../agent/codex/codex-app-server';
+import { APP_VERSION } from '@shared/version';
 
 export interface EnvironmentCheckDeps extends EnvCheckOptions {
   codexBin?: string;
@@ -38,7 +39,7 @@ async function probeAppServer(deps: EnvironmentCheckDeps): Promise<AppServerChec
   try {
     server.start();
     await withTimeout(
-      server.initialize({ name: 'duetlens', version: '2.0.0-dev' }),
+      server.initialize({ name: 'duetlens', version: APP_VERSION }),
       APP_SERVER_TIMEOUT_MS,
       'app-server 握手超时',
     );

--- a/src/backend/ipc/index.ts
+++ b/src/backend/ipc/index.ts
@@ -19,16 +19,18 @@ import type { ReviewUiState, Triage, UiSettings } from '@shared/domain';
 import type { EnvCheckOptions } from '@shared/environment';
 import type { PromptSaveInput } from '@shared/prompt';
 import type { ReviewManager } from '../review/review-manager';
+import type { Updater } from '../update/updater';
 import { resolvePrUrl } from '../source/source-discovery';
 
 export interface IpcDeps {
   manager: ReviewManager;
   /** 把领域事件推给所有 renderer(main 提供,通常遍历 BrowserWindow) */
   broadcast: (channel: string, payload: unknown) => void;
+  updater: Updater;
 }
 
 /** 注册 main 侧全部 IPC handler,并把 ReviewManager 事件转发给 renderer。 */
-export function registerIpcHandlers({ manager, broadcast }: IpcDeps): void {
+export function registerIpcHandlers({ manager, broadcast, updater }: IpcDeps): void {
   ipcMain.handle(IpcChannels.appGetInfo, (): AppInfo => ({
     name: app.getName(),
     version: app.getVersion(),
@@ -136,6 +138,10 @@ export function registerIpcHandlers({ manager, broadcast }: IpcDeps): void {
 
   ipcMain.handle(IpcChannels.uiGetSettings, () => manager.getUiSettings());
   ipcMain.handle(IpcChannels.uiSaveSettings, (_e, settings: UiSettings) => manager.saveUiSettings(settings));
+
+  ipcMain.handle(IpcChannels.updateGetStatus, () => updater.getStatus());
+  ipcMain.handle(IpcChannels.updateCheck, () => updater.check());
+  ipcMain.handle(IpcChannels.updateInstall, () => updater.install());
 
   ipcMain.handle(IpcChannels.agentListModels, () => manager.listModels());
 

--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -11,6 +11,7 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FINDING_CATEGORIES, RESOLUTIONS_REQUIRING_NOTE, resolveFindingSchema } from '@shared/domain';
+import { APP_VERSION } from '@shared/version';
 
 const CATEGORY_HINT = `建议取值:${FINDING_CATEGORIES.join(' / ')}`;
 
@@ -230,7 +231,7 @@ export class DuetlensMcpServer extends EventEmitter {
 
   private buildMcpServer(): Server {
     const server = new Server(
-      { name: 'duetlens', version: '2.0.0' },
+      { name: 'duetlens', version: APP_VERSION },
       { capabilities: { tools: {} } },
     );
 

--- a/src/backend/update/updater.ts
+++ b/src/backend/update/updater.ts
@@ -1,0 +1,97 @@
+import { app } from 'electron';
+import electronUpdater from 'electron-updater';
+import type { UpdateStatus } from '@shared/update';
+
+// electron-updater 是 CJS,具名 import 在 ESM 产物下会拿到 undefined,只能默认导入后解构
+// eslint-disable-next-line import/no-named-as-default-member
+const { autoUpdater } = electronUpdater;
+
+/** 启动后延迟首查:让窗口先画出来,别和冷启动抢带宽。 */
+const FIRST_CHECK_DELAY_MS = 8_000;
+/** 常驻期间的复查间隔。 */
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export interface UpdaterDeps {
+  /** 状态变化推给所有窗口 */
+  onStatus: (status: UpdateStatus) => void;
+  /** 装更新前拆掉活跃会话(复用退出时那套收尾) */
+  cleanup: () => Promise<void>;
+}
+
+export interface Updater {
+  getStatus(): UpdateStatus;
+  check(): void;
+  install(): Promise<void>;
+  dispose(): void;
+}
+
+/**
+ * electron-updater 的薄封装。渠道是 electron-builder 在打包时写进 app-update.yml 的
+ * GitHub Releases,所以这里不碰 setFeedURL。
+ *
+ * 默认后台下载 + 退出时安装:用户什么都不做也能升级,设置屏那行只是让他能提前重启。
+ * dev 下没有 app-update.yml,直接停在 unsupported,别让 updater 在开发态刷错误。
+ */
+export function createUpdater({ onStatus, cleanup }: UpdaterDeps): Updater {
+  let status: UpdateStatus = { phase: app.isPackaged ? 'idle' : 'unsupported' };
+  let timer: NodeJS.Timeout | undefined;
+
+  function set(next: UpdateStatus): void {
+    status = next;
+    onStatus(next);
+  }
+
+  if (!app.isPackaged) {
+    return {
+      getStatus: () => status,
+      check: () => undefined,
+      install: async () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+
+  autoUpdater.on('checking-for-update', () => set({ phase: 'checking' }));
+  autoUpdater.on('update-not-available', () => set({ phase: 'current' }));
+  autoUpdater.on('update-available', (info) =>
+    set({ phase: 'downloading', version: info.version, percent: 0 }),
+  );
+  autoUpdater.on('download-progress', (p) => {
+    // version 只在 update-available 里给,进度事件没有,沿用当前档里的
+    const version = status.phase === 'downloading' ? status.version : '';
+    set({ phase: 'downloading', version, percent: Math.round(p.percent) });
+  });
+  autoUpdater.on('update-downloaded', (info) => set({ phase: 'ready', version: info.version }));
+  autoUpdater.on('error', (err) => set({ phase: 'error', message: err.message }));
+
+  function check(): void {
+    // 已经下好了就别再查:再查一轮会把 ready 冲回 checking,用户那颗「立即重启」按钮就没了
+    if (status.phase === 'ready' || status.phase === 'downloading') return;
+    void autoUpdater.checkForUpdates().catch((e: unknown) => {
+      set({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+    });
+  }
+
+  const first = setTimeout(check, FIRST_CHECK_DELAY_MS);
+  timer = setInterval(check, RECHECK_INTERVAL_MS);
+
+  return {
+    getStatus: () => status,
+    check,
+    async install() {
+      if (status.phase !== 'ready') return;
+      // 先拆会话再交给 Squirrel:quitAndInstall 会立刻走退出流程,
+      // 那之后 codex 子进程没人管,会成为孤儿活到用户手动 kill。
+      await cleanup();
+      autoUpdater.quitAndInstall();
+    },
+    dispose() {
+      clearTimeout(first);
+      if (timer) clearInterval(timer);
+      timer = undefined;
+      autoUpdater.removeAllListeners();
+    },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { ReviewStore } from '@backend/db/review-store';
 import { ReviewManager } from '@backend/review/review-manager';
 import { createCompletionNotifier } from '@backend/notify/completion-notifier';
 import { hydratePath } from '@backend/env/shell-path';
+import { createUpdater } from '@backend/update/updater';
 import { IpcEvents, type CompletionNotice, type ReviewEvent } from '@shared/ipc';
 
 // 开发态与打包版可能同时开着:各自独立 userData,否则两个进程写同一个 sqlite,
@@ -96,7 +97,15 @@ app.whenReady().then(async () => {
   const broadcast = (channel: string, payload: unknown) => {
     for (const w of BrowserWindow.getAllWindows()) w.webContents.send(channel, payload);
   };
-  registerIpcHandlers({ manager, broadcast });
+  const updater = createUpdater({
+    onStatus: (s) => broadcast(IpcEvents.updateStatus, s),
+    cleanup: async () => {
+      // 置位要在清理之前:cleanup 期间 before-quit 若被触发,得让它放行
+      installingUpdate = true;
+      await cleanupSessions();
+    },
+  });
+  registerIpcHandlers({ manager, broadcast, updater });
 
   // 长任务完成提示:焦点判定 + 原生通知归 main(独占 BrowserWindow/Notification);
   // review-event 已流经 main,此处再挂一个消费者驱动通知。
@@ -129,23 +138,30 @@ app.on('window-all-closed', () => {
  */
 const QUIT_CLEANUP_TIMEOUT_MS = 3000;
 let quitting = false;
+let installingUpdate = false;
 
 /**
- * 退出前拆掉所有活跃会话,**清完再退**。
+ * 拆掉所有活跃会话,最多等 {@link QUIT_CLEANUP_TIMEOUT_MS}。
  *
- * 默认的退出不等异步清理:`session.dispose()` 里发 SIGTERM 与关 MCP 都是异步的,进程先跑掉的话,
- * 那些 codex 子进程就成了孤儿(POSIX 不因父进程退出而杀子进程),一路活到用户手动 kill。
- * 所以拦下这次退出自己收尾,再 {@link app.exit} —— exit 不会重新触发本事件。
+ * `session.dispose()` 里发 SIGTERM 与关 MCP 都是异步的,进程先跑掉的话那些 codex 子进程
+ * 就成了孤儿(POSIX 不因父进程退出而杀子进程),一路活到用户手动 kill。
  */
+function cleanupSessions(): Promise<unknown> {
+  const cleanup = manager?.disposeAll() ?? Promise.resolve();
+  const deadline = new Promise((r) => setTimeout(r, QUIT_CLEANUP_TIMEOUT_MS));
+  // 拆会话失败也照样往下走,别把错误挡在退出前面
+  return Promise.race([cleanup, deadline]).catch(() => undefined);
+}
+
+/** 退出前**清完再退**;默认的退出流程不等异步清理,所以拦下这次自己收尾。 */
 app.on('before-quit', (e) => {
+  // 装更新这条路自己清过了,且必须让退出真的发生 —— 拦下来 Squirrel 就永远等不到进程结束。
+  if (installingUpdate) return;
   // 拦下要先于重入判断:清理期间用户再按一次退出,放行的话默认流程当场结束进程,
   // 正好绕过这里的「清完再退」。第一次的收尾跑完(或超时)会统一 exit。
   e.preventDefault();
   if (quitting) return;
   quitting = true;
-  const cleanup = manager?.disposeAll() ?? Promise.resolve();
-  const deadline = new Promise((r) => setTimeout(r, QUIT_CLEANUP_TIMEOUT_MS));
-  void Promise.race([cleanup, deadline])
-    .catch(() => undefined) // 拆会话失败也照样退出,别把错误挡在 exit 前面
-    .then(() => app.exit(0));
+  // app.exit 不会重新触发本事件
+  void cleanupSessions().then(() => app.exit(0));
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -8,6 +8,7 @@ import {
   type ReviewStartProgress,
 } from '@shared/ipc';
 import type { UiSettings } from '@shared/domain';
+import type { UpdateStatus } from '@shared/update';
 
 // 唯一暴露给 renderer 的桥;沿 contextIsolation 边界只透出白名单方法。
 const api: DuetlensApi = {
@@ -81,6 +82,16 @@ const api: DuetlensApi = {
   ui: {
     getSettings: () => ipcRenderer.invoke(IpcChannels.uiGetSettings),
     saveSettings: (settings: UiSettings) => ipcRenderer.invoke(IpcChannels.uiSaveSettings, settings),
+  },
+  update: {
+    getStatus: () => ipcRenderer.invoke(IpcChannels.updateGetStatus),
+    check: () => ipcRenderer.invoke(IpcChannels.updateCheck),
+    install: () => ipcRenderer.invoke(IpcChannels.updateInstall),
+    onStatus: (handler: (s: UpdateStatus) => void) => {
+      const listener = (_e: IpcRendererEvent, s: UpdateStatus) => handler(s);
+      ipcRenderer.on(IpcEvents.updateStatus, listener);
+      return () => ipcRenderer.off(IpcEvents.updateStatus, listener);
+    },
   },
   agent: {
     listModels: () => ipcRenderer.invoke(IpcChannels.agentListModels),

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -18,6 +18,17 @@ import { scanDoneStatus } from '@shared/domain';
 import { isSubmittable } from '@shared/github-review';
 import type { Discussion, Finding, Message, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
 import { mergeLayers } from '@shared/prompt';
+import { APP_VERSION } from '@shared/version';
+import type { UpdateStatus } from '@shared/update';
+
+const UPDATE_FIXTURES: Record<string, UpdateStatus> = {
+  unsupported: { phase: 'unsupported' },
+  checking: { phase: 'checking' },
+  current: { phase: 'current' },
+  downloading: { phase: 'downloading', version: '0.2.0', percent: 42 },
+  ready: { phase: 'ready', version: '0.2.0' },
+  error: { phase: 'error', message: 'net::ERR_INTERNET_DISCONNECTED' },
+};
 import type { EditablePromptLayer, PromptSectionKey, ReviewPromptView } from '@shared/prompt';
 
 /** 预览用 src/pipeline.ts 新侧全文(供展开 diff 外上下文自查);行 14–24 为 hunk 覆盖区。 */
@@ -446,6 +457,14 @@ export function installPreviewApi(): void {
   (window as unknown as { __fireInApp?: (n: CompletionNotice) => void }).__fireInApp = (n) => {
     for (const l of inAppListeners) l(n);
   };
+
+  const updateListeners = new Set<(s: UpdateStatus) => void>();
+  const fireUpdate = (): void => {
+    for (const l of updateListeners) l(updateStatus);
+  };
+  let updateStatus: UpdateStatus = UPDATE_FIXTURES[params.get('upd') ?? 'current'] ?? {
+    phase: 'current',
+  };
   const emit = (payload: Finding) => {
     const i = findings.findIndex((f) => f.id === payload.id);
     if (i >= 0) findings[i] = payload;
@@ -470,7 +489,7 @@ export function installPreviewApi(): void {
   const api: DuetlensApi = {
     getAppInfo: async () => ({
       name: 'Duetlens (preview)',
-      version: '2.0.0-dev',
+      version: APP_VERSION,
       electron: '34.0.0',
       chrome: '132.0',
       node: '20.18',
@@ -869,6 +888,23 @@ export function installPreviewApi(): void {
       getSettings: async () => uiSettings,
       saveSettings: async (s) => {
         uiSettings = s;
+      },
+    },
+    // ?upd=current|checking|downloading|ready|error|unsupported(缺省 current)
+    update: {
+      getStatus: async () => updateStatus,
+      check: async () => {
+        updateStatus = { phase: 'checking' };
+        fireUpdate();
+        setTimeout(() => {
+          updateStatus = { phase: 'current' };
+          fireUpdate();
+        }, 900);
+      },
+      install: async () => undefined,
+      onStatus: (handler) => {
+        updateListeners.add(handler);
+        return () => updateListeners.delete(handler);
       },
     },
     agent: {

--- a/src/renderer/screens/SettingsScreen.css
+++ b/src/renderer/screens/SettingsScreen.css
@@ -345,6 +345,22 @@
   padding: 2px 8px;
 }
 
+/* 版本卡与外链行之间的更新状态行 */
+.settings .about-update {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 4px 0;
+}
+.settings .about-update .stat {
+  min-width: 0;
+}
+.settings .about-update .btn-sm {
+  flex: none;
+  height: 26px;
+  margin-left: auto;
+}
+
 /* 版本卡下的外链行;点分隔,点了会离开应用 */
 .settings .about-links {
   display: flex;

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AppInfo } from '@shared/ipc';
+import type { UpdateStatus } from '@shared/update';
 import type { CodexModelInfo, SourceKind, UiSettings } from '@shared/domain';
 import { DEFAULT_UI_SETTINGS, REASONING_EFFORTS, REVIEW_INTENSITIES } from '@shared/domain';
 import type { EnvironmentReport } from '@shared/environment';
@@ -335,6 +336,7 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
               </div>
               <span className="lic mono">GPL-3.0</span>
             </div>
+            <UpdateRow />
             <div className="about-links">
               <LinkOut href={PROJECT_LINKS.repo}>源码仓库</LinkOut>
               <i />
@@ -406,6 +408,61 @@ function LinkOut({ href, children }: { href: string; children: React.ReactNode }
       {children}
     </a>
   );
+}
+
+/**
+ * 更新状态一行。更新本身是后台下载、退出时静默安装的,所以这里不是升级的必经之路 ——
+ * 只让用户看得见进度、并能提前重启。dev / 不支持的渠道整行不渲染。
+ */
+function UpdateRow(): React.JSX.Element | null {
+  const [status, setStatus] = useState<UpdateStatus>({ phase: 'idle' });
+
+  useEffect(() => {
+    window.duetlens.update.getStatus().then(setStatus).catch(() => undefined);
+    return window.duetlens.update.onStatus(setStatus);
+  }, []);
+
+  if (status.phase === 'unsupported') return null;
+
+  const busy = status.phase === 'checking' || status.phase === 'downloading';
+  const tone =
+    status.phase === 'ready' ? 'ok' : status.phase === 'error' ? 'err' : busy ? 'checking' : '';
+
+  return (
+    <div className="about-update">
+      <span className={`stat${tone ? ` ${tone}` : ''}`}>
+        <span className="d" />
+        {updateText(status)}
+      </span>
+      {status.phase === 'ready' ? (
+        <button className="btn-sm" onClick={() => void window.duetlens.update.install()}>
+          立即重启更新
+        </button>
+      ) : (
+        <button className="btn-sm" disabled={busy} onClick={() => void window.duetlens.update.check()}>
+          检查更新
+        </button>
+      )}
+    </div>
+  );
+}
+
+function updateText(s: UpdateStatus): string {
+  switch (s.phase) {
+    case 'checking':
+      return '正在检查…';
+    case 'current':
+      return '已是最新版本';
+    case 'downloading':
+      // update-available 之后、第一个进度事件之前 version 才会是空
+      return s.version ? `正在下载 ${s.version} · ${s.percent}%` : '正在下载新版本…';
+    case 'ready':
+      return `${s.version} 已下载,重启后生效`;
+    case 'error':
+      return `检查失败:${s.message}`;
+    default:
+      return '尚未检查更新';
+  }
 }
 
 function Toggle({ on, onToggle }: { on: boolean; onToggle: () => void }): React.JSX.Element {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -21,6 +21,7 @@ import type { AgentEvent } from './agent-events';
 import type { GhReviewEvent } from './github-review';
 import type { PromptSaveInput, ReviewPromptView } from './prompt';
 import type { EnvCheckOptions, EnvironmentReport } from './environment';
+import type { UpdateStatus } from './update';
 import type {
   LocalBranchList,
   PrPreview,
@@ -80,6 +81,9 @@ export const IpcChannels = {
   dialogPickDirectory: 'dialog:pick-directory',
   dialogPickFile: 'dialog:pick-file',
   dialogSaveTextFile: 'dialog:save-text-file',
+  updateGetStatus: 'update:get-status',
+  updateCheck: 'update:check',
+  updateInstall: 'update:install',
 } as const;
 
 /** 发起一次真实审核的目标(对应 backend ReviewTarget;repoPath 对 github-pr 可省)。 */
@@ -235,6 +239,8 @@ export const IpcEvents = {
   notifyOpenReview: 'notify:open-review',
   /** 窗口聚焦时的应用内轻提示(不弹原生通知) */
   notifyInApp: 'notify:in-app',
+  /** 自动更新状态推进 */
+  updateStatus: 'update:status',
 } as const;
 
 /** 长任务完成提示的载荷(扫描完成 / 追问回复);原生通知与应用内提示共用。 */
@@ -356,6 +362,16 @@ export interface DuetlensApi {
   ui: {
     getSettings(): Promise<UiSettings>;
     saveSettings(settings: UiSettings): Promise<void>;
+  };
+  update: {
+    /** 当前状态(挂载时取一次,之后靠 onStatus 推)。 */
+    getStatus(): Promise<UpdateStatus>;
+    /** 手动查一次;结果同样走 onStatus,不用等这个 Promise 的返回值。 */
+    check(): Promise<void>;
+    /** 拆完活跃会话后重启装更新;仅在 ready 态可用。 */
+    install(): Promise<void>;
+    /** 订阅状态推进;返回取消订阅函数。 */
+    onStatus(handler: (s: UpdateStatus) => void): () => void;
   };
   agent: {
     /** 列举账号可用的 codex 模型(供发起表单下拉);未登录/出错时抛错,前端降级为手填。 */

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -1,0 +1,18 @@
+/**
+ * 自动更新的状态机。main 侧 electron-updater 的事件收敛成这几档,renderer 只认这里。
+ *
+ * 更新默认后台下好、退出时静默装上(autoInstallOnAppQuit),所以 UI 只有一处:
+ * 设置屏「关于」的一行 —— 用户不去看也照样能升级,去看则能提前手动重启。
+ */
+export type UpdateStatus =
+  /** 打包外(dev)或渠道不可用 —— 不做检查,UI 隐藏整行 */
+  | { phase: 'unsupported' }
+  /** 尚未检查过 */
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  /** 已是最新 */
+  | { phase: 'current' }
+  | { phase: 'downloading'; version: string; percent: number }
+  /** 已下好,重启即生效 */
+  | { phase: 'ready'; version: string }
+  | { phase: 'error'; message: string };

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,13 @@
+/**
+ * 客户端版本号的唯一来源。发给 app-server / MCP 的 clientInfo 都取这里,发版只改 package.json。
+ *
+ * 值由三份 vite 配置在构建期 define 注入(main / preload / renderer 各一份,漏一份就会静默回落)。
+ * spike 脚本在 tsx 下跑,没有 define,回落到 npm run 暴露的 npm_package_version。
+ * main 里展示用的 `app.getVersion()` 读的是同一个 package.json,不是第二份来源。
+ */
+declare const __APP_VERSION__: string | undefined;
+
+export const APP_VERSION: string =
+  typeof __APP_VERSION__ === 'string'
+    ? __APP_VERSION__
+    : (globalThis.process?.env?.npm_package_version ?? '0.0.0-dev');

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import { appVersionDefine } from './scripts/app-version-define';
 
 // 同时被 electron.vite.config.ts(打包 renderer)和 vite.preview.config.ts(纯 vite 浏览器预览)使用。
 // 必须保持成对象形式:electron.vite.config.ts 用 mergeConfig 合成它,函数式 config 合不进去。
 // root 必须显式指向项目根:index.html / preview.html 都在这里,electron-vite 默认的 src/renderer 不适用。
 export default defineConfig({
   root: __dirname,
+  define: appVersionDefine(__dirname),
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
- version comes from package.json only, injected at build time
- developer id signing plus notarization; dmg to download, zip for the updater
- electron-updater against public github releases, published as a draft first
- tagged builds run on ci, arm64 only

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #7 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6
<!-- GitButler Footer Boundary Bottom -->