### PR TITLE
fix(entry): keep recent-repo name on one line

### DIFF
--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -982,7 +982,7 @@ export function installPreviewApi(): void {
           return { ...base, head: 'gitbutler/workspace', mode: 'local', degraded: 'but-missing' };
         return { ...base, head: 'gitbutler/workspace', mode: 'gitbutler', gitbutler };
       },
-      listRepoPaths: async () => ['/Users/dev/podcast-go', '/Users/dev/duetlens'],
+      listRepoPaths: async () => ['/Users/dev/GitHub/backend-podcast-node', '/Users/dev/duetlens'],
     },
     prompt: {
       get: async (cwd) => buildPromptView(cwd),

--- a/src/renderer/screens/EntryScreen.css
+++ b/src/renderer/screens/EntryScreen.css
@@ -649,6 +649,7 @@
   align-items: baseline;
   gap: 7px;
   max-width: 260px;
+  overflow: hidden;
   padding: 5px 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -657,10 +658,21 @@
   font-family: inherit;
 }
 .rr-item:hover { border-color: var(--agent-line); background: var(--agent-soft); }
-.rr-item .rr-name { font-size: 12px; color: var(--text); font-weight: 600; }
+/* 超宽时只截目录 —— 名字是识别这颗胶囊的唯一凭据,只有它自己撑满一行才退让 */
+.rr-item .rr-name {
+  font-size: 12px;
+  color: var(--text);
+  font-weight: 600;
+  flex: none;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .rr-item .rr-dir {
   font-size: 10.5px;
   color: var(--text-faint);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
`.rr-name` had no `white-space: nowrap`, so a long repo name wrapped inside
the 260px chip instead of letting the directory path truncate — the chip grew
to two lines and no longer matched the height of its neighbours.

The name now sits outside the flex shrink entirely (`flex: none`), capped at
`max-width: 100%` with an ellipsis, so it only gives way when it alone fills
the chip. The path takes all the shrink via `min-width: 0`.

Tuning shrink ratios was not enough: proportional shrink still left the name
0.03px short, and the floored `clientWidth` triggered the ellipsis anyway.

The preview fixture now uses a long repo path, since the old short one never
exercised the truncating case.

Verified in `preview:ui` (`?screen=entry&entry-state=pick`, local-repo tab):
name intact with the path truncated, both chips single-line at 26px; a
44-character name degrades to a single-line ellipsis rather than a hard clip.