### PR TITLE
fix(review): keep suggestion indentation in submitted patches

### DIFF
--- a/scripts/spike-submit.ts
+++ b/scripts/spike-submit.ts
@@ -46,7 +46,7 @@ function seed(store: ReviewStore) {
     body: '用 Atomic 替代。',
     file: 'src/p.ts',
     line: 20,
-    suggestion: 'const c = new Atomic(0);',
+    suggestion: '    const c = new Atomic(0);',
   });
   const f2 = store.addFinding(review.id, {
     severity: 'low',
@@ -72,7 +72,8 @@ async function main() {
     assert.equal(payload.comments.length, 2, '两条有锚点 → 两条 inline');
     assert.equal(payload.comments[0].side, 'RIGHT');
     assert.equal(payload.comments[0].line, 20);
-    assert.match(payload.comments[0].body, /```suggestion\nconst c = new Atomic/, 'suggestion 块');
+    // 缩进是补丁的一部分:被削掉的话 author 一键采纳就把那行的缩进也改了
+    assert.match(payload.comments[0].body, /```suggestion\n {4}const c = new Atomic\(0\);\n```/, 'suggestion 块逐字保留缩进');
     assert.match(payload.body, /整体方向 OK/, 'review body = summary');
     log('payload 组装 ok');
   }

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -298,7 +298,9 @@ export function findingNarrative(f: Finding, currentRound: number): string {
  */
 export function findingSuggestion(f: Finding, currentRound: number): string | null {
   if (recheckNote(f, currentRound) !== null) return null;
-  return f.suggestion?.trim() || null;
+  // 首行缩进是补丁的一部分(会被逐字替换进代码),只能削首尾空行与行尾空白,不能 trim
+  const s = f.suggestion?.replace(/^[ \t]*\n+/, '').replace(/\s+$/, '') ?? '';
+  return s || null;
 }
 
 export interface Message {


### PR DESCRIPTION
`findingSuggestion` ran `.trim()` on the whole string, which dropped the leading
indentation of a suggestion's first line. That helper is shared by the submit
preview, the ```suggestion block posted to GitHub, and the markdown export, so a
one-click "Apply suggestion" silently re-indented the anchored line.

Now only leading blank lines and trailing whitespace are stripped; indentation is
part of the patch and is preserved verbatim. Whitespace-only suggestions still
collapse to null, and the round-2 recheck rule is unchanged.

The submit spike's fixture now carries an indented suggestion and its assertion
is tightened to lock the behaviour in.