### PR TITLE
feat(theme): add parchment color theme for light and dark

### DIFF
--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -6,10 +6,14 @@
 
 ## 两个正交轴
 
-- `data-mode` = `light | dark` —— 明暗**品牌外壳**(chrome:bg / surface / border / text / brand / 阴影 / 辉光)。
-- `data-theme` = `duetlens | github` —— **配色主题**,成套打包所有该随主题走的部件:语法 token + 代码正文色、diff 增删的前景 / 背景 / gutter、severity 徽标色、代码内引用与搜索高亮。主题跟随 `data-mode` 自动切子模式,共四种组合。
+- `data-mode` = `light | dark` —— 明暗**品牌外壳**(chrome:bg / surface / border / text / brand / 阴影 / 辉光)的**默认档**。
+- `data-theme` = `duetlens | github | parchment` —— **配色主题**,成套打包所有该随主题走的部件:语法 token + 代码正文色、diff 增删的前景 / 背景 / gutter、severity 徽标色、代码内引用与搜索高亮。主题跟随 `data-mode` 自动切子模式。
 
-CHROME 与 THEME 变量**分离、互不耦合**;新增配色主题只需补一组 THEME 变量,不动外壳。**duet 双声道 accent(agent 天蓝 / human 琥珀)属于 chrome、跨配色主题恒定**,是品牌标识,仅随明暗取不同深浅。屏幕特有的布局变量(如栏宽)留在各屏自己的 CSS。
+**主题默认只管代码那一半,chrome 由 `data-mode` 给;但主题可以整套覆写 chrome** —— 纸的色温本身就是羊皮纸这套主题要传达的东西,只换语法色留一块冷灰画布等于没做。覆写档的选择器带两个属性(`[data-mode][data-theme]`),特异性高于 `data-mode` 那档,与书写顺序无关。**duet 双声道 accent(agent 天蓝 / human 琥珀)由 chrome 给出默认值,主题可按自己的画布覆写** —— 要守住的是**两条声道的语义角色与彼此、与 severity / diff 的可辨识度**,不是某个固定色值;把色值锁死等于规定了以后所有配色方案的画布色温。羊皮纸这一版就是照此各选各的:agent 天蓝原样(冷 accent 压在暖纸上最跳,信息层级一点不用重排),human 琥珀微调一档补偿暖纸吃掉的暖意。屏幕特有的布局变量(如栏宽)留在各屏自己的 CSS。
+
+> 覆写 chrome 的主题**必须把 THEME 变量给全**:`data-theme` 不是 `duetlens` 时,`duetlens · light` 那组不匹配,缺哪个变量就掉回 `:root` 的**深色**值(不是浅色),漏一个就是一处白底浅字。
+
+新增主题后按两条口径验:**逐屏跑对比度、并与现有主题逐条比差集** —— 只看绝对不达标数会被一批「本来就这样」的装饰性字形(diff gutter 的 ＋ ／ −、off-diff 的 ◇)淹掉,真正要拦的是**只有新主题才有的那几条**。羊皮纸这轮就是这样揪出两处:注释色整行落在 add/del 行底色上(只按画布验合格、压到 del 行不合格),以及 `--text-faint` 落在 `--surface-3` 的 chip 上 —— **两档的下限都由最亮的那层底定,不是由画布定**。
 
 > 检索命中色**独占靛紫色相**,不借用 agent 蓝 / human 琥珀 / diff 绿红任何一档语义。
 

--- a/src/renderer/components/ThemeControls.tsx
+++ b/src/renderer/components/ThemeControls.tsx
@@ -13,6 +13,7 @@ export function ThemeControls() {
       >
         <option value="duetlens">duetlens</option>
         <option value="github">github</option>
+        <option value="parchment">parchment</option>
       </select>
       <button
         className="mode-toggle"

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -427,9 +427,16 @@ export function installPreviewApi(): void {
     ...(asRoundFailed ? { status: 'failed' as const } : {}),
   };
   // entry-state=pick 清掉记住的仓库,自查本地仓库档的选目录空态
+  // ?mode= / ?theme= 直接开在某套配色上:出图与逐屏比色都要它,靠点 rail 那颗钮只能切明暗、切不了主题
+  const asMode = params.get('mode');
+  const asTheme = params.get('theme');
   let uiSettings: UiSettings = {
     ...UI_SETTINGS,
     ...(params.get('entry-state') === 'pick' ? { lastRepoPath: '' } : {}),
+    ...(asMode === 'light' || asMode === 'dark' ? { dataMode: asMode } : {}),
+    ...(asTheme === 'duetlens' || asTheme === 'github' || asTheme === 'parchment'
+      ? { dataTheme: asTheme }
+      : {}),
   };
   // 预置一个已看文件,证明启动即从后端恢复 per-review 进度(非组件默认空态)
   // ?tab=findings|discussion|summary 强制初始右栏 tab(自查用,如在扫描期停在 Discussion 看进度头)

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -149,7 +149,7 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
           {/* 外观 */}
           <section className="set-sec" data-sec="appearance">
             <h2><span className="ic">◐</span> 外观</h2>
-            <div className="desc">明暗模式与配色主题两个正交轴,应用启动即生效,跨所有审核一致。</div>
+            <div className="desc">明暗模式与配色主题两个正交轴,应用启动即生效,跨所有审核一致。羊皮纸会连同界面底色一起换。</div>
             <Row label="明暗模式">
               <Choice
                 value={settings.dataMode}
@@ -168,6 +168,7 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
               >
                 <option value="duetlens">Duetlens</option>
                 <option value="github">GitHub</option>
+                <option value="parchment">羊皮纸</option>
               </select>
             </Row>
           </section>

--- a/src/renderer/theme/tokens.css
+++ b/src/renderer/theme/tokens.css
@@ -1,10 +1,11 @@
 /* =========================================================
    Duetlens design tokens — 单一来源
    两个正交的配色轴:
-     data-mode  = dark | light        (明暗模式 · 品牌外壳 chrome)
-     data-theme = duetlens | github   (配色主题 · 成套:语法 token + diff + severity + 代码高亮)
+     data-mode  = dark | light                    (明暗模式 · 给出 chrome 的默认档)
+     data-theme = duetlens | github | parchment   (配色主题 · 成套:语法 token + diff + severity + 代码高亮)
    配色主题跟随 data-mode 自动切子模式(GitHub → Dark/Light)。
-   CHROME 变量与 THEME 变量分离,互不耦合;新增主题只补一组 THEME 变量。
+   THEME 默认只管代码那一半,chrome 由 data-mode 给;但**主题可以整套覆写 chrome**(parchment 即如此),
+   此时它的选择器带两个属性,特异性高于 data-mode 那档,与书写顺序无关。
    本文件是配色 tokens 的单一来源;勿在各处内联复制这些值。
    ========================================================= */
 
@@ -87,6 +88,56 @@
   --code-hl:color-mix(in oklab,var(--agent) 13%,transparent);
   --find-hl:color-mix(in oklab,oklch(.52 .17 285) 26%,transparent); --find-hl-on:oklch(.52 .17 285); --find-hl-fg:#fff;
   --sev-high:oklch(46% .18 16); --sev-med:oklch(46% .13 86); --sev-low:oklch(47% .055 242);
+}
+/* ---- THEME: Parchment · light ---- */
+/* 羊皮纸是三个主题里唯一连 chrome 一起换的:纸的色温本身就是这套主题要传达的东西,
+   只换语法色留一块冷灰画布,等于没做。
+   双声道要守住的是**语义角色与可辨识度**,不是固定色值:agent 天蓝原样照搬浅色基础档
+   —— 冷 accent 压在暖纸上最跳,信息层级一点不用重排;human 琥珀则微调(暖纸会吃掉一点
+   它的暖),两者仍各占原来的色相区,没往对方或 severity 那几档靠。
+   THEME 变量必须给全:data-theme 不是 duetlens 时,duetlens·light 那组不匹配,
+   缺哪个就掉回 :root 的**深色**值(不是浅色),漏一个就是一处白底浅字。 */
+:root[data-mode="light"][data-theme="parchment"]{
+  --bg:oklch(94.8% .014 88); --surface:oklch(97.4% .010 88); --card:oklch(99.2% .006 90);
+  --surface-2:oklch(96.2% .012 88); --surface-3:oklch(93.2% .016 86);
+  --border:oklch(82% .026 82); --border-soft:oklch(89.5% .018 84);
+  --text:oklch(23% .016 70); --text-dim:oklch(45% .018 68); --text-faint:oklch(52% .018 66); --text-deco:oklch(60% .016 66);
+  --agent:oklch(.50 .145 252); --agent-2:oklch(.43 .155 254); --agent-soft:color-mix(in oklab,var(--agent) 9%,transparent); --agent-line:color-mix(in oklab,var(--agent) 28%,transparent);
+  --accent-solid:oklch(.49 .16 253); --on-solid:#fff;
+  --human:oklch(.55 .15 52); --human-soft:color-mix(in oklab,var(--human) 12%,transparent); --human-line:color-mix(in oklab,var(--human) 32%,transparent);
+  --on-accent:#ffffff; --hover:color-mix(in oklab,var(--text) 4%,transparent);
+  --sel:color-mix(in oklab,var(--agent) 15%,transparent); --scroll:oklch(86% .022 84); --scroll-h:oklch(78% .030 82);
+  /* 阴影取纸的色相而非蓝灰,否则暖纸上的投影发青 */
+  --shadow:0 1px 2px oklch(38% .05 68/.07),0 8px 22px -14px oklch(38% .06 68/.26);
+  --glow1:color-mix(in oklab,var(--agent) 5%,transparent); --glow2:color-mix(in oklab,var(--human) 5%,transparent);
+  --code-text:oklch(23% .016 70);
+  /* --c 比浅色基础档更深一级:注释常整行落在 add/del 行底色上,那才是它最暗的处境 ——
+     只按画布验会漏(53% 在画布上 4.55 合格,压到 del 行只剩 4.46)。 */
+  --k:oklch(46% .19 296); --fn:oklch(46% .14 243); --s:oklch(43% .12 152); --n:oklch(47% .13 52); --c:oklch(51% .020 72); --ty:oklch(47% .11 74); --mac:oklch(47% .18 334);
+  --add:oklch(46% .13 150); --del:oklch(49% .17 26);
+  /* 增删底色也得带纸的暖底,否则两条 diff 行像贴在纸上的两张冷色贴纸。
+     它们与画布之间是**色相差不是明度差**,别拿亮度比去验(现状浅色同样只有 1.01)。 */
+  --add-bg:oklch(95.6% .042 145); --del-bg:oklch(95.2% .040 32);
+  --add-gutter:color-mix(in oklab,var(--add) 26%,transparent); --del-gutter:color-mix(in oklab,var(--del) 24%,transparent);
+  --code-hl:color-mix(in oklab,var(--agent) 13%,transparent);
+  --find-hl:color-mix(in oklab,oklch(.52 .17 285) 26%,transparent); --find-hl-on:oklch(.52 .17 285); --find-hl-fg:#fff;
+  --sev-high:oklch(46% .18 18); --sev-med:oklch(46% .13 84); --sev-low:oklch(47% .055 242);
+}
+/* ---- THEME: Parchment · dark ---- */
+/* 深色档只把纸与墨焐暖(灯下的旧纸),语法色、diff、severity 全部沿用基础深色档 ——
+   深底上再动语法色只会削弱它们彼此的区分度,而暖色调这件事靠 bg / text / border 就已经说清。 */
+:root[data-mode="dark"][data-theme="parchment"]{
+  --bg:oklch(15.5% .012 68); --surface:oklch(19.5% .012 70); --card:oklch(19.5% .012 70);
+  --surface-2:oklch(22.5% .013 70); --surface-3:oklch(25.5% .014 72);
+  --border:oklch(38% .020 74); --border-soft:oklch(28.5% .016 72);
+  /* faint 的下限由**最亮的那层底**定,不是画布:文件行的改动计数落在 --surface-3 的 chip 上,
+     63% 在那儿只有 4.48。65% 同时给选中态的 -soft 底留出被吃掉的那一档。 */
+  --text:oklch(92.5% .012 88); --text-dim:oklch(70% .016 84); --text-faint:oklch(65% .017 82); --text-deco:oklch(49% .015 78);
+  --hover:color-mix(in oklab,oklch(90% .04 82) 3%,transparent);
+  --scroll:oklch(26% .016 72); --scroll-h:oklch(32% .018 72);
+  --shadow:0 8px 24px -14px oklch(10% .02 60/.75);
+  --code-text:oklch(86% .012 85);
+  --c:oklch(62% .022 80);
 }
 /* ---- THEME: GitHub · dark ---- */
 :root[data-mode="dark"][data-theme="github"]{

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -314,7 +314,7 @@ export interface Message {
 // ---- Persisted UI state(见 docs/design/architecture.md 持久化表)----
 export interface UiSettings {
   dataMode: 'light' | 'dark';
-  dataTheme: 'duetlens' | 'github';
+  dataTheme: 'duetlens' | 'github' | 'parchment';
   leftWidth: number;
   rightWidth: number;
   defaultTab: 'discussion' | 'findings' | 'summary';


### PR DESCRIPTION
Adds a warm parchment theme as a third `data-theme` value, with a tuned variant for each mode.

- Light: cream paper (hue 88, C.014), warm neutral ink, warm borders and shadow. Syntax colors follow the light base with the comment color pushed one step darker.
- Dark: only the paper and ink are warmed. Syntax, diff and severity colors stay on the dark base, so the delta is small.

The duet channels keep their roles: agent blue is unchanged from the light base, human amber is nudged one step to compensate for what the warm paper eats.

Axis contract change: a theme may now override chrome, not just the code half. Parchment does exactly that, because the paper temperature is the point of the theme. The override block carries two attributes, so it outranks the `data-mode` block regardless of source order. Doc updated in `docs/design/design-system.md`, including the rule that a chrome-overriding theme must supply the full set of THEME variables (a missing one falls back to the dark value in `:root`, not the light one).

The doc also no longer promises that the duet accent is constant across themes. Locking exact values would constrain the canvas temperature of every future theme; what has to hold is the semantic role and the distinguishability against each other, severity and diff.

Verification: contrast measured per screen through canvas compositing, with element opacity multiplied down the tree, then compared item by item against the duetlens theme. Across 7 screens x 2 modes, parchment matches duetlens in count with an empty difference set. Two regressions were caught this way and fixed:

- Comment color sits on the add/del row background for whole lines. It passed against the canvas but dropped to 4.46 on a del row.
- `--text-faint` sits on a `--surface-3` chip in the file list, where it was 4.48.

Both floors are set by the brightest layer underneath, not by the canvas.

Preview gained `?mode=` and `?theme=` so a screen can open directly on a given palette. The rail toggle only switches light and dark, so there was no way to reach a theme for screenshots or per-screen comparison.