### PR TITLE
feat(discussion): propose finding write-backs for one-click adoption

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ codex app-server 把「一次常驻会话」本身称作 `thread`。为避免冲
 | [architecture.md](design/architecture.md) | 技术栈选型与代价、后端分层、前端状态分层与 UI 持久化、保留自 1.0 的能力 | 动结构 / 加模块前 |
 | [data-model.md](design/data-model.md) | review / round / discussion / finding 的结构与状态,历史保留策略 | 改 schema / 数据流前 |
 | [codex-integration.md](design/codex-integration.md) | app-server 协议的实测结论、MCP HTTP 注入、elicitation / sandbox / 审批 | 碰 codex 集成前 |
+| [discussion-proposals.md](design/discussion-proposals.md) | 讨论里 agent 的回写提案:提案而非直接改、剔除独立成档、卡片挂消息与过期口径 | 碰 discussion 回写 / MCP 写工具前 |
 | [rerun.md](design/rerun.md) | 多轮复审:轮次模型、三态表态、剔除抑制、PR 协作上下文、失败留证 | 碰复审 / 轮次 / 去重前 |
 | [findings-submit.md](design/findings-submit.md) | findings 筛选与提交 PR review / 导出 Markdown,422 失效锚点 | 碰提交流程 / finding 状态前 |
 | [ui.md](design/ui.md) | 各屏的锚点决策与易踩约束 | 做界面前 |
@@ -42,4 +43,5 @@ codex app-server 把「一次常驻会话」本身称作 `thread`。为避免冲
 10. **入口只分 GitHub PR / 本地仓库两档**,本地这档按 HEAD 自动判普通分支还是 GitButler 虚拟分支;落库的 `SourceKind` 仍是三值。→ [ui](design/ui.md#主入口--launcher)
 11. **审核强度两档(标准 / 对抗),只做 L1 只读对抗推理**;L2「拉 worktree 写并执行对抗测试」已明确否决。→ [architecture](design/architecture.md#审核强度)
 12. **审核历史保留 30 天**,按 `updated_at`、启动清一次、不豁免未完成会话。→ [data-model](design/data-model.md#历史保留)
-13. **UI:diff review 是主场**,三栏 + 内联 discussion;duet 双声道(agent 天蓝 / human 琥珀);明暗与配色是两个正交轴。→ [ui](design/ui.md) · [design-system](design/design-system.md)
+13. **讨论里的回写走「提案 + 一键采纳」**:追问轮的写 finding 工具不落库,只生成待确认卡片;剔除是独立一档(`dismiss_finding`),只写理由、保留原文。→ [discussion-proposals](design/discussion-proposals.md)
+14. **UI:diff review 是主场**,三栏 + 内联 discussion;duet 双声道(agent 天蓝 / human 琥珀);明暗与配色是两个正交轴。→ [ui](design/ui.md) · [design-system](design/design-system.md)

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -25,7 +25,7 @@ Review (一次审核会话)
 
 finding 是一类 discussion,但同时是一条**可提交到 GitHub 的记录**,带两组**正交**状态:
 
-- **triage**:`open` → `keep` / `dismiss`(用户裁决;剔除可附 `dismissReason`,复审时注入以抑制同类)
+- **triage**:`open` → `keep` / `dismiss`(用户裁决;剔除可附 `dismissReason`,复审时注入以抑制同类)。剔除**只写 triage 与理由**,标题/正文/suggestion 原样保留 —— agent 在讨论里提出的剔除同走这条路径,见 [discussion-proposals](discussion-proposals.md)
 - **submission**:`unsubmitted` → `submitted`(记录 GitHub 链接)
 
 只有 `keep` 进提交集;`submitted` 后内容锁定只读,不因 triage 变化而回退(唯一例外是复核追评,见 [findings-submit](findings-submit.md))。

--- a/docs/design/discussion-proposals.md
+++ b/docs/design/discussion-proposals.md
@@ -1,0 +1,130 @@
+# 讨论里的回写提案
+
+一条 finding 报出来之后,真正把它打磨准的地方是 discussion。但「谈定了」与「改了」之间原本隔着一道人工搬运:
+agent 谈出结论,却要 reviewer 再说一句「回写 finding」,它才动手。这一节交代为什么把那句话换成一个按钮。
+
+## 为什么是提案,不是直接改
+
+finding 是要提交给 author 的东西,**改动权归 reviewer**。所以两个极端都不成立:
+
+- 让 agent 谈完直接改 —— review 的结论会在 reviewer 没看的时候悄悄变形;
+- 让 agent 只在被明确要求时才改 —— 就是原来的样子:每次都要人把已经达成的共识再复述一遍。
+
+取中间:**追问轮里写 finding 的工具调用不落库,落成一条待确认的提案**,在 agent 那条回复下方渲染成卡片,
+reviewer 一键采纳。判断权没变,搬运没了。
+
+工具面因此**不分叉**:agent 用的仍是 `report_finding` / `update_finding` 这些工具,是我们按 turn 的性质
+决定它们的语义(见 `McpWriteMode`)——
+
+| turn | 语义 | 理由 |
+| --- | --- | --- |
+| 机审扫描 / 对抗自检 | 直接落库 | reviewer 不在场;自检轮本就靠 `update_finding` 给存疑结论降级,拦下来只会卡死它 |
+| 追问 | 记成提案 | reviewer 在场,由他点头 |
+
+另开一套 `propose_*` 工具与之并存的方案**已否决**:让模型在「做」和「提议做」两套工具之间选,选错的概率
+是白送的;而这个区分我们自己完全知道。
+
+提案的工具应答必须说清「尚未生效、在等 reviewer」。只说「已记录」的话,agent 会在同一条回复里宣称改好了,
+而屏上的 finding 一个字没动。
+
+模式挂在**串行执行的 turn 内部**,不是队列外的一个标志位。挂在外面的话:排队期间跑着的扫描 turn 会把它的
+`report_finding` 记成这条讨论的提案;而扫描收尾时的复位又会让排在后面的那一问退回直接落库 ——
+一次绕过 reviewer 确认的静默改动。本轮提案 id 的收集篮同理由调用方持有:同一线程可以并发追问,
+记在 session 上会被后一条清掉,提案就再也挂不上产生它的那句回复。
+
+提案落库前照样过 ingress 校验(`reportFindingSchema` / `updateFindingSchema` 等),错误原样回给 agent。
+直接落库那条路由 ReviewSession 兜着,提案这条没有 —— 不校验的话非法 severity 或缺字段会一路存进
+`finding_proposals`,等到采纳那一刻才炸。
+
+受理与否也要有回执。接收方会因 `finding_id` 不存在 / 不属于本 review 而丢弃提案,若照样答「卡片已呈现」,
+agent 就会拿着这句话向 reviewer 复述,而界面上根本没有那张卡。`ProposalOutcome` 是个由发起方传入、
+接收方就地填的可写对象(emit 是同步的),只有真的落库了才回 `PROPOSED`,否则以 `isError` 要求重来。
+
+## 剔除是独立的一档,不是 update 的一种写法
+
+`dismiss_finding` 是新增的工具,不是锦上添花 —— 在它之前,agent **没有任何表达「这条不成立」的手段**:
+唯一能碰 finding 的 `update_finding` 只写得了 severity / title / body / suggestion,于是它只能把剔除理由
+写进 `body`。后果是两条:原始 finding 正文被覆盖(库里也没了),以及一张已经没有意义的卡片继续占着待提交清单。
+
+正确的落法是 `triage=dismiss` + `dismissReason`,**title / body / suggestion 一个字不动**。
+理由与正文是两种东西,存两个字段,不能互相顶替。
+
+剔除只在讨论里作为提案提出,机审轮直接回绝。理由同 [rerun](rerun.md):连 `wont_fix`(作者亲口说不改)
+都不自动剔除,agent 自己更不该关掉自己报的问题。
+
+采纳之后**不记 `autoClosed`**。那一格的语义是「复核判定代码里已经没有了」;而这里是 reviewer 看过论证后
+点的头,属他自己的判断,下一轮的回归逻辑不该把它翻掉(见 `isAutoClosedFixed`)。
+
+## 剔除态要看得见原文
+
+剔除不动正文,但卡片收起态只剩一个划掉的标题 —— 「当初到底报的是什么」在屏上无处可查。
+剔除态卡片因此给「展开原文」,不必先恢复再剔一遍。
+
+## 卡片挂在消息上,落定之后也不消失
+
+提案先于回复文本产生(工具调用在前,回复要等 turn 收尾才落库),所以落库时还不知道该挂哪条消息;
+turn 收尾后回挂,不回挂就会排在解释它的那句话**上面**。挂不上的(turn 没给回复文本、消息被清空过)
+接在线程末尾 —— 不渲染的话,一张待确认卡片会凭空消失,而它是唯一的确认入口。
+
+applied / skipped 之后卡片折叠成一行,不删。它是「谁在什么时候把这条改成了什么」的唯一凭据;
+applied 记下旧值快照,所以撤销是真的还原,而不是再猜一遍原来长什么样。
+
+三个去向不能互相顶替:**已应用的只能撤销,不能直接标成已忽略**。后者会把改动留在 finding 里、
+卡片却写着「已忽略」并给出「重新应用」,而那一下还会把已被它改过的当前值拍成新快照 ——
+从此撤销回的是它自己写下的东西,留痕与撤销一起失真。
+
+快照**只含该提案动过的字段**。拍全量的话,撤销会把应用之后 reviewer 自己的编辑一并回滚 ——
+提案只降了个 severity,撤销却连带把他重写过的正文换回旧版。dismiss/restore 的撤销走
+`restoreTriage` 而非 `setTriage`:后者会把 `autoClosed` 一律清零(手动裁决就该如此),于是复核自动结案的
+条目撤销后会变成「reviewer 亲手剔的」,下一轮回归不再自动恢复,真问题就此被一直抑制。
+
+`create`(由讨论新建 finding)不给撤销:新建出来的东西该留该删是 reviewer 的事,别在这里替他决定。
+
+**已提交到 GitHub 的 finding,内容不可改**:`update` 的应用与撤销都在权威层拦下。UI 早按这条画
+(卡片的 `writable` 排除 submitted),但提案是一条没有界面把关的写路径,只靠 UI 拦不住,
+本地记录会与已发出去的评论对不上。只锁内容,不锁裁决 —— 已提交的追评项照样可以剔
+(见 [findings-submit](findings-submit.md))。
+
+## 过期只提醒,不拦
+
+提案记下当时 finding 的 `updatedAt`;与当前值不同即说明这条在提案之后又被改过,直接套用会盖掉那次改动。
+UI 就此提醒,但**照样让点** —— 判断权在 reviewer,我们只负责让他知道自己在盖什么。
+
+判据逐档不同,因为各自会顶掉的东西不同:
+
+- `update` 比 `updatedAt`:它覆盖的是正文字段,任何后续改动都可能与之冲突。
+- `dismiss` 比**剔除理由**:它不只是翻一格 triage,还写理由 —— 这条已被剔除且理由与提案不同时,
+  套用就是把 reviewer 自己写的那句顶掉。这里不能用 `updatedAt`,否则改个标题都会触发提醒。
+- `restore` 不判:它把 triage 翻回 open 并清掉理由,而那正是「恢复」本来的语义(见 `setTriage`)。
+
+`skipped` 与 `pending` 一样要判 —— 忽略过的提案仍给「重新应用」,那一下同样是覆盖;
+只有 `applied` 不必判,当前值本就是它写的。
+
+**撤销的方向反过来,而且是硬拦**:撤销写的是应用前的旧值,只有当前值**仍是这条提案写下的那些值**
+时才成立。提案把 severity 降到 medium、reviewer 随后手动改成 low,再撤销就会把它顶回 high ——
+既不是提案的功劳也不是他要的,所以直接不给撤(要回退就手动改,别替他做主)。
+判据是逐字段比对而非 `updatedAt`:后者会被任何无关写入推高,一律拦下等于永远不给撤销。
+
+## 四种意图
+
+| kind | 落库路径 | 备注 |
+| --- | --- | --- |
+| `update` | `updateFinding` | 与 reviewer 就地编辑同一条路径 |
+| `dismiss` | `setTriage('dismiss', reason)` | 正文保留;理由注入下一轮复审 |
+| `restore` | `setTriage('open')` | dismiss 的镜像:讨论后确认它其实成立 |
+| `create` | `promoteDiscussion` / `addFinding` | 提案出自哪条 user discussion 就落在哪条,不另起线程 —— 另建会把论证过程与 finding 拆散 |
+
+`create` 的**锚点以提案为准**,不是 discussion 的。只在同文件时才提升(锚到别处的提案与这条讨论无关),
+提升后若行号与提案不同,按提案改锚 —— agent 常会在框选范围内给出更准的一行,
+而卡片上写的就是它;不对齐的话,采纳到手的锚点和看到的不是一个。
+
+`update_finding` 的 `category` / `suggestion` 在公开 schema 里是 `string | null` —— 领域侧 `null` 就是
+「清空」,只声明 `string` 的话,会校验 JSON Schema 的 client 会把 `null` 挡掉,已有的分类与补丁
+再也删不掉,公开契约与实际接收形状对不上。
+
+端到端验证在 `scripts/spike-proposals.ts`(`npm run spike:proposals`,需 `codex login`):真 codex 走一遍
+「追问 → 提案 → 采纳 / 撤销」,并用桩 agent 经真实 MCP 端点复现「扫描在跑时插一条追问」的时序。
+最后这条是回归用的 —— 把模式改回队列外设置,它会立刻失败在「扫描应落库一条真 finding」。
+
+**改锚点(`file` / `line`)不在其中**。它决定提交到 GitHub 的落点,要先扩 `report_finding` 的 ingress schema,
+与这条通道无关,单独再议。

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "spike:stop-scan": "tsx scripts/spike-stop-scan.ts",
     "spike:session-busy": "tsx scripts/spike-session-busy.ts",
     "spike:followup-queue": "tsx scripts/spike-followup-queue.ts",
+    "spike:proposals": "tsx scripts/spike-proposals.ts",
     "codex:gen-types": "codex app-server generate-ts --out src/backend/agent/codex/generated"
   },
   "keywords": [],

--- a/scripts/spike-proposals.ts
+++ b/scripts/spike-proposals.ts
@@ -1,0 +1,446 @@
+/**
+ * Headless 端到端验证:讨论里的回写提案(见 docs/design/discussion-proposals.md)。
+ *
+ * 覆盖三类断言,前两类要真 codex,第三类是纯本地不烧 token:
+ *   A. 追问轮的 update / dismiss 只生成**待确认提案**,finding 一个字不动;提案挂到那条 agent 回复上。
+ *   B. 采纳 / 撤销走真库:剔除只写 triage 与理由(正文原样保留),撤销按快照还原。
+ *   C. 事务边界与机审轮拒绝剔除 —— 用桩制造失败,断言整体回滚。
+ *
+ * 需 `codex login`;跑之前 `npm run rebuild:node`,跑完 `npm run rebuild:electron` 切回。
+ *   运行:npm run spike:proposals
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { strict as assert } from 'node:assert';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { openDatabase } from '../src/backend/db/database';
+import { ReviewStore } from '../src/backend/db/review-store';
+import { CodexAgent } from '../src/backend/agent/codex/codex-agent';
+import { ReviewSession } from '../src/backend/review/review-session';
+import { ReviewManager } from '../src/backend/review/review-manager';
+import { DuetlensMcpServer } from '../src/backend/mcp/duetlens-mcp-server';
+import type {
+  AgentEvent,
+  ConversationalAgent,
+  ConversationHandle,
+  StartConversationOptions,
+} from '../src/backend/agent/conversational-agent';
+import type { FindingProposal } from '../src/shared/domain';
+
+const REVIEW_FILE = 'scripts/seed-demo.js';
+const SRC = `const db = require('../src/db');
+
+// 一次性数据播种脚本
+async function seed(name) {
+  const query = "INSERT INTO users (name) VALUES ('" + name + "')";
+  return db.query(query);
+}
+
+module.exports = { seed };
+`;
+const DIFF = `diff --git a/${REVIEW_FILE} b/${REVIEW_FILE}
+new file mode 100644
+--- /dev/null
++++ b/${REVIEW_FILE}
+@@ -0,0 +1,10 @@
+${SRC.split('\n').map((l) => '+' + l).join('\n')}`;
+
+const log = (m: string) => process.stdout.write(`[proposals] ${m}\n`);
+const brief = (s: string, n = 70) => s.replace(/\s+/g, ' ').slice(0, n);
+const tick = (ms = 20) => new Promise((r) => setTimeout(r, ms));
+
+/** 本 review 名下当前的提案(按落库顺序)。 */
+const proposalsOf = (store: ReviewStore, reviewId: string): FindingProposal[] =>
+  store.listProposals(reviewId);
+
+async function main() {
+  const workdir = mkdtempSync(path.join(tmpdir(), 'duetlens-proposals-'));
+  mkdirSync(path.join(workdir, 'scripts'), { recursive: true });
+  writeFileSync(path.join(workdir, REVIEW_FILE), SRC);
+
+  // 真库(内存版走同一套迁移与 SQL,含 V13 的 finding_proposals)
+  const db = openDatabase(':memory:');
+  const store = new ReviewStore(db);
+  const review = store.createReview({
+    source: 'local-branch',
+    sourceRef: 'chore/seed-script',
+    repoPath: workdir,
+    title: 'Add seed script',
+  });
+
+  // 采纳 / 撤销一律走 manager 的公开入口 —— spike 里另抄一份就只是在测自己刚写的那几行
+  const manager = new ReviewManager(store);
+  const agent = new CodexAgent({ onLog: (l) => l && process.stderr.write(`[codex] ${l}\n`) });
+  const session = new ReviewSession(review.id, store, agent);
+  session.on('finding', (f) => log(`finding 事件 ◀ ${f.severity} · ${brief(f.title, 40)}`));
+  session.on('finding-proposal', (p) =>
+    log(`proposal 事件 ◀ ${p.kind} · ${p.status} · msg=${p.messageId ?? '(未挂)'}`),
+  );
+
+  try {
+    // ── C1. 机审轮拒绝 dismiss_finding(纯本地,不起 codex)────────────────────
+    log('──── C1. 机审轮不接受 dismiss_finding ────');
+    await assertScanRejectsDismiss();
+
+    // ── C2. 事务边界:第二步失败要整体回滚(纯本地)──────────────────────────
+    log('──── C2. 采纳中途失败 → 整体回滚 ────');
+    assertApplyRollsBack();
+
+    // ── C3. 并发:扫描在跑时插一条追问,两边的写语义不得互相污染(纯本地)────────
+    log('──── C3. 扫描在跑 + 追问排队 ────');
+    await assertModeIsPerTurn();
+
+    // ── A. 扫描 ────────────────────────────────────────────────────────────
+    log('──── A. 首轮扫描 ────');
+    const findings = await session.start({
+      cwd: workdir,
+      providers: {
+        getDiff: () => DIFF,
+        getFile: (p) => (p.endsWith('seed-demo.js') ? SRC : `// 未知: ${p}`),
+      },
+    });
+    assert.ok(findings.length > 0, '扫描应产出至少一条 finding');
+    assert.equal(proposalsOf(store, review.id).length, 0, '机审轮不该产出提案');
+
+    const target = findings[0];
+    log(`选中 finding: ${target.severity} · ${brief(target.title, 50)}`);
+
+    // ── A1. 追问诱发 update 提案 ────────────────────────────────────────────
+    log('──── A1. 追问 → 期待 update 提案 ────');
+    await session.sendMessage(
+      target.discussionId,
+      '这个脚本只在本机手动跑一次、参数由我自己输入,没有外部输入源。' +
+        '按这个前提,你这条的严重度是不是定高了?如果同意,请把它改准一些。',
+    );
+    const afterA1 = proposalsOf(store, review.id);
+    const update = afterA1.find((p) => p.kind === 'update');
+    assert.ok(update, `追问后应有一条 update 提案(实际: ${afterA1.map((p) => p.kind).join(',') || '无'})`);
+    assert.equal(update.status, 'pending', '提案应停在待确认,不能直接生效');
+
+    // 关键:提案期间 finding 一个字都不能变
+    const untouched = store.getFinding(target.id)!;
+    assert.equal(untouched.title, target.title, 'pending 期间标题不得改动');
+    assert.equal(untouched.body, target.body, 'pending 期间正文不得改动');
+    assert.equal(untouched.severity, target.severity, 'pending 期间严重度不得改动');
+    log(`✓ 提案已记下但未生效:${JSON.stringify(update.patch).slice(0, 90)}`);
+
+    // 提案要挂在解释它的那条回复上(不然会排在那句话上面)
+    const msgs = store.listMessages(target.discussionId);
+    const lastAgent = [...msgs].reverse().find((m) => m.role === 'agent');
+    assert.ok(lastAgent, 'agent 应有回复');
+    assert.equal(update.messageId, lastAgent.id, '提案应挂到本轮 agent 回复上');
+    assert.equal(update.discussionId, target.discussionId, '提案应落在被追问的那条讨论上');
+    log('✓ 提案挂到了本轮 agent 回复上');
+
+    // ── B1. 采纳 update ────────────────────────────────────────────────────
+    log('──── B1. 采纳 update ────');
+    const applied = manager.applyProposal(review.id, update.id);
+    assert.equal(applied.status, 'applied');
+    const updated = store.getFinding(target.id)!;
+    for (const key of Object.keys(update.patch) as (keyof typeof update.patch)[]) {
+      assert.deepEqual(updated[key] ?? null, update.patch[key] ?? null, `${key} 应已按提案落库`);
+    }
+    // 快照只含动过的字段 —— 拍全量会让撤销顺手回滚应用之后的编辑
+    assert.deepEqual(
+      Object.keys(applied.before ?? {}).sort(),
+      Object.keys(update.patch).sort(),
+      'before 快照只应包含该提案动过的字段',
+    );
+    log(`✓ 已落库,快照字段: ${Object.keys(applied.before ?? {}).join(',')}`);
+
+    // ── B2. 撤销 ───────────────────────────────────────────────────────────
+    log('──── B2. 撤销 ────');
+    const undone = manager.undoProposal(review.id, update.id);
+    assert.equal(undone.status, 'skipped', '撤销后退回可重新应用的已忽略态');
+    const restored = store.getFinding(target.id)!;
+    assert.equal(restored.title, target.title, '标题应还原');
+    assert.equal(restored.body, target.body, '正文应还原');
+    assert.equal(restored.severity, target.severity, '严重度应还原');
+    log('✓ 撤销后逐字段还原');
+
+    // ── A2. 追问诱发 dismiss 提案 ──────────────────────────────────────────
+    log('──── A2. 追问 → 期待 dismiss 提案 ────');
+    await session.sendMessage(
+      target.discussionId,
+      '再补一个前提:这个文件在本次改动的下一个提交里已经被删掉了,不会进主干,也没有任何调用点。' +
+        '这条 finding 还成立吗?如果不成立,请把它剔除掉。',
+    );
+    const dismiss = proposalsOf(store, review.id).find((p) => p.kind === 'dismiss');
+    assert.ok(dismiss, '应产出一条 dismiss 提案');
+    assert.equal(dismiss.status, 'pending');
+    const stillIntact = store.getFinding(target.id)!;
+    assert.equal(stillIntact.triage, 'open', 'pending 期间不得剔除');
+    assert.equal(stillIntact.body, target.body, 'dismiss 提案不得改动正文');
+    log(`✓ dismiss 提案(理由 ${(dismiss.patch as { reason: string }).reason.length} 字)已记下,finding 未动`);
+
+    // ── B3. 采纳 dismiss:只写 triage 与理由,正文原样保留 ────────────────────
+    log('──── B3. 采纳 dismiss ────');
+    manager.applyProposal(review.id, dismiss.id);
+    const dropped = store.getFinding(target.id)!;
+    const reason = (dismiss.patch as { reason: string }).reason;
+    assert.equal(dropped.triage, 'dismiss', '应已剔除');
+    assert.equal(dropped.dismissReason, reason, '剔除理由应是 agent 的原话');
+    assert.equal(dropped.title, target.title, '★ 标题必须原样保留(本次要修的 bug)');
+    assert.equal(dropped.body, target.body, '★ 正文必须原样保留(本次要修的 bug)');
+    assert.equal(dropped.autoClosed, false, '人点的头不算自动结案');
+    log('✓ 剔除只改了 triage + 理由,原文完好');
+
+    log('✅ PASS — 提案回路打通:追问只提议不落库 → 采纳/撤销走真库 → 剔除保留原文');
+    process.exitCode = 0;
+  } finally {
+    await session.dispose();
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * 采纳的两步(改 finding / 落定提案)必须同进同退。
+ *
+ * **必须打在 manager 的公开入口上**:在 spike 里另写一份带事务的实现,等于测自己刚写的那几行 ——
+ * 生产代码里的 `store.transaction` 被拿掉也照样绿,这个断言就白立了。
+ * 桩打在 store 的第二步上,让它在事务中途抛错。
+ */
+function assertApplyRollsBack(): void {
+  const store = new ReviewStore(openDatabase(':memory:'));
+  const manager = new ReviewManager(store);
+  const reviewId = store.createReview({ source: 'local-branch', sourceRef: 'x', title: 't' }).id;
+  const finding = store.addFinding(
+    reviewId,
+    { severity: 'high', title: '原标题', body: '原正文', file: 'a.ts', line: 1 },
+    'agent',
+  );
+  const disc = store.addUserDiscussion(reviewId, { file: 'a.ts', line: 1 });
+  const proposalId = store.addProposal({
+    reviewId,
+    discussionId: disc.id,
+    findingId: finding.id,
+    kind: 'update',
+    patch: { severity: 'low', title: '新标题' },
+    baseUpdatedAt: finding.updatedAt,
+  }).id;
+  const findingId = finding.id;
+  const before = store.getFinding(findingId)!;
+  const real = store.setProposalStatus.bind(store);
+  (store as { setProposalStatus: unknown }).setProposalStatus = () => {
+    throw new Error('注入的落库失败');
+  };
+  let threw = false;
+  try {
+    manager.applyProposal(reviewId, proposalId);
+  } catch {
+    threw = true;
+  } finally {
+    (store as { setProposalStatus: unknown }).setProposalStatus = real;
+  }
+  assert.ok(threw, '第二步失败应把错误抛出去');
+  const after = store.getFinding(findingId)!;
+  assert.equal(after.title, before.title, '★ 回滚后标题不应变');
+  assert.equal(after.body, before.body, '★ 回滚后正文不应变');
+  assert.equal(after.severity, before.severity, '★ 回滚后严重度不应变');
+  assert.equal(store.getProposal(proposalId)!.status, 'pending', '★ 回滚后提案仍是待确认');
+  log('✓ 第二步失败 → finding 与提案一起回滚,没有半状态');
+}
+
+/**
+ * 机审轮(apply 模式)不接受 dismiss_finding —— 剔除始终是 reviewer 的判断,
+ * 没有人在场确认时就地放行,等于让 agent 自己关掉自己报的问题。
+ * 直接对 MCP server 断言,不起 codex。
+ */
+async function assertScanRejectsDismiss(): Promise<void> {
+  const mcp = new DuetlensMcpServer({ getDiff: () => '', getFile: () => '' });
+  let proposed = 0;
+  mcp.on('finding-proposal', () => (proposed += 1));
+  const url = await mcp.listen();
+  const client = new Client({ name: 'spike-proposals', version: '0' });
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(url), {
+      requestInit: { headers: { authorization: `Bearer ${mcp.token}` } },
+    }),
+  );
+  try {
+    // 缺省即 apply 模式(机审轮)。走真实工具调用,不去戳私有处理器 —— 那种写法会随重构静默失效。
+    const res = (await client.callTool({
+      name: 'dismiss_finding',
+      arguments: { finding_id: 'x', reason: '误报' },
+    })) as { isError?: boolean; content?: Array<{ type: string; text?: string }> };
+    assert.equal(res.isError, true, '机审轮应拒绝 dismiss_finding');
+    assert.equal(proposed, 0, '机审轮不应产出提案');
+    log(`✓ 机审轮拒绝剔除:${brief(res.content?.[0]?.text ?? '', 46)}`);
+
+    // 顺带验 propose 模式的两道 ingress:空理由、以及 update 一个字段都不给
+    mcp.setWriteMode('propose');
+    const noReason = (await client.callTool({
+      name: 'dismiss_finding',
+      arguments: { finding_id: 'x', reason: '   ' },
+    })) as { isError?: boolean };
+    assert.equal(noReason.isError, true, '空理由应被拒收');
+    const emptyPatch = (await client.callTool({
+      name: 'update_finding',
+      arguments: { finding_id: 'x' },
+    })) as { isError?: boolean };
+    assert.equal(emptyPatch.isError, true, '不给任何待改字段应被拒收');
+    assert.equal(proposed, 0, '被拒的调用不应留下提案');
+    log('✓ 空理由 / 空 patch 均被 ingress 拒收');
+  } finally {
+    await client.close();
+    await mcp.close();
+  }
+}
+
+/**
+ * 回归:提案模式必须绑在**真正执行**的那个 turn 上,不能是队列外的一个标志位。
+ *
+ * 复现原来的错法:追问一入队就把模式翻成 propose,于是**正在跑的扫描 turn** 的 report_finding
+ * 会被记成那条讨论的提案(而不是一条真 finding);扫描收尾时的复位又会让排在后面的那一问
+ * 退回直接落库 —— 一次绕过 reviewer 确认的静默改动。
+ *
+ * 用桩 agent 精确编排时序,不烧 token:桩在自己的 turn 里经真实 MCP 端点调工具,
+ * 与 codex 走的是同一条路。
+ */
+async function assertModeIsPerTurn(): Promise<void> {
+  const db = openDatabase(':memory:');
+  const store = new ReviewStore(db);
+  const review = store.createReview({ source: 'local-branch', sourceRef: 'x', title: 't' });
+
+  const scanGate = new Gate();
+  const agent = new StubAgent(scanGate);
+  const session = new ReviewSession(review.id, store, agent);
+  try {
+    const scanning = session.start({
+      cwd: '/tmp',
+      providers: { getDiff: () => 'DIFF', getFile: () => 'SRC' },
+      scanPrompt: 'SCAN',
+    });
+    await agent.conversationStarted;
+
+    // 扫描 turn 已经在跑(卡在 gate 上),此刻插一条追问 —— 它会排在扫描后面
+    const disc = store.addUserDiscussion(review.id, { file: 'a.ts', line: 1 });
+    const asking = session.sendMessage(disc.id, 'ASK');
+    await tick(30);
+    assert.equal(store.listMessages(disc.id).length, 1, '追问此刻只落库了问题,还没轮到它');
+
+    // 放行扫描:它的 report_finding 必须落成**真 finding**,不能变成那条讨论的提案
+    scanGate.open();
+    const findings = await scanning;
+    assert.equal(findings.length, 1, '扫描应落库一条真 finding');
+    assert.equal(store.listProposals(review.id).length, 0, '★ 扫描轮的上报不得变成提案');
+    log('✓ 扫描在跑时插入追问,扫描的 report_finding 仍直接落库');
+
+    // 轮到追问:它的 update_finding 必须变成提案,且挂在这条讨论上
+    await asking;
+    const proposals = store.listProposals(review.id);
+    assert.equal(proposals.length, 1, '★ 排队的追问仍应走提案,不能被前一轮的复位打回直接落库');
+    assert.equal(proposals[0].kind, 'update');
+    assert.equal(proposals[0].discussionId, disc.id, '提案应落在发起追问的那条讨论上');
+    assert.equal(
+      store.getFinding(findings[0].id)!.title,
+      findings[0].title,
+      '★ 追问轮的 update 不得直接改动 finding',
+    );
+    log('✓ 排队的追问轮走提案,finding 未被直接改动');
+  } finally {
+    await session.dispose();
+  }
+}
+
+/** 可按住再放开的一道闸(同 spike-followup-queue 的用法)。 */
+class Gate {
+  private release!: () => void;
+  readonly passed: Promise<void>;
+  constructor() {
+    this.passed = new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+  open(): void {
+    this.release();
+  }
+}
+
+/**
+ * 桩 agent:不连 codex,但在自己的每个 turn 里经**真实 MCP 端点**调工具 ——
+ * 走的正是 codex 会走的那条路,故写语义(直接落库 / 提案)由被测代码而非桩决定。
+ */
+class StubAgent implements ConversationalAgent {
+  private handlers = new Set<(e: AgentEvent) => void>();
+  private mcpUrl = '';
+  private mcpToken = '';
+  private turnSeq = 0;
+  private started!: () => void;
+  readonly conversationStarted: Promise<void>;
+  private findingId = '';
+
+  constructor(private readonly scanGate: Gate) {
+    this.conversationStarted = new Promise<void>((r) => {
+      this.started = r;
+    });
+  }
+
+  async startConversation(opts: StartConversationOptions): Promise<ConversationHandle> {
+    this.mcpUrl = opts.mcpUrl!;
+    this.mcpToken = opts.mcpToken!;
+    return { conversationId: 'stub-thread' };
+  }
+  resumeConversation(opts: StartConversationOptions): Promise<ConversationHandle> {
+    return this.startConversation(opts);
+  }
+
+  async sendMessage(_conversationId: string, text: string): Promise<string> {
+    const turnId = `t${++this.turnSeq}`;
+    void this.runTurn(turnId, text);
+    return turnId;
+  }
+
+  /** 每个 turn:调一次工具,再发终局。扫描 turn 的工具调用卡在闸上,好让追问排到它后面。 */
+  private async runTurn(turnId: string, text: string): Promise<void> {
+    if (text === 'SCAN') {
+      this.started();
+      await this.scanGate.passed;
+      const res = await this.callTool('report_finding', {
+        severity: 'high',
+        title: '桩上报',
+        body: 'b',
+        file: 'a.ts',
+        line: 1,
+      });
+      this.findingId = /id=([0-9a-f-]+)/.exec(res)?.[1] ?? '';
+    } else {
+      await this.callTool('update_finding', { finding_id: this.findingId, severity: 'low' });
+    }
+    for (const h of this.handlers) {
+      h({ kind: 'message-delta', turnId, text: 'ok' } as AgentEvent);
+      h({ kind: 'turn-completed', turnId } as AgentEvent);
+    }
+  }
+
+  private async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    const client = new Client({ name: 'stub', version: '0' });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(this.mcpUrl), {
+        requestInit: { headers: { authorization: `Bearer ${this.mcpToken}` } },
+      }),
+    );
+    const res = (await client.callTool({ name, arguments: args })) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    await client.close();
+    return res.content?.[0]?.text ?? '';
+  }
+
+  streamEvents(handler: (e: AgentEvent) => void): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+  async interrupt(): Promise<void> {}
+  approve(): void {}
+  dispose(): void {
+    this.handlers.clear();
+  }
+}
+
+main().catch((e) => {
+  process.stdout.write(`[proposals] ❌ FAIL — ${(e as Error).stack ?? String(e)}\n`);
+  process.exit(1);
+});

--- a/src/backend/db/review-store.ts
+++ b/src/backend/db/review-store.ts
@@ -7,9 +7,14 @@ import {
   isAutoClosedFixed,
   type Discussion,
   type Finding,
+  type FindingProposal,
   type FindingResolution,
   type Message,
   type MessageRole,
+  type ProposalBefore,
+  type ProposalKind,
+  type ProposalPatch,
+  type ProposalStatus,
   type ReportFindingInput,
   DEFAULT_REVIEW_UI_STATE,
   type Review,
@@ -109,6 +114,21 @@ interface MessageRow {
   created_at: number;
 }
 
+interface ProposalRow {
+  id: string;
+  review_id: string;
+  discussion_id: string;
+  message_id: string | null;
+  finding_id: string | null;
+  kind: string;
+  patch: string;
+  before_snapshot: string | null;
+  base_updated_at: number | null;
+  status: string;
+  created_at: number;
+  resolved_at: number | null;
+}
+
 function toReview(r: ReviewRow): Review {
   return {
     id: r.id,
@@ -184,6 +204,35 @@ function toFinding(r: FindingRow): Finding {
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
+}
+
+/**
+ * 提案行 → 领域对象。patch / before 是 JSON 列:坏值不能让整条讨论读不出来,
+ * 故解析失败退化成空 patch(UI 会把它显示成没有改动的提案),而不是抛。
+ */
+function toProposal(r: ProposalRow): FindingProposal {
+  const parse = <T>(raw: string | null): T | null => {
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  };
+  return {
+    id: r.id,
+    reviewId: r.review_id,
+    discussionId: r.discussion_id,
+    messageId: r.message_id,
+    findingId: r.finding_id,
+    kind: r.kind,
+    patch: parse<ProposalPatch>(r.patch) ?? {},
+    before: parse<ProposalBefore>(r.before_snapshot),
+    baseUpdatedAt: r.base_updated_at,
+    status: r.status as ProposalStatus,
+    createdAt: r.created_at,
+    resolvedAt: r.resolved_at,
+  } as FindingProposal;
 }
 
 function toDiscussion(r: DiscussionRow): Discussion {
@@ -830,6 +879,137 @@ export class ReviewStore {
   clearMessages(discussionId: string): void {
     this.withReviewTouch({ discussion: discussionId }, () => {
       this.db.prepare('DELETE FROM messages WHERE discussion_id = ?').run(discussionId);
+    });
+  }
+
+  /**
+   * 把一组写操作收进同一个数据库事务(better-sqlite3 同步执行,故直接传同步闭包)。
+   * 内层的 {@link withReviewTouch} 会以 savepoint 嵌套,不会互相冲突。
+   *
+   * 给编排层用:提案的采纳既要改 finding 又要改提案自己,分两次提交的话,
+   * 第二步一挂就留下「finding 已改、卡片还写着待确认」的半状态。
+   */
+  transaction<T>(run: () => T): T {
+    return this.db.transaction(run)();
+  }
+
+  // ---- 回写提案(讨论里 agent 提出、reviewer 确认后才落库)----
+
+  /**
+   * 记一条待确认提案。message_id 此刻还没有(agent 的回复要等 turn 收尾才落库),
+   * 由 {@link attachProposalsToMessage} 补上。
+   */
+  addProposal(input: {
+    reviewId: string;
+    discussionId: string;
+    findingId: string | null;
+    kind: ProposalKind;
+    patch: ProposalPatch;
+    baseUpdatedAt: number | null;
+  }): FindingProposal {
+    const id = randomUUID();
+    this.withReviewTouch({ discussion: input.discussionId }, (ts) => {
+      this.db
+        .prepare(
+          `INSERT INTO finding_proposals (id, review_id, discussion_id, message_id, finding_id, kind, patch, before_snapshot, base_updated_at, status, created_at, resolved_at)
+           VALUES (?, ?, ?, NULL, ?, ?, ?, NULL, ?, 'pending', ?, NULL)`,
+        )
+        .run(
+          id,
+          input.reviewId,
+          input.discussionId,
+          input.findingId,
+          input.kind,
+          JSON.stringify(input.patch),
+          input.baseUpdatedAt,
+          ts,
+        );
+    });
+    return this.getProposal(id)!;
+  }
+
+  getProposal(id: string): FindingProposal | null {
+    const r = this.db.prepare('SELECT * FROM finding_proposals WHERE id = ?').get(id) as
+      | ProposalRow
+      | undefined;
+    return r ? toProposal(r) : null;
+  }
+
+  listProposals(reviewId: string): FindingProposal[] {
+    const rows = this.db
+      .prepare('SELECT * FROM finding_proposals WHERE review_id = ? ORDER BY created_at ASC')
+      .all(reviewId) as ProposalRow[];
+    return rows.map(toProposal);
+  }
+
+  /**
+   * 把本轮新记的提案挂到刚落库的 agent 回复上。
+   * 提案先于回复文本产生(工具调用在前),不回挂的话它们会排在解释它们的那句话**上面**。
+   */
+  attachProposalsToMessage(ids: readonly string[], messageId: string): void {
+    if (ids.length === 0) return;
+    const stmt = this.db.prepare('UPDATE finding_proposals SET message_id = ? WHERE id = ?');
+    this.db.transaction(() => {
+      for (const id of ids) stmt.run(messageId, id);
+    })();
+  }
+
+  /**
+   * 落定一条提案的去向;applied 时连同旧值快照一起记下,供撤销还原。
+   *
+   * 同样要冒泡 review 的 updated_at:「忽略提案」不伴随任何 finding 写入,不冒泡的话,
+   * 一条刚被处置过的 review 在历史里仍顶着旧时间排序,并可能按旧时间进 30 天清理。
+   */
+  setProposalStatus(
+    id: string,
+    status: ProposalStatus,
+    opts: { before?: ProposalBefore | null; findingId?: string } = {},
+  ): FindingProposal | null {
+    const existing = this.getProposal(id);
+    if (!existing) return null;
+    this.withReviewTouch({ discussion: existing.discussionId }, (ts) => {
+      this.db
+        .prepare(
+          `UPDATE finding_proposals
+              SET status = ?, resolved_at = ?,
+                  before_snapshot = COALESCE(?, before_snapshot),
+                  finding_id = COALESCE(?, finding_id)
+            WHERE id = ?`,
+        )
+        .run(
+          status,
+          status === 'pending' ? null : ts,
+          opts.before == null ? null : JSON.stringify(opts.before),
+          opts.findingId ?? null,
+          id,
+        );
+    });
+    return this.getProposal(id);
+  }
+
+  /**
+   * 原样还原一条 finding 的裁决态(撤销 dismiss/restore 提案用)。
+   *
+   * 不能用 {@link setTriage} 顶替:它会把 auto_closed 一律清零(手动裁决就该如此),
+   * 于是复核自动结案的条目撤销后会变成「reviewer 亲手剔的」,下一轮回归不再自动恢复
+   * (见 {@link isAutoClosedFixed}),真问题就此被一直抑制下去。
+   */
+  restoreTriage(
+    findingId: string,
+    snapshot: { triage: Triage; dismissReason: string | null; autoClosed: boolean },
+  ): void {
+    this.withReviewTouch({ finding: findingId }, (ts) => {
+      this.db
+        .prepare(
+          'UPDATE findings SET triage = ?, dismiss_reason = ?, auto_closed = ?, updated_at = ? WHERE id = ?',
+        )
+        .run(
+          snapshot.triage,
+          snapshot.dismissReason,
+          Number(snapshot.autoClosed),
+          ts,
+          findingId,
+        );
     });
   }
 

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -180,7 +180,30 @@ ALTER TABLE findings ADD COLUMN auto_closed INTEGER NOT NULL DEFAULT 0;
 UPDATE findings SET auto_closed = 1 WHERE triage = 'dismiss' AND resolution = 'fixed';
 `;
 
-const MIGRATIONS: string[] = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12];
+// 讨论里 agent 对 finding 的回写提案(update / dismiss / restore / create)。
+// 独立成表而非挂在 finding 上:一条 finding 可以先后有多个提案,且应用/忽略之后要留在对话里 ——
+// 「谁在什么时候把这条改成了什么」除此之外没有第二处凭据。
+// message_id 可空:该 turn 没有回复文本时提案就地接在线程末尾;消息被清空(clearMessages)时置空而非连坐删除。
+const V13 = `
+CREATE TABLE finding_proposals (
+  id             TEXT PRIMARY KEY,
+  review_id      TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+  discussion_id  TEXT NOT NULL REFERENCES discussions(id) ON DELETE CASCADE,
+  message_id     TEXT REFERENCES messages(id) ON DELETE SET NULL,
+  finding_id     TEXT REFERENCES findings(id) ON DELETE CASCADE,
+  kind           TEXT NOT NULL,
+  patch          TEXT NOT NULL,
+  before_snapshot TEXT,
+  base_updated_at INTEGER,
+  status         TEXT NOT NULL DEFAULT 'pending',
+  created_at     INTEGER NOT NULL,
+  resolved_at    INTEGER
+);
+CREATE INDEX idx_proposals_review ON finding_proposals(review_id);
+CREATE INDEX idx_proposals_discussion ON finding_proposals(discussion_id);
+`;
+
+const MIGRATIONS: string[] = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13];
 
 export function migrate(db: Database): void {
   const current = db.pragma('user_version', { simple: true }) as number;

--- a/src/backend/ipc/index.ts
+++ b/src/backend/ipc/index.ts
@@ -93,6 +93,16 @@ export function registerIpcHandlers({ manager, broadcast, updater }: IpcDeps): v
   ipcMain.handle(IpcChannels.reviewClearDiscussion, (_e, reviewId: string, discussionId: string) =>
     manager.clearDiscussion(reviewId, discussionId),
   );
+  ipcMain.handle(IpcChannels.reviewProposals, (_e, reviewId: string) => manager.getProposals(reviewId));
+  ipcMain.handle(IpcChannels.reviewApplyProposal, (_e, reviewId: string, proposalId: string) =>
+    manager.applyProposal(reviewId, proposalId),
+  );
+  ipcMain.handle(IpcChannels.reviewSkipProposal, (_e, reviewId: string, proposalId: string) =>
+    manager.skipProposal(reviewId, proposalId),
+  );
+  ipcMain.handle(IpcChannels.reviewUndoProposal, (_e, reviewId: string, proposalId: string) =>
+    manager.undoProposal(reviewId, proposalId),
+  );
   ipcMain.handle(
     IpcChannels.reviewSetTriage,
     (_e, reviewId: string, findingId: string, triage: Triage, reason?: string | null) =>

--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -10,7 +10,18 @@ import {
   isInitializeRequest,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
-import { FINDING_CATEGORIES, RESOLUTIONS_REQUIRING_NOTE, resolveFindingSchema } from '@shared/domain';
+import type { ZodError } from 'zod';
+import {
+  dismissFindingSchema,
+  FINDING_CATEGORIES,
+  reportFindingSchema,
+  RESOLUTIONS_REQUIRING_NOTE,
+  resolveFindingSchema,
+  restoreFindingSchema,
+  updateFindingSchema,
+  type ProposalKind,
+  type ProposalPatch,
+} from '@shared/domain';
 import { APP_VERSION } from '@shared/version';
 
 const CATEGORY_HINT = `建议取值:${FINDING_CATEGORIES.join(' / ')}`;
@@ -32,7 +43,8 @@ export interface ReportedFinding {
 export interface ReportedFindingUpdate {
   findingId: string;
   severity?: 'high' | 'medium' | 'low';
-  category?: string;
+  /** null = 清空分类(缺省才是「不改」) */
+  category?: string | null;
   title?: string;
   body?: string;
   suggestion?: string | null;
@@ -44,6 +56,65 @@ export interface ReportedFindingResolution {
   status: 'fixed' | 'still_present' | 'wont_fix';
   note?: string;
 }
+
+/** dismiss_finding / restore_finding 的裁决意见(理由必填,会成为剔除理由 / 恢复依据)。 */
+export interface ReportedFindingTriage {
+  findingId: string;
+  reason: string;
+}
+
+/**
+ * 工具调用当下这一 turn 的语义。
+ * - `apply`:机审/自检轮,写 finding 的工具直接落库(reviewer 不在场,拦下来只会卡死自检)。
+ * - `propose`:追问轮,一律先记成待确认提案 —— 回给 agent 的文本也要说清「尚未生效」,
+ *   否则它会在回复里宣称已经改好,而屏上根本没变。
+ */
+export type McpWriteMode = 'apply' | 'propose';
+
+/** propose 模式下一次写 finding 的意图;由 ReviewSession 落成 finding_proposals 的一行。 */
+export interface ProposedFindingChange {
+  kind: ProposalKind;
+  /** kind='create' 时为 null(finding 尚不存在) */
+  findingId: string | null;
+  patch: ProposalPatch;
+}
+
+/**
+ * 提案的受理结果。EventEmitter 没有返回值,故由发起方传一个可写对象、接收方就地填 ——
+ * emit 是同步的,回来即已定。
+ *
+ * 非要有这条回执:接收方会因 finding 不存在 / 不属于本 review 而丢弃提案,而 agent 那边
+ * 收到的却是「卡片已呈现」。它随后会照此向 reviewer 宣称已提议,可界面上根本没有确认入口。
+ */
+export interface ProposalOutcome {
+  accepted: boolean;
+  /** 未受理的原因,原样回给 agent */
+  reason: string;
+}
+
+/** ingress 校验失败的统一应答:把问题原样说给 agent,让它补齐重来,而不是静默丢掉。 */
+const reject = (tool: string, error: ZodError) => ({
+  content: [
+    {
+      type: 'text' as const,
+      text: `${tool} 参数不合法,未记录:${error.issues.map((i) => `${i.path.join('.') || '(根)'} ${i.message}`).join(';')}。请修正后重新调用。`,
+    },
+  ],
+  isError: true,
+});
+
+/** 摘掉值为 undefined 的键(工具入参里「没给」与「给了 undefined」要一视同仁)。 */
+function dropUndefined<T extends object>(o: T): Partial<T> {
+  return Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined)) as Partial<T>;
+}
+
+/**
+ * 提案回给 agent 的应答。措辞要点:说清**没有生效**且**在等 reviewer** ——
+ * 只说「已记录」的话,agent 会在同一条回复里宣称改好了,而屏上的 finding 一个字没动。
+ */
+const PROPOSED = (what: string): string =>
+  `已把「${what}」作为待确认卡片呈现在讨论里,尚未生效,等 reviewer 采纳。` +
+  `请在回复中说明你的判断与依据,不要声称已经改好。`;
 
 /** 供 agent 读取源码/diff 的回调;由 review 会话注入真实数据。 */
 export interface McpContentProviders {
@@ -73,18 +144,56 @@ const TOOLS = [
   {
     name: 'update_finding',
     description:
-      '更新一条已上报 finding 的可编辑字段。仅在用户明确要求回写 finding 时调用;普通追问只需在对话中回答。finding_id 用 report_finding 的返回值。',
+      '更正一条已上报 finding 的可编辑字段(改严重度 / 改写正文 / 换标题 / 调整 suggestion)。' +
+      '讨论中一旦认定原来写的不准,就调用它,不必等用户开口 —— 讨论期间它不会立即改动 finding,' +
+      '只会在对话里生成一张待确认卡片,由 reviewer 一键采纳。只传要改的字段。' +
+      '注意:若结论是「这条根本不成立」,请用 dismiss_finding,不要把剔除理由写进 body。',
     inputSchema: {
       type: 'object',
       properties: {
         finding_id: { type: 'string', description: 'report_finding 返回的 id' },
         severity: { type: 'string', enum: ['high', 'medium', 'low'] },
-        category: { type: 'string', description: CATEGORY_HINT },
+        // 可清空的两个字段声明成 string|null:领域侧 null 就是「清空」,只写 string 的话,
+        // 会校验 JSON Schema 的 client 会把 null 挡掉,已有的 category / suggestion 再也删不掉
+        category: { type: ['string', 'null'], description: `${CATEGORY_HINT};传 null 清空分类` },
         title: { type: 'string' },
         body: { type: 'string' },
-        suggestion: { type: 'string' },
+        suggestion: { type: ['string', 'null'], description: '建议代码;传 null 删掉原有 suggestion' },
       },
       required: ['finding_id'],
+    },
+  },
+  {
+    name: 'dismiss_finding',
+    description:
+      '剔除一条 finding:讨论后认定它不成立(误报 / 前提不存在 / 代码不可达 / 属可接受差异)时调用。' +
+      '只写剔除理由,finding 的标题与正文原样保留 —— 不要改用 update_finding 把理由覆盖进 body。' +
+      '讨论期间同样只生成待确认卡片,由 reviewer 决定是否采纳。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        finding_id: { type: 'string', description: 'report_finding 返回的 id' },
+        reason: {
+          type: 'string',
+          minLength: 1,
+          description:
+            '为什么这条不成立。会存为剔除理由并注入下一轮复审,需自足 —— 写清判据(在哪看到、凭什么),不要只写「误报」。',
+        },
+      },
+      required: ['finding_id', 'reason'],
+    },
+  },
+  {
+    name: 'restore_finding',
+    description:
+      '恢复一条已被剔除的 finding:讨论后确认它其实成立(剔除依据不完整 / 另有路径可达)时调用。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        finding_id: { type: 'string' },
+        reason: { type: 'string', minLength: 1, description: '为什么它其实成立;原剔除理由错在哪。' },
+      },
+      required: ['finding_id', 'reason'],
     },
   },
   {
@@ -142,8 +251,13 @@ const TOOLS = [
 /**
  * Duetlens 对 codex 暴露的 in-process HTTP MCP server(StreamableHTTP)。
  * findings 经 report_finding 实时回传落进 app 状态,取代 1.0 watch 文件。
+ *
+ * 写 finding 的四个工具(report / update / dismiss / restore)在 `propose` 模式下不落库,
+ * 改发 'finding-proposal';语义与模式切换见 {@link McpWriteMode}。
+ *
  * 事件:'finding' (ReportedFinding) · 'finding-update' (ReportedFindingUpdate)
- * · 'finding-resolution' (ReportedFindingResolution) · 'tool-call' (name, args)。
+ * · 'finding-resolution' (ReportedFindingResolution) · 'finding-proposal' (ProposedFindingChange)
+ * · 'tool-call' (name, args)。
  */
 export class DuetlensMcpServer extends EventEmitter {
   private httpServer?: http.Server;
@@ -151,10 +265,36 @@ export class DuetlensMcpServer extends EventEmitter {
   readonly findings: ReportedFinding[] = [];
   /** 本 server 的 bearer 令牌;codex 经 bearer_token_env_var 携带,隔离本地其他进程。 */
   readonly token: string;
+  private writeMode: McpWriteMode = 'apply';
 
   constructor(private readonly providers: McpContentProviders, token: string = randomUUID()) {
     super();
     this.token = token;
+  }
+
+  /**
+   * 切换写 finding 的语义。由 ReviewSession 在每个 turn 前后设置;turn 是串行的
+   * (见 ReviewSession.turnChain),所以单个标志位够用,不会有两个 turn 同时读到对方的模式。
+   */
+  setWriteMode(mode: McpWriteMode): void {
+    this.writeMode = mode;
+  }
+
+  /**
+   * 发一条提案并按**受理结果**作答。接收方会因 finding 不存在 / 不属于本 review 而丢弃它,
+   * 那时必须以 isError 告诉 agent 重来 —— 否则它拿着一句「卡片已呈现」去向 reviewer 复述,
+   * 而界面上根本没有那张卡。
+   */
+  private propose(change: ProposedFindingChange, what: string) {
+    const outcome: ProposalOutcome = { accepted: false, reason: '没有可呈现提案的讨论上下文' };
+    this.emit('finding-proposal', change, outcome);
+    if (!outcome.accepted) {
+      return {
+        content: [{ type: 'text' as const, text: `提案未记录:${outcome.reason}。请核对后重新调用。` }],
+        isError: true,
+      };
+    }
+    return { content: [{ type: 'text' as const, text: PROPOSED(what) }] };
   }
 
   /** 监听在 127.0.0.1 上;端口 0 = 系统分配,返回 codex 用的 url。 */
@@ -242,7 +382,18 @@ export class DuetlensMcpServer extends EventEmitter {
       this.emit('tool-call', name, args);
 
       if (name === 'report_finding') {
-        const f: ReportedFinding = { id: randomUUID(), ...(args as Omit<ReportedFinding, 'id'>) };
+        const input = args as Omit<ReportedFinding, 'id'>;
+        if (this.writeMode === 'propose') {
+          // 提案同样要过 ingress 校验:直接落库那条路由 ReviewSession 兜着,提案这条没有 ——
+          // 不校验的话非法 severity / 缺字段会一路存进 finding_proposals,采纳时才炸。
+          const parsed = reportFindingSchema.safeParse(input);
+          if (!parsed.success) return reject('report_finding', parsed.error);
+          return this.propose(
+            { kind: 'create', findingId: null, patch: parsed.data },
+            '把它记为一条新 finding',
+          );
+        }
+        const f: ReportedFinding = { id: randomUUID(), ...input };
         this.findings.push(f);
         this.emit('finding', f);
         // 回传 id,供后续 update_finding 定位
@@ -253,13 +404,62 @@ export class DuetlensMcpServer extends EventEmitter {
         const update: ReportedFindingUpdate = {
           findingId: String(a.finding_id ?? ''),
           severity: a.severity as ReportedFindingUpdate['severity'],
-          category: a.category as string | undefined,
+          category: a.category as string | null | undefined,
           title: a.title as string | undefined,
           body: a.body as string | undefined,
           suggestion: a.suggestion as string | undefined,
         };
+        if (this.writeMode === 'propose') {
+          // 落库前先把没给的字段摘掉:zod 的 optional 会把显式 undefined 原样带过,
+          // 留着既数不清「到底改了几个字段」,也会在 patch JSON 里存下一串空键。
+          const parsed = updateFindingSchema.safeParse(dropUndefined(update));
+          if (!parsed.success) return reject('update_finding', parsed.error);
+          const { findingId, ...patch } = parsed.data;
+          // 一个字段都没给 = 什么也没提;放行只会在对话里留一张「未改动任何字段」的空卡片
+          if (Object.keys(patch).length === 0) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'update_finding 至少要给一个待改字段(severity / category / title / body / suggestion),未记录。',
+                },
+              ],
+              isError: true,
+            };
+          }
+          return this.propose({ kind: 'update', findingId, patch }, '更正这条 finding');
+        }
         this.emit('finding-update', update);
         return { content: [{ type: 'text', text: `finding updated, id=${update.findingId}` }] };
+      }
+      if (name === 'dismiss_finding' || name === 'restore_finding') {
+        const a = args as Record<string, unknown>;
+        const kind = name === 'dismiss_finding' ? 'dismiss' : 'restore';
+        // 剔除/恢复始终是 reviewer 的判断,只在他在场的讨论里作为提案提出。机审轮没有人可确认,
+        // 就地放行等于让 agent 自己关掉自己报的问题(rerun.md:连 wont_fix 都不自动剔除)。
+        if (this.writeMode !== 'propose') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `${name} 只能在与 reviewer 的讨论中使用。本轮请改用 update_finding 降级严重度或在 body 里标注存疑。`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        // 理由是这两个动作的**全部**内容(剔除不改正文,恢复不改任何字段),空理由等于什么也没提;
+        // 且它会注入下一轮复审,静默收下只会让下一轮拿到一条没有依据的抑制项。
+        const schema = kind === 'dismiss' ? dismissFindingSchema : restoreFindingSchema;
+        const parsed = schema.safeParse({
+          findingId: String(a.finding_id ?? ''),
+          reason: String(a.reason ?? '').trim(),
+        } satisfies ReportedFindingTriage);
+        if (!parsed.success) return reject(name, parsed.error);
+        return this.propose(
+          { kind, findingId: parsed.data.findingId, patch: { reason: parsed.data.reason } },
+          kind === 'dismiss' ? '剔除这条 finding' : '恢复这条 finding',
+        );
       }
       if (name === 'resolve_finding') {
         const a = args as Record<string, unknown>;

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -1,10 +1,16 @@
 import { EventEmitter } from 'node:events';
-import { REVIEW_RETENTION_MS } from '@shared/domain';
+import { isProposalUndoBlocked, REVIEW_RETENTION_MS } from '@shared/domain';
 import type {
   CodexModelInfo,
   Discussion,
   Finding,
+  FindingProposal,
   Message,
+  ProposalBefore,
+  ProposalStatus,
+  ProposalTriageBefore,
+  ProposalUpdateBefore,
+  ProposalUpdatePatch,
   Review,
   ReviewIntensity,
   ReviewRound,
@@ -47,6 +53,33 @@ import type {
 } from '@shared/source-discovery';
 import { GhReviewSubmitter, type GitHubSubmitter } from './github-submitter';
 import { AgentTurnError, DEFAULT_SCAN_PROMPT, ReviewSession, type ReviewSessionEvents } from './review-session';
+
+/**
+ * 已提交到 GitHub 的 finding,正文类字段锁定。UI 早就按这条画(卡片的 `writable` 排除 submitted),
+ * 但提案是条**没有界面把关**的写路径 —— 不在权威层拦一道,本地记录会与已发出去的评论对不上。
+ *
+ * 只锁内容,不锁裁决:剔除/恢复是 reviewer 对「这条要不要继续追」的判断,
+ * 已提交的追评项照样可以剔(见 findings-submit.md)。
+ */
+function assertContentWritable(f: Finding, action: string): void {
+  if (f.submission === 'submitted')
+    throw new Error(`这条 finding 已提交到 GitHub,内容已锁定,无法${action}对它的修改提案。`);
+}
+
+/**
+ * 只拍 patch 真正动过的那几个字段的旧值。
+ * 拍全量的话,撤销会把应用之后 reviewer 自己的编辑一并回滚 —— 提案只降了个 severity,
+ * 撤销却连带把他重写过的正文换回旧版。
+ */
+function snapshotPatched(before: Finding, patch: ProposalUpdatePatch): ProposalUpdateBefore {
+  const snapshot: ProposalUpdateBefore = {};
+  if (patch.severity !== undefined) snapshot.severity = before.severity;
+  if (patch.category !== undefined) snapshot.category = before.category;
+  if (patch.title !== undefined) snapshot.title = before.title;
+  if (patch.body !== undefined) snapshot.body = before.body;
+  if (patch.suggestion !== undefined) snapshot.suggestion = before.suggestion;
+  return snapshot;
+}
 
 /** 首轮扫描指令:有附加上下文时拼在缺省指令之后一并注入,否则用缺省。 */
 function buildScanPrompt(context?: string): string | undefined {
@@ -99,6 +132,7 @@ const SESSION_FORWARDERS: {
   finding: (reviewId, payload) => ({ reviewId, type: 'finding', payload }),
   discussion: (reviewId, payload) => ({ reviewId, type: 'discussion', payload }),
   message: (reviewId, payload) => ({ reviewId, type: 'message', payload }),
+  'finding-proposal': (reviewId, payload) => ({ reviewId, type: 'finding-proposal', payload }),
   status: (reviewId, payload) => ({ reviewId, type: 'status', payload }),
   'agent-event': (reviewId, payload) => ({ reviewId, type: 'agent', payload }),
 };
@@ -321,6 +355,161 @@ export class ReviewManager extends EventEmitter {
     if (!finding) throw new Error(`finding 不存在: ${findingId}`);
     this.forward({ reviewId, type: 'finding', payload: finding });
     return finding;
+  }
+
+  /** 一次 review 名下的全部回写提案(进 review 屏时随讨论一起拉)。 */
+  getProposals(reviewId: string): FindingProposal[] {
+    return this.store.listProposals(reviewId);
+  }
+
+  /**
+   * 采纳一条 agent 提案:按 kind 走既有的落库路径(与用户手动操作同一条),
+   * 并把旧值记进提案供「↩ 撤销」还原。
+   *
+   * 剔除刻意**不**记 autoClosed —— 那一格的语义是「复核判定代码里已经没有了」,
+   * 而这里是 reviewer 看过 agent 的论证后点的头,属他自己的判断,下一轮不该被回归逻辑翻掉
+   * (见 isAutoClosedFixed)。理由存 agent 的原话,照常注入下一轮复审。
+   */
+  applyProposal(reviewId: string, proposalId: string): FindingProposal {
+    const p = this.requireProposal(reviewId, proposalId);
+    if (p.status === 'applied') return p;
+
+    // finding 的改动与提案的落定必须同进同退:分两次提交的话,第二步一挂就留下
+    // 「finding 已改、卡片还写着待确认」的半状态,重试还会拿这个错误现状去拍新快照。
+    // 事件一律等事务提交后再发 —— 回滚掉的改动不该先一步上屏。
+    const written = this.store.transaction(() => {
+      if (p.kind === 'create') {
+        const input = p.patch;
+        // 提案出自哪条讨论就落在哪条:另起一条新讨论会把这段论证过程与 finding 拆散。
+        // 但只在**同一个文件**上才提升 —— 锚到别处的提案与这条讨论无关,提升会把它挂错地方。
+        const disc = this.store.getDiscussion(p.discussionId);
+        const promotable = disc?.kind === 'user' && disc.file === input.file && disc.line != null;
+        const finding = promotable
+          ? this.store.promoteDiscussion(p.discussionId, {
+              severity: input.severity,
+              category: input.category ?? null,
+              title: input.title,
+              body: input.body,
+              suggestion: input.suggestion ?? null,
+            })
+          : this.store.addFinding(reviewId, input, 'agent');
+        // promoteDiscussion 用的是 discussion 的行号,而卡片上写的是提案里的 —— agent 常会在
+        // 框选范围内给出更准的一行。以卡片所示为准,否则采纳到手的锚点和看到的不是一个。
+        // 只在提案给了真实行号时改:setFindingAnchor 的 0 是「脱锚降级为摘要」(见 anchorDropped),
+        // 而 report_finding 的 schema 允许 line=0,照传就会把一条新 finding 直接降级掉。
+        if (promotable && input.line > 0 && finding.line !== input.line)
+          this.store.setFindingAnchor(finding.id, input.line);
+        const created = this.store.getFinding(finding.id) ?? finding;
+        return {
+          finding: created,
+          discussion: this.store.getDiscussion(created.discussionId),
+          proposal: this.resolveProposal(proposalId, 'applied', { findingId: created.id }),
+        };
+      }
+
+      const before = this.store.getFinding(p.findingId);
+      if (!before) throw new Error(`finding 不存在: ${p.findingId}`);
+      if (p.kind === 'update') {
+        assertContentWritable(before, '应用');
+        this.store.updateFinding({ findingId: p.findingId, ...p.patch });
+      } else {
+        this.store.setTriage(
+          p.findingId,
+          p.kind === 'dismiss' ? 'dismiss' : 'open',
+          p.kind === 'dismiss' ? p.patch.reason : null,
+        );
+      }
+      const before_ =
+        p.kind === 'update'
+          ? snapshotPatched(before, p.patch)
+          : { triage: before.triage, dismissReason: before.dismissReason, autoClosed: before.autoClosed };
+      return {
+        finding: this.store.getFinding(p.findingId),
+        discussion: null,
+        proposal: this.resolveProposal(proposalId, 'applied', { before: before_ }),
+      };
+    });
+    return this.publish(reviewId, written);
+  }
+
+  /**
+   * 忽略一条提案:只落定去向,不碰 finding。卡片留在对话里,之后仍可重新应用。
+   *
+   * 已应用的必须走 {@link undoProposal}:在这里直接标成 skipped 的话,改动仍留在 finding 里,
+   * 卡片却写着「已忽略」并给出「重新应用」—— 那一下还会把已经被它改过的当前值拍成新快照,
+   * 从此撤销回的是它自己写下的东西,留痕与撤销一起失真。
+   */
+  skipProposal(reviewId: string, proposalId: string): FindingProposal {
+    const p = this.requireProposal(reviewId, proposalId);
+    if (p.status === 'applied')
+      throw new Error('该提案已应用,要收回改动请点「撤销」,不能直接标为已忽略。');
+    // 只落定提案自己,没有 finding 侧的写,单条 UPDATE 本身即原子
+    const next = this.resolveProposal(proposalId, 'skipped');
+    this.forward({ reviewId, type: 'finding-proposal', payload: next });
+    return next;
+  }
+
+  /**
+   * 撤销一条已采纳的提案:按落库的旧值还原,提案退回「已忽略」(仍可重新应用)。
+   * create 无从撤销 —— 新建的 finding 由用户自己剔除/删除,别在这里替他决定。
+   */
+  undoProposal(reviewId: string, proposalId: string): FindingProposal {
+    const p = this.requireProposal(reviewId, proposalId);
+    if (p.status !== 'applied' || p.kind === 'create' || !p.before || !p.findingId)
+      throw new Error('该提案无法撤销');
+    const written = this.store.transaction(() => {
+      const current = this.store.getFinding(p.findingId);
+      // 应用之后又被改过就不再撤:撤销写的是应用前的旧值,那会把后来的判断一起顶掉,
+      // 而这既不是提案的功劳也不是他要的。要回退就手动改,别在这里替他做主。
+      if (isProposalUndoBlocked(p, current))
+        throw new Error('这条 finding 在应用之后又被改过,撤销会覆盖那次改动 —— 请手动调整。');
+      if (p.kind === 'update') {
+        if (current) assertContentWritable(current, '撤销');
+        // 快照只含该提案动过的字段,所以这一还原不会碰 reviewer 在应用之后自己改的其他字段
+        this.store.updateFinding({ findingId: p.findingId, ...(p.before as ProposalUpdateBefore) });
+      } else {
+        // 走 restoreTriage 而非 setTriage:后者会把 auto_closed 清零,复核自动结案的条目
+        // 撤销后就变成「reviewer 亲手剔的」,下一轮回归不再自动恢复
+        this.store.restoreTriage(p.findingId, p.before as ProposalTriageBefore);
+      }
+      return {
+        finding: this.store.getFinding(p.findingId),
+        discussion: null,
+        proposal: this.resolveProposal(proposalId, 'skipped'),
+      };
+    });
+    return this.publish(reviewId, written);
+  }
+
+  private requireProposal(reviewId: string, proposalId: string): FindingProposal {
+    const p = this.store.getProposal(proposalId);
+    if (!p) throw new Error(`提案不存在: ${proposalId}`);
+    // 串号会把改动写到另一条 review 名下的 finding 上,两边数据都被污染(同 sendMessage 的校验)
+    if (p.reviewId !== reviewId) throw new Error(`提案不属于本次审核: ${proposalId}`);
+    return p;
+  }
+
+  /** 落定提案状态(纯写,不发事件)—— 调用方在事务内用它,提交后再统一外发。 */
+  private resolveProposal(
+    proposalId: string,
+    status: ProposalStatus,
+    opts: { before?: ProposalBefore; findingId?: string } = {},
+  ): FindingProposal {
+    const next = this.store.setProposalStatus(proposalId, status, opts);
+    if (!next) throw new Error(`提案不存在: ${proposalId}`);
+    return next;
+  }
+
+  /** 事务提交之后再把这一批改动外发。回滚掉的东西不该先一步上屏。 */
+  private publish(
+    reviewId: string,
+    written: { finding: Finding | null; discussion: Discussion | null; proposal: FindingProposal },
+  ): FindingProposal {
+    if (written.finding) this.forward({ reviewId, type: 'finding', payload: written.finding });
+    if (written.discussion)
+      this.forward({ reviewId, type: 'discussion', payload: written.discussion });
+    this.forward({ reviewId, type: 'finding-proposal', payload: written.proposal });
+    return written.proposal;
   }
 
   /**

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from 'node:events';
 import {
   DuetlensMcpServer,
   type McpContentProviders,
+  type ProposalOutcome,
+  type ProposedFindingChange,
   type ReportedFinding,
   type ReportedFindingResolution,
   type ReportedFindingUpdate,
@@ -14,6 +16,7 @@ import {
   updateFindingSchema,
   type Discussion,
   type Finding,
+  type FindingProposal,
   type Message,
   type Review,
   type ReviewIntensity,
@@ -78,6 +81,15 @@ export const ADVERSARIAL_SELFCHECK_PROMPT = `现在做一轮对抗式自检,站�
 2. 更重要的是审你**没报**的地方:哪个函数、边界或错误分支你只是扫过、并未真正构造反例去验证?对这些补一次证伪 —— 发现真实且可复现的新问题就用 report_finding 上报,已报过的不要重复。
 3. 给一句话小结:本轮自检补报了几条、降级/撤回了几条。`;
 
+/**
+ * 一个 turn 的「提案而非落库」上下文。收集篮由**调用方**持有:同一线程可以并发追问,
+ * 记在 session 上会被后一条清掉,提案就再也挂不上产生它的那句回复。
+ */
+interface ProposeContext {
+  discussionId: string;
+  collected: string[];
+}
+
 type TurnOutcome =
   | { kind: 'ok'; reply: string }
   | { kind: 'stopped' }
@@ -116,6 +128,37 @@ interface StopTarget {
 
 /** 追问时重述的历史条数上限;够唤起线程脉络,又不至于把整条对话再喂一遍。 */
 const FOLLOWUP_RECAP = 6;
+
+/** 注入追问的 finding 现状快照(正文截断,够对齐口径即可)。 */
+const STATE_EXCERPT = 600;
+
+function findingStateBlock(f: Finding): string {
+  const body = f.body.trim();
+  const lines = [
+    `- 当前严重度:${f.severity}${f.category ? ` · ${f.category}` : ''}`,
+    `- 当前正文:${body.length > STATE_EXCERPT ? `${body.slice(0, STATE_EXCERPT)}…` : body || '(空)'}`,
+  ];
+  if (f.triage === 'dismiss')
+    lines.push(`- 状态:已剔除${f.dismissReason ? `,理由:${f.dismissReason}` : ''}`);
+  return lines.join('\n');
+}
+
+/**
+ * 追问轮的回写口径。与旧版相反 —— 旧版要求「除非我明确说回写,否则别动」,
+ * 于是 agent 每次都以「按规则我不回写」收尾,一件本可以一键完成的事要人再说一遍。
+ * 现在这些工具在追问轮不落库,只生成待确认卡片,所以让它想到就提,由 reviewer 点。
+ */
+const FOLLOWUP_WRITEBACK_RULE = (findingId: string, dismissed: boolean): string =>
+  [
+    `请直接回答。如果讨论下来你认为这条 finding 该改,不必等我开口,就调用对应工具提出来 ——`,
+    `追问期间这些调用**不会**直接改动 finding,只会在对话里生成一张待我确认的卡片:`,
+    `- 内容/严重度写得不准 → update_finding(finding_id="${findingId}", 只传要改的字段)`,
+    dismissed
+      ? `- 它其实成立、不该被剔除 → restore_finding(finding_id="${findingId}", reason=...)`
+      : `- 整条不成立(误报 / 前提不存在 / 代码不可达)→ dismiss_finding(finding_id="${findingId}", reason=...),` +
+        `理由单独存,标题与正文原样保留 —— 不要用 update_finding 把剔除理由写进 body。`,
+    `没有要改的就什么也别调,正常回答即可。`,
+  ].join('\n');
 
 /** 把一条 discussion 的既往往来压成一段可注入的回顾;无历史返回空串。 */
 function recap(history: readonly Message[]): string {
@@ -157,6 +200,8 @@ export interface ReviewSessionEvents {
   message: Message;
   /** 归一后的 agent 流事件(原样转发) */
   'agent-event': AgentEvent;
+  /** 讨论里 agent 提出的待确认回写提案(新建 / 挂上消息后重发) */
+  'finding-proposal': FindingProposal;
   status: 'scanning' | 'reviewing' | 'completed' | 'failed';
 }
 
@@ -204,6 +249,11 @@ export class ReviewSession {
   private readonly conversationReady: Promise<void>;
   private openConversation!: () => void;
   private failConversation!: (reason: unknown) => void;
+  /**
+   * 正在跑的那个 turn 的提案上下文;非空即表示写 finding 的工具应转成提案。
+   * 只在 {@link runTurn} 的队列内部设置与清除 —— turn 是串行的,故同一时刻至多一个。
+   */
+  private proposeCtx: ProposeContext | null = null;
 
   constructor(
     private readonly reviewId: string,
@@ -351,8 +401,14 @@ export class ReviewSession {
 
     // 过了这一行,问题已经落库并推给了 UI:此后再失败都是「没等到回复」,不是「没发出去」。
     // 两者对用户的下一步截然相反,故换上识别串(见 FollowupReplyError)。
+    // 本轮提案的收集篮由调用方持有并原样传进 turn:同一线程可以有多条追问并发,
+    // 记在 session 上的话,后一条会把前一条的篮子清掉,提案就再也挂不上那句回复。
+    const collected: string[] = [];
     try {
-      const outcome = await this.runTurn(this.buildFollowupPrompt(discussion, text, history));
+      const outcome = await this.runTurn(this.buildFollowupPrompt(discussion, text, history), {
+        discussionId,
+        collected,
+      });
       if (outcome.kind === 'failed')
         throw new AgentTurnError(`追问失败: ${outcome.error}`, outcome.errorKind, outcome.error);
       if (outcome.kind === 'stopped') return userMsg;
@@ -361,9 +417,23 @@ export class ReviewSession {
       if (!reply) return userMsg;
       const agentMsg = this.store.addMessage(discussionId, 'agent', reply);
       this.emit('message', agentMsg);
+      this.bindProposals(collected, agentMsg.id);
       return agentMsg;
     } catch (e) {
       throw new FollowupReplyError(e);
+    }
+  }
+
+  /**
+   * 把本轮的提案挂到刚落库的那条 agent 回复上,并重发一次事件让 UI 归位。
+   * 提案先于回复文本产生(工具调用在前、回复在 turn 收尾才落库),不回挂就会排在解释它的那句话上面。
+   */
+  private bindProposals(ids: readonly string[], messageId: string): void {
+    if (ids.length === 0) return;
+    this.store.attachProposalsToMessage(ids, messageId);
+    for (const id of ids) {
+      const p = this.store.getProposal(id);
+      if (p) this.emit('finding-proposal', p);
     }
   }
 
@@ -446,6 +516,29 @@ export class ReviewSession {
       const updated = this.store.updateFinding(parsed.data);
       if (updated) this.emit('finding', updated); // 复用 finding 事件;renderer upsert
     });
+    // outcome 由本处就地填(emit 同步),让 MCP 侧按真实受理结果作答 —— 丢弃却回「已呈现」的话,
+    // agent 会照此向 reviewer 复述,而界面上没有那张卡。
+    this.mcp.on('finding-proposal', (raw: ProposedFindingChange, outcome: ProposalOutcome) => {
+      const ctx = this.proposeCtx;
+      if (!ctx) return; // 没有讨论上下文的提案无处呈现(理论上不会到:propose 模式只在追问轮开)
+      const finding = raw.findingId ? this.store.getFinding(raw.findingId) : null;
+      // 只认本 review 名下的 id,防 agent 编造 / 串号提到别处(同 finding-resolution)
+      if (raw.kind !== 'create' && (!finding || finding.reviewId !== this.reviewId)) {
+        outcome.reason = `finding_id 在本次审核里不存在: ${raw.findingId ?? '(空)'}`;
+        return;
+      }
+      const proposal = this.store.addProposal({
+        reviewId: this.reviewId,
+        discussionId: ctx.discussionId,
+        findingId: finding?.id ?? null,
+        kind: raw.kind,
+        patch: raw.patch,
+        baseUpdatedAt: finding?.updatedAt ?? null,
+      });
+      ctx.collected.push(proposal.id);
+      outcome.accepted = true;
+      this.emit('finding-proposal', proposal);
+    });
     this.mcp.on('finding-resolution', (raw: ReportedFindingResolution) => {
       const parsed = resolveFindingSchema.safeParse(raw);
       if (!parsed.success) return;
@@ -493,6 +586,9 @@ export class ReviewSession {
    * 把追问拼上锚点/finding 上下文,让 agent 知道在聊哪一处。
    * 讨论历史一并重述:每轮复审都换新 thread,且 codex 会 auto-compact ——
    * 都不能指望会话自身还记得这条线程之前说过什么。
+   *
+   * finding 的**当前**字段也一并给出:它可能已被 reviewer 就地编辑、被剔除、或被上一条提案改过,
+   * agent 记着的还是自己首次上报的那份 —— 不重述就会拿过时的正文当依据继续讨论。
    */
   private buildFollowupPrompt(discussion: Discussion, text: string, history: Message[]): string {
     const loc = discussion.file
@@ -503,18 +599,23 @@ export class ReviewSession {
       const finding = this.store.getFindingByDiscussion(discussion.id);
       if (finding) {
         return (
-          `关于你上报的 finding「${finding.title}」(${finding.file}:${finding.line}):\n` +
+          `关于 finding「${finding.title}」(${finding.file}:${finding.line}):\n` +
+          `${findingStateBlock(finding)}\n\n` +
           prior +
-          `${text}\n` +
-          `请在对话中直接回答,默认不要改动这条 finding。` +
-          `只有当我明确要求「更新 / 回写 finding」时,才调用 update_finding(finding_id="${finding.id}", ...)。`
+          `${text}\n\n` +
+          FOLLOWUP_WRITEBACK_RULE(finding.id, finding.triage === 'dismiss')
         );
       }
     }
     // 无锚点 = reviewer 在问整体(架构 / 取舍 / 某个跨文件的疑问),得说清范围是本次改动全体,
     // 否则 agent 容易拿上一条讨论的锚点当上下文接着答。
     const head = loc ? `关于 ${loc} 处的代码:\n` : '关于本次改动整体(未锚定到具体代码位置):\n';
-    return `${head}${prior}${text}`;
+    const tail =
+      discussion.file && discussion.line != null
+        ? `\n\n如果讨论下来这确实是一个该记录的问题,调用 report_finding 提议记一条(锚点用 ${discussion.file}:${discussion.line});` +
+          `它同样只生成待我确认的卡片,不会直接落库。`
+        : '';
+    return `${head}${prior}${text}${tail}`;
   }
 
   /**
@@ -542,25 +643,33 @@ export class ReviewSession {
    * 跑一轮 turn(串行入队):累积 message-delta 作为 agent 回复文本,resolve 于 turn 结束。
    * 前一轮失败不阻断后续轮(链上 catch)。
    */
-  private runTurn(text: string): Promise<TurnOutcome> {
+  private runTurn(text: string, propose?: ProposeContext): Promise<TurnOutcome> {
     const run = async (): Promise<TurnOutcome> => {
       // 排在队里的那些:轮到自己时会话可能已经拆了,别再发一轮出去等终局
       if (this.disposed) throw new SessionDisposedError();
       const conversationId = this.conversationId!;
-      // 订阅要先于发起:极快的 turn(乃至 stub)会在 turn/start 应答之前就把 delta 与终局发出来
-      const waiter = this.awaitTurnEnd();
+      // 提案模式必须开在**队列之内**:开在外面的话,排队期间跑着的扫描 turn 会把它的
+      // report_finding 记成这条讨论的提案,而扫描收尾时的复位又会让排在后面的这一问
+      // 退回直接落库 —— 一次绕过 reviewer 确认的静默改动。
+      this.enterTurnMode(propose);
       try {
-        waiter.identify(await this.agent.sendMessage(conversationId, text));
-      } catch (e) {
-        waiter.cancel(); // turn 根本没起来,别把订阅留在那儿等一个不会来的终局
-        throw e;
+        // 订阅要先于发起:极快的 turn(乃至 stub)会在 turn/start 应答之前就把 delta 与终局发出来
+        const waiter = this.awaitTurnEnd();
+        try {
+          waiter.identify(await this.agent.sendMessage(conversationId, text));
+        } catch (e) {
+          waiter.cancel(); // turn 根本没起来,别把订阅留在那儿等一个不会来的终局
+          throw e;
+        }
+        const outcome = await waiter.end;
+        if (outcome.kind === 'disposed') throw new SessionDisposedError();
+        if (outcome.kind === 'stopped') return { kind: 'stopped' };
+        if (outcome.kind === 'turn-failed')
+          return { kind: 'failed', error: outcome.error, errorKind: outcome.errorKind };
+        return { kind: 'ok', reply: waiter.reply() };
+      } finally {
+        this.exitTurnMode();
       }
-      const outcome = await waiter.end;
-      if (outcome.kind === 'disposed') throw new SessionDisposedError();
-      if (outcome.kind === 'stopped') return { kind: 'stopped' };
-      if (outcome.kind === 'turn-failed')
-        return { kind: 'failed', error: outcome.error, errorKind: outcome.errorKind };
-      return { kind: 'ok', reply: waiter.reply() };
     };
     // 排队期间也算忙:队里还压着一轮的会话被拆掉,和跑到一半被拆没有区别。
     this.inFlight += 1;
@@ -569,6 +678,17 @@ export class ReviewSession {
     });
     this.turnChain = result.catch(() => undefined);
     return result;
+  }
+
+  /** 进入本 turn 的写语义;缺省(机审/自检)即直接落库。 */
+  private enterTurnMode(propose?: ProposeContext): void {
+    this.proposeCtx = propose ?? null;
+    this.mcp?.setWriteMode(propose ? 'propose' : 'apply');
+  }
+
+  private exitTurnMode(): void {
+    this.proposeCtx = null;
+    this.mcp?.setWriteMode('apply');
   }
 
   private setStatus(status: 'scanning' | 'reviewing' | 'completed' | 'failed'): void {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -39,6 +39,13 @@ const api: DuetlensApi = {
       ipcRenderer.invoke(IpcChannels.reviewSendMessage, reviewId, discussionId, text),
     clearDiscussion: (reviewId, discussionId) =>
       ipcRenderer.invoke(IpcChannels.reviewClearDiscussion, reviewId, discussionId),
+    proposals: (reviewId) => ipcRenderer.invoke(IpcChannels.reviewProposals, reviewId),
+    applyProposal: (reviewId, proposalId) =>
+      ipcRenderer.invoke(IpcChannels.reviewApplyProposal, reviewId, proposalId),
+    skipProposal: (reviewId, proposalId) =>
+      ipcRenderer.invoke(IpcChannels.reviewSkipProposal, reviewId, proposalId),
+    undoProposal: (reviewId, proposalId) =>
+      ipcRenderer.invoke(IpcChannels.reviewUndoProposal, reviewId, proposalId),
     setTriage: (reviewId, findingId, triage, reason) =>
       ipcRenderer.invoke(IpcChannels.reviewSetTriage, reviewId, findingId, triage, reason),
     setFindingAnchor: (reviewId, findingId, line) =>

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -16,7 +16,7 @@ import type {
 import type { PrSummary } from '@shared/source-discovery';
 import { scanDoneStatus } from '@shared/domain';
 import { isSubmittable } from '@shared/github-review';
-import type { Discussion, Finding, Message, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
+import type { Discussion, Finding, FindingProposal, Message, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
 import { mergeLayers } from '@shared/prompt';
 import { APP_VERSION } from '@shared/version';
 import type { UpdateStatus } from '@shared/update';
@@ -370,8 +370,108 @@ const SEED_MESSAGES: Record<string, Message[]> = {
       text: '这里 done += 1 在并发下会不会丢更新?想听听 agent 的意见。',
       createdAt: now + 500,
     },
+    {
+      id: 'm-user-seed-2',
+      discussionId: 'd-user-seed',
+      role: 'agent',
+      text: '会。读-改-写三步之间可被另一个 task 打断,统计值会偏小。这值得单独记一条。',
+      createdAt: now + 1500,
+    },
+  ],
+  'd-f5': [
+    {
+      id: 'm-seed-f5-q',
+      discussionId: 'd-f5',
+      role: 'user',
+      text: '这个函数在本次改动里还有调用点吗?',
+      createdAt: now + 3000,
+    },
+    {
+      id: 'm-seed-f5',
+      discussionId: 'd-f5',
+      role: 'agent',
+      text: '没有了 —— 最后一处引用随本次改动一并删除,这条 finding 描述的路径不可达。',
+      createdAt: now + 3200,
+    },
   ],
 };
+
+/**
+ * 回写提案 fixture:三种状态各一,便于自查提案卡的 pending / applied / skipped 三态。
+ * update 挂在 d-f1 的 agent 回复上;dismiss 走 d-f3(那条本就是剔除态,可自查恢复档)。
+ */
+const SEED_PROPOSALS: FindingProposal[] = [
+  {
+    id: 'p-update',
+    reviewId: 'demo',
+    discussionId: 'd-f1',
+    messageId: 'm-seed-2',
+    findingId: 'f1',
+    kind: 'update',
+    patch: {
+      severity: 'medium',
+      title: 'counter 跨 spawn 共享:近似进度下可放宽为 Relaxed 原子',
+      body: '仍需原子类型(跨线程),但只求近似进度时 Ordering::Relaxed 即可,开销接近裸加。原文按「必须加锁」写,过重了。',
+    },
+    before: null,
+    baseUpdatedAt: now,
+    status: 'pending',
+    createdAt: now + 2500,
+    resolvedAt: null,
+  },
+  {
+    id: 'p-dismiss',
+    reviewId: 'demo',
+    discussionId: 'd-f5',
+    messageId: 'm-seed-f5',
+    findingId: 'f5',
+    kind: 'dismiss',
+    patch: { reason: '这条路径的调用点已随本次改动删除,代码不可达;原文描述的场景在当前分支上不存在。' },
+    before: null,
+    baseUpdatedAt: now,
+    status: 'pending',
+    createdAt: now + 3500,
+    resolvedAt: null,
+  },
+  {
+    // 已提交的 finding:内容锁定,提案不可应用。同时 d-f7 没有消息,顺带自查「挂不上消息的提案」那条路
+    id: 'p-locked',
+    reviewId: 'demo',
+    discussionId: 'd-f7',
+    messageId: null,
+    findingId: 'f7',
+    kind: 'update',
+    patch: { severity: 'medium', body: '重试耗尽后返回 null,建议改为抛出最后一次错误。' },
+    before: null,
+    baseUpdatedAt: now,
+    status: 'pending',
+    createdAt: now + 3800,
+    resolvedAt: null,
+  },
+  {
+    id: 'p-done',
+    reviewId: 'demo',
+    discussionId: 'd-user-seed',
+    messageId: 'm-user-seed-2',
+    findingId: null,
+    kind: 'create',
+    patch: {
+      severity: 'high',
+      category: 'Correctness',
+      title: 'done += 1 在并发下丢更新',
+      body: '多个 task 并发自增同一个非原子计数器,读-改-写之间可被打断,统计值会偏小。',
+      file: 'src/pipeline.ts',
+      line: 19,
+      // 带 suggestion:它会随新 finding 落库并最终发给 author,卡上必须看得见
+      suggestion: '      counter.fetch_add(1, Ordering::Relaxed);',
+    },
+    before: null,
+    baseUpdatedAt: null,
+    status: 'pending',
+    createdAt: now + 4000,
+    resolvedAt: null,
+  },
+];
 
 // 三层审核规则 fixture:内置基线与合并逻辑直接复用 @shared/prompt(不再抄一份,免得与后端漂移),
 // 这里只预置若干层覆盖,供三层编辑器双主题自查。
@@ -455,6 +555,8 @@ export function installPreviewApi(): void {
     asClean || asStream ? [] : asRoundFailed ? [{ ...ROUNDS[0] }, { ...FAILED_ROUND }] : ROUNDS.map((r) => ({ ...r }));
   const discussions = asClean || asStream ? [] : DISCUSSIONS.map((d) => ({ ...d }));
   const msgStore: Record<string, Message[]> = structuredClone(SEED_MESSAGES);
+  const proposals: FindingProposal[] =
+    asClean || asStream ? [] : structuredClone(SEED_PROPOSALS);
   const listeners = new Set<(e: ReviewEvent) => void>();
   const startListeners = new Set<(p: ReviewStartProgress) => void>();
   const fire = (e: ReviewEvent) => {
@@ -541,6 +643,7 @@ export function installPreviewApi(): void {
       },
       fileContent: async (_r, path) => (path === 'src/pipeline.ts' ? PIPELINE_SRC : null),
       discussions: async () => discussions,
+      proposals: async () => proposals,
       messages: async (discussionId) => msgStore[discussionId] ?? [],
       // ?start 模拟大 PR 的慢启动(阶段按真实顺序推进,diff 停够久能看到「拉取偏慢」提示);
       // ?start=error 在 diff 阶段失败,自查浮层的错误态
@@ -700,6 +803,51 @@ export function installPreviewApi(): void {
       clearDiscussion: async (_r, discussionId) => {
         msgStore[discussionId] = [];
         fire({ reviewId: 'demo', type: 'messages-cleared', discussionId });
+      },
+      // 提案三个去向:与后端同样真的改内存态并回推,便于在预览里走完「应用 → 卡片刷新 → 撤销」
+      applyProposal: async (_r, proposalId) => {
+        const i = proposals.findIndex((p) => p.id === proposalId);
+        const p = proposals[i];
+        const f = p.findingId ? findings.find((x) => x.id === p.findingId) : null;
+        // 旧值快照与后端同步落下 —— 不记的话预览里永远走不到「↩ 撤销」那条路
+        let before: FindingProposal['before'] = null;
+        if (p.kind === 'update' && f) {
+          // 与后端同口径:只拍 patch 动过的字段,拍全量会让撤销顺手回滚应用之后的编辑
+          before = Object.fromEntries(
+            Object.keys(p.patch).map((k) => [k, (f as unknown as Record<string, unknown>)[k]]),
+          );
+          emit({ ...f, ...p.patch, updatedAt: Date.now() });
+        } else if ((p.kind === 'dismiss' || p.kind === 'restore') && f) {
+          before = { triage: f.triage, dismissReason: f.dismissReason, autoClosed: f.autoClosed };
+          emit({
+            ...f,
+            triage: p.kind === 'dismiss' ? 'dismiss' : 'open',
+            dismissReason: p.kind === 'dismiss' ? p.patch.reason : null,
+            autoClosed: false,
+            updatedAt: Date.now(),
+          });
+        }
+        const next = { ...p, before, status: 'applied' as const, resolvedAt: Date.now() } as FindingProposal;
+        proposals[i] = next;
+        fire({ reviewId: 'demo', type: 'finding-proposal', payload: next });
+        return next;
+      },
+      skipProposal: async (_r, proposalId) => {
+        const i = proposals.findIndex((p) => p.id === proposalId);
+        const next = { ...proposals[i], status: 'skipped' as const, resolvedAt: Date.now() };
+        proposals[i] = next;
+        fire({ reviewId: 'demo', type: 'finding-proposal', payload: next });
+        return next;
+      },
+      undoProposal: async (_r, proposalId) => {
+        const i = proposals.findIndex((p) => p.id === proposalId);
+        const p = proposals[i];
+        const f = p.findingId ? findings.find((x) => x.id === p.findingId) : null;
+        if (f && p.before) emit({ ...f, ...p.before, updatedAt: Date.now() });
+        const next = { ...p, status: 'skipped' as const, resolvedAt: Date.now() };
+        proposals[i] = next;
+        fire({ reviewId: 'demo', type: 'finding-proposal', payload: next });
+        return next;
       },
       setTriage: async (_r, findingId, triage, reason) => {
         const f = findings.find((x) => x.id === findingId)!;

--- a/src/renderer/review/useReviewStream.ts
+++ b/src/renderer/review/useReviewStream.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Discussion, Finding, Message, Review, ReviewRound } from '@shared/domain';
+import type { Discussion, Finding, FindingProposal, Message, Review, ReviewRound } from '@shared/domain';
 import type { DiffFile } from '@shared/diff';
 import type { AgentEvent, TokenUsage } from '@shared/agent-events';
 
@@ -16,6 +16,8 @@ export interface ReviewStreamState {
   diffReady: boolean;
   /** 按 discussionId 聚合的消息(user/agent),随 message 事件增量追加 */
   messages: Record<string, Message[]>;
+  /** agent 在讨论里提出的回写提案(含已落定的,它们是改动来由的凭据) */
+  proposals: FindingProposal[];
   status: Review['status'] | null;
   /** 轮次履历(首轮 + 每次重跑);末条即当前轮 */
   rounds: ReviewRound[];
@@ -53,6 +55,7 @@ export function useReviewStream(reviewId: string | null): ReviewStreamState {
   const [diff, setDiff] = useState<DiffFile[]>([]);
   const [diffReady, setDiffReady] = useState(false);
   const [messages, setMessages] = useState<Record<string, Message[]>>({});
+  const [proposals, setProposals] = useState<FindingProposal[]>([]);
   const [status, setStatus] = useState<Review['status'] | null>(null);
   const [rounds, setRounds] = useState<ReviewRound[]>([]);
   const [tokenUsage, setTokenUsage] = useState<TokenUsage | null>(null);
@@ -110,6 +113,7 @@ export function useReviewStream(reviewId: string | null): ReviewStreamState {
     setLastTool(null);
     setRetrying(null);
     setMessages({});
+    setProposals([]);
     setDiff([]);
     setDiffReady(false);
     fetched.current = new Set();
@@ -134,6 +138,7 @@ export function useReviewStream(reviewId: string | null): ReviewStreamState {
     });
     void window.duetlens.review.findings(reviewId).then((f) => alive && setFindings(f));
     void window.duetlens.review.discussions(reviewId).then((d) => alive && setDiscussions(d));
+    void window.duetlens.review.proposals(reviewId).then((p) => alive && setProposals(p));
     loadDiff();
     void window.duetlens.review.rounds(reviewId).then((r) => alive && setRounds(r));
 
@@ -176,6 +181,18 @@ export function useReviewStream(reviewId: string | null): ReviewStreamState {
                 ? bucket.filter((x) => !(x.id.startsWith('pending-') && x.text === m.text))
                 : bucket;
             return { ...prev, [m.discussionId]: [...cleaned, m] };
+          });
+          return;
+        }
+        case 'finding-proposal': {
+          // upsert:新提案追加,落定(applied/skipped)或回挂 messageId 后就地替换
+          const p = e.payload;
+          setProposals((prev) => {
+            const i = prev.findIndex((x) => x.id === p.id);
+            if (i < 0) return [...prev, p];
+            const next = prev.slice();
+            next[i] = p;
+            return next;
           });
           return;
         }
@@ -249,6 +266,7 @@ export function useReviewStream(reviewId: string | null): ReviewStreamState {
     diff,
     diffReady,
     messages,
+    proposals,
     status,
     rounds,
     tokenUsage,

--- a/src/renderer/screens/ReviewScreen.css
+++ b/src/renderer/screens/ReviewScreen.css
@@ -4370,3 +4370,261 @@
 .c-actions .f-accept:hover {
   filter: brightness(1.12);
 }
+
+/* ---------- 讨论里的回写提案卡(ProposalCard)----------
+   接在 agent 气泡下方,是「把这条改动落库」的唯一确认入口,故必须比气泡更实 ——
+   用卡面 + agent 左边线;剔除档单独走 sev-high 色,别让两个后果不同的动作长得一样。 */
+.prop {
+  margin-top: 8px;
+  border: 1px solid var(--agent-line);
+  border-left: 2px solid var(--agent);
+  border-radius: 9px;
+  background: color-mix(in oklab, var(--agent) 6%, var(--card));
+  overflow: hidden;
+}
+.prop.drop {
+  border-color: color-mix(in oklab, var(--sev-high) 40%, transparent);
+  border-left-color: var(--sev-high);
+  background: color-mix(in oklab, var(--sev-high) 5%, var(--card));
+}
+/* 已过期:提案之后 finding 又被改过,套用会盖掉那次改动 —— 用 human 色提示「这是你的改动在被威胁」 */
+.prop.stale {
+  border-color: var(--human-line);
+  border-left-color: var(--human);
+  background: var(--human-soft);
+}
+.prop-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 11px;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+.prop-head .pi {
+  color: var(--agent-2);
+}
+.prop.drop .prop-head .pi {
+  color: var(--sev-high);
+}
+.prop.stale .prop-head .pi {
+  color: var(--human);
+}
+.prop-head .pt {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--text-faint);
+}
+.prop-warn {
+  padding: 8px 11px 0;
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--human);
+}
+.prop.done .prop-warn,
+.prop.skipped .prop-warn {
+  color: var(--sev-high);
+  padding-bottom: 8px;
+}
+/* 折叠态里的过期提醒不是错误,别跟着上面那条走 sev-high */
+.prop .prop-warn.stale-note {
+  color: var(--human);
+}
+.prop.skipped.stale {
+  border-left-color: var(--human);
+}
+.prop-body {
+  padding: 9px 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+/* 字段级 旧 → 新 */
+.pf {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 12px;
+  line-height: 1.55;
+}
+.pf-k {
+  flex: none;
+  width: 58px;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.pf-v {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
+.pf-old {
+  color: var(--text-deco);
+  text-decoration: line-through;
+}
+.pf-arr {
+  margin: 0 5px;
+  color: var(--text-deco);
+}
+.pf-new {
+  color: var(--text);
+}
+.pf-keep {
+  color: var(--text-faint);
+}
+.pf-sev {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+/* 长文本对照:沿用 diff 栏的红绿两档,不必学新的读法 */
+.pf-diff {
+  border: 1px solid var(--border-soft);
+  border-radius: 7px;
+  overflow: hidden;
+}
+.pf-diff .r {
+  display: flex;
+  gap: 7px;
+  padding: 4px 8px;
+  font-size: 11.5px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+.pf-diff.mono .r {
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+}
+.pf-diff .r.del {
+  background: var(--del-bg);
+  color: var(--text-faint);
+}
+.pf-diff .r.add {
+  background: var(--add-bg);
+  color: var(--text);
+}
+.pf-diff .r .g {
+  flex: none;
+  width: 10px;
+  font-family: var(--mono);
+}
+.pf-diff .r.del .g {
+  color: var(--del);
+}
+.pf-diff .r.add .g {
+  color: var(--add);
+}
+.prop-foot {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding: 0 11px 10px;
+}
+/* 说明较长时(如 create 的「不可撤销」)整句折到下一行,别把按钮压成两行字 */
+.prop-foot .pb {
+  white-space: nowrap;
+}
+.prop-foot .why {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.pb {
+  padding: 4px 11px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+  color: var(--text-dim);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.pb:hover:not(:disabled) {
+  color: var(--text);
+}
+.pb:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.pb.go {
+  border-color: transparent;
+  background: var(--accent-solid);
+  color: var(--on-solid);
+  font-weight: 600;
+}
+.pb.go:hover:not(:disabled) {
+  background: var(--accent-solid-hover);
+}
+.pb.drop {
+  border-color: color-mix(in oklab, var(--sev-high) 45%, transparent);
+  background: transparent;
+  color: var(--sev-high);
+  font-weight: 600;
+}
+.pb.drop:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--sev-high) 12%, transparent);
+}
+/* 已落定:卡片不消失,折叠成一行留作改动来由的凭据 */
+.prop.done,
+.prop.skipped {
+  background: transparent;
+  border-color: var(--border-soft);
+}
+.prop.done {
+  border-left-color: var(--add);
+}
+.prop.skipped {
+  border-left-color: var(--text-deco);
+}
+.prop.done .prop-done-row .pi {
+  color: var(--add);
+}
+.prop.skipped .prop-done-row .pi {
+  color: var(--text-deco);
+}
+.prop-done-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 11px;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-faint);
+}
+.prop-done-row .u {
+  margin-left: auto;
+  flex: none;
+}
+
+/* 剔除态卡片里的原文:剔除不动正文,但收起态只剩划掉的标题 —— 展开即可查回当初报的是什么 */
+.c-dismissed .dm-src {
+  margin-top: 7px;
+  padding-top: 7px;
+  border-top: 1px dashed var(--border-soft);
+}
+.c-dismissed .dm-src > button {
+  padding: 1px 0;
+  border: 0;
+  background: none;
+  color: var(--text-faint);
+  font-size: 11px;
+  cursor: pointer;
+}
+.c-dismissed .dm-src > button:hover {
+  color: var(--text-dim);
+}
+.c-dismissed .dm-orig {
+  margin-top: 6px;
+  padding: 7px 9px;
+  border-radius: 7px;
+  background: var(--surface-2);
+  color: var(--text-faint);
+  font-size: 11.5px;
+  line-height: 1.6;
+}

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import type { Discussion, Finding, Message, Review, ReviewIntensity, Severity, Triage, UiSettings } from '@shared/domain';
+import type { Discussion, Finding, FindingProposal, Message, Review, ReviewIntensity, Severity, Triage, UiSettings } from '@shared/domain';
 import { DEFAULT_UI_SETTINGS } from '@shared/domain';
 import type { DiffFile } from '@shared/diff';
 import type { AddFindingInput, DiscussionAnchor, FindingEditInput } from '@shared/ipc';
@@ -70,6 +70,7 @@ export function ReviewScreen({
     findings,
     discussions,
     messages,
+    proposals,
     diff,
     diffReady,
     status,
@@ -354,6 +355,22 @@ export function ReviewScreen({
       if (!reviewId) return;
       void window.duetlens.review.updateFinding(reviewId, input);
     },
+    [reviewId],
+  );
+  // agent 回写提案的三个去向。同写路径:落库后经事件回推,失败原样抛出由提案卡就地回显。
+  const onApplyProposal = useCallback(
+    (proposalId: string) =>
+      reviewId ? window.duetlens.review.applyProposal(reviewId, proposalId) : Promise.resolve(),
+    [reviewId],
+  );
+  const onSkipProposal = useCallback(
+    (proposalId: string) =>
+      reviewId ? window.duetlens.review.skipProposal(reviewId, proposalId) : Promise.resolve(),
+    [reviewId],
+  );
+  const onUndoProposal = useCallback(
+    (proposalId: string) =>
+      reviewId ? window.duetlens.review.undoProposal(reviewId, proposalId) : Promise.resolve(),
     [reviewId],
   );
   // DiffPane 展开 diff 外上下文时按需拉取文件新侧全文(读不到返回 null)
@@ -650,6 +667,10 @@ export function ReviewScreen({
             ensureMessages={ensureMessages}
             onPromote={onPromote}
             onClearMessages={onClearMessages}
+            proposals={proposals}
+            onApplyProposal={onApplyProposal}
+            onSkipProposal={onSkipProposal}
+            onUndoProposal={onUndoProposal}
             categoryFilter={categoryFilter}
             onClearCategory={() => setCategoryFilter(null)}
             onEditSummary={onEditSummary}
@@ -742,6 +763,10 @@ function RightPanel({
   ensureMessages,
   onPromote,
   onClearMessages,
+  proposals,
+  onApplyProposal,
+  onSkipProposal,
+  onUndoProposal,
   categoryFilter,
   onClearCategory,
   onEditSummary,
@@ -773,6 +798,10 @@ function RightPanel({
   ensureMessages: (id: string) => void;
   onPromote: (discussionId: string) => void;
   onClearMessages: (discussionId: string) => void;
+  proposals: FindingProposal[];
+  onApplyProposal: (proposalId: string) => Promise<unknown>;
+  onSkipProposal: (proposalId: string) => Promise<unknown>;
+  onUndoProposal: (proposalId: string) => Promise<unknown>;
   categoryFilter: string | null;
   onClearCategory: () => void;
   onEditSummary: (body: string) => void;
@@ -987,6 +1016,10 @@ function RightPanel({
           ensureMessages={ensureMessages}
           onPromote={onPromote}
           onClearMessages={onClearMessages}
+          proposals={proposals}
+          onApplyProposal={onApplyProposal}
+          onSkipProposal={onSkipProposal}
+          onUndoProposal={onUndoProposal}
         />
       )}
       {tab === 'summary' &&

--- a/src/renderer/screens/review/DiscussionTab.tsx
+++ b/src/renderer/screens/review/DiscussionTab.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Discussion, Finding, Message } from '@shared/domain';
+import type { Discussion, Finding, FindingProposal, Message } from '@shared/domain';
 import { Composer, type UnsentDraft } from './Composer';
 import { renderMarkdown } from './markdown';
+import { ProposalCard } from './ProposalCard';
 import { stripIpcWrapper } from './round-error';
 
 const basename = (p: string) => p.split('/').pop() ?? p;
@@ -38,6 +39,11 @@ export interface DiscussionTabProps {
   onPromote: (discussionId: string) => void;
   /** 清空当前 discussion 的往来消息(finding 卡保留),重开讨论 */
   onClearMessages: (discussionId: string) => void;
+  /** agent 在讨论里提出的回写提案(全 review 范围,按 discussionId 筛) */
+  proposals: FindingProposal[];
+  onApplyProposal: (proposalId: string) => Promise<unknown>;
+  onSkipProposal: (proposalId: string) => Promise<unknown>;
+  onUndoProposal: (proposalId: string) => Promise<unknown>;
 }
 
 /** 一条 discussion 的展示标题:finding 用其标题,user 用首条消息 / 兜底文案 */
@@ -117,6 +123,31 @@ export function DiscussionTab(props: DiscussionTabProps) {
 
   const activeMsgs = active ? messages[active.id] ?? [] : [];
   const rootFinding = active ? findingByDisc.get(active.id) ?? null : null;
+
+  // 当前线程的提案:按消息分组挂到各自那条回复下,挂不上的(无 messageId / 消息已被清空)另收一处。
+  const { proposalsByMessage, looseProposals } = useMemo(() => {
+    const byMessage = new Map<string, FindingProposal[]>();
+    const loose: FindingProposal[] = [];
+    const known = new Set(activeMsgs.map((m) => m.id));
+    for (const p of props.proposals) {
+      if (!active || p.discussionId !== active.id) continue;
+      if (p.messageId && known.has(p.messageId)) {
+        const bucket = byMessage.get(p.messageId);
+        if (bucket) bucket.push(p);
+        else byMessage.set(p.messageId, [p]);
+      } else loose.push(p);
+    }
+    return { proposalsByMessage: byMessage, looseProposals: loose };
+  }, [props.proposals, active, activeMsgs]);
+
+  // 提案要对照的是 finding 的**当前**值(可能已被就地编辑过);create 提案应用前还没有 finding。
+  const findingById = useMemo(() => {
+    const m = new Map<string, Finding>();
+    for (const f of findings) m.set(f.id, f);
+    return m;
+  }, [findings]);
+  const findingOf = (p: FindingProposal): Finding | null =>
+    (p.findingId ? findingById.get(p.findingId) : null) ?? null;
   const anchorLabel = active?.file
     ? `${basename(active.file)}:${active.line ?? ''}${active.lineEnd ? `–${active.lineEnd}` : ''}`
     : null;
@@ -208,8 +239,32 @@ export function DiscussionTab(props: DiscussionTabProps) {
                 role={m.role}
                 name={m.role === 'agent' ? 'agent' : 'reviewer'}
                 text={m.text}
+                proposals={proposalsByMessage.get(m.id)}
+                findingOf={findingOf}
+                onApplyProposal={props.onApplyProposal}
+                onSkipProposal={props.onSkipProposal}
+                onUndoProposal={props.onUndoProposal}
               />
             ))}
+            {/* 还没回挂到消息上的提案(turn 没给回复文本,或消息被清空过)接在线程末尾 ——
+                挂不上就不渲染的话,一张待确认卡片会凭空消失,而它是唯一的确认入口 */}
+            {looseProposals.length > 0 && (
+              <div className="msg">
+                <span className="av agent">◆</span>
+                <div className="body">
+                  {looseProposals.map((p) => (
+                    <ProposalCard
+                      key={p.id}
+                      proposal={p}
+                      finding={findingOf(p)}
+                      onApply={props.onApplyProposal}
+                      onSkip={props.onSkipProposal}
+                      onUndo={props.onUndoProposal}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
             {activeAwaiting && (
               <div className="msg">
                 <span className="av agent">◆</span>
@@ -326,11 +381,22 @@ function MessageBubble({
   name,
   meta,
   text,
+  proposals,
+  findingOf,
+  onApplyProposal,
+  onSkipProposal,
+  onUndoProposal,
 }: {
   role: 'agent' | 'user';
   name: string;
   meta?: string;
   text: string;
+  /** 这一轮 agent 顺带提出的回写提案,接在气泡下方 */
+  proposals?: FindingProposal[];
+  findingOf?: (p: FindingProposal) => Finding | null;
+  onApplyProposal?: (id: string) => Promise<unknown>;
+  onSkipProposal?: (id: string) => Promise<unknown>;
+  onUndoProposal?: (id: string) => Promise<unknown>;
 }) {
   return (
     <div className="msg">
@@ -344,7 +410,19 @@ function MessageBubble({
         <div className={`bubble${role === 'agent' ? ' agent' : ''}`}>
           <div className="c-prose">{renderMarkdown(text)}</div>
         </div>
+        {proposals?.map((p) => (
+          <ProposalCard
+            key={p.id}
+            proposal={p}
+            finding={findingOf?.(p) ?? null}
+            onApply={onApplyProposal ?? noop}
+            onSkip={onSkipProposal ?? noop}
+            onUndo={onUndoProposal ?? noop}
+          />
+        ))}
       </div>
     </div>
   );
 }
+
+const noop = async (): Promise<void> => undefined;

--- a/src/renderer/screens/review/InlineCard.tsx
+++ b/src/renderer/screens/review/InlineCard.tsx
@@ -113,6 +113,7 @@ function DismissedCard({
   onTriage?: (finding: Finding, triage: Triage, reason?: string | null) => void;
 }) {
   const [editing, setEditing] = useState(false);
+  const [showOriginal, setShowOriginal] = useState(false);
   const [reason, setReason] = useState(finding.dismissReason ?? '');
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -170,6 +171,21 @@ function DismissedCard({
           <button className="dm-save" onClick={save}>
             保存
           </button>
+        </div>
+      )}
+      {/* 剔除只写 triage 与理由,原文一直都在库里 —— 但收起态只剩一个划掉的标题,
+          于是「当初到底报的是什么」在屏上无处可查。展开即可,不必先恢复再剔一遍。 */}
+      {finding.body.trim() && (
+        <div className="dm-src">
+          <button onClick={() => setShowOriginal((v) => !v)}>
+            {showOriginal ? '▴ 收起原文' : '▾ 展开原文'}
+          </button>
+          {/* 标题已在上面那行(划掉的那条)给过,这里只补正文 —— 再印一遍就是同一句话说两次 */}
+          {showOriginal && (
+            <div className="dm-orig">
+              <div className="c-prose">{renderMarkdown(finding.body)}</div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/screens/review/ProposalCard.tsx
+++ b/src/renderer/screens/review/ProposalCard.tsx
@@ -1,0 +1,320 @@
+import { useState } from 'react';
+import {
+  isProposalStale,
+  isProposalUndoBlocked,
+  type Finding,
+  type FindingProposal,
+  type ProposalUpdatePatch,
+  type Severity,
+} from '@shared/domain';
+import { stripIpcWrapper } from './round-error';
+
+const SEV_LABEL: Record<Severity, string> = { high: 'high', medium: 'med', low: 'low' };
+
+export interface ProposalCardProps {
+  proposal: FindingProposal;
+  /** 提案针对的 finding 当前值(create 提案尚无);用于对照旧值与判定是否已过期 */
+  finding: Finding | null;
+  onApply: (id: string) => Promise<unknown>;
+  onSkip: (id: string) => Promise<unknown>;
+  onUndo: (id: string) => Promise<unknown>;
+}
+
+/** 每档的图标 / 标题 / 工具名。剔除单独用 sev-high 色,免得与「更新」长得一样却后果不同。 */
+const KIND_META = {
+  update: { icon: '◆', title: '建议更新这条 finding', tool: 'update_finding', danger: false },
+  dismiss: { icon: '✕', title: '建议剔除这条 finding', tool: 'dismiss_finding', danger: true },
+  restore: { icon: '↩', title: '建议恢复这条 finding', tool: 'restore_finding', danger: false },
+  create: { icon: '＋', title: '建议记为一条 finding', tool: 'report_finding', danger: false },
+} as const;
+
+/**
+ * agent 在讨论里提出的回写提案,接在它那条回复下方。
+ * 提案本身不改任何东西 —— 落库要 reviewer 点这里的主按钮(见 backend applyProposal)。
+ * applied / skipped 之后卡片不消失,折叠成一行留作「谁在什么时候改了什么」的凭据。
+ */
+export function ProposalCard({ proposal, finding, onApply, onSkip, onUndo }: ProposalCardProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const meta = KIND_META[proposal.kind];
+  const stale = isProposalStale(proposal, finding);
+  // 已提交的 finding 内容锁定(后端也拦,见 assertContentWritable)。提前说,别让人点了才知道。
+  // 只锁内容:剔除/恢复是「这条还追不追」的判断,已提交的追评项照样可以剔。
+  const locked = proposal.kind === 'update' && finding?.submission === 'submitted';
+  // 应用之后 finding 又被改过 → 撤销会顶掉那次改动,后端直接回绝(见 isProposalUndoBlocked)。
+  // 这里同口径先把按钮收起来,别让人点了才知道。
+  const undoBlocked = isProposalUndoBlocked(proposal, finding);
+
+  const run = (fn: (id: string) => Promise<unknown>) => () => {
+    setError(null);
+    setBusy(true);
+    void fn(proposal.id)
+      .catch((e: unknown) => setError(stripIpcWrapper((e as Error)?.message ?? String(e))))
+      .finally(() => setBusy(false));
+  };
+
+  if (proposal.status !== 'pending') {
+    const applied = proposal.status === 'applied';
+    // create 无从撤销:新建出来的 finding 该留该删是 reviewer 的事,不在这里替他决定
+    const undoable =
+      applied && proposal.kind !== 'create' && !!proposal.before && !locked && !undoBlocked;
+    return (
+      <div className={`prop ${applied ? 'done' : 'skipped'}${stale ? ' stale' : ''}`}>
+        <div className="prop-done-row">
+          <span className="pi">{applied ? '✓' : '○'}</span>
+          <span>
+            {applied ? '已应用' : '已忽略'} · {summarize(proposal, finding)}
+          </span>
+          {undoable && (
+            <button className="pb u" disabled={busy} onClick={run(onUndo)}>
+              ↩ 撤销
+            </button>
+          )}
+          {!applied && !locked && (
+            <button className="pb u" disabled={busy} onClick={run(onApply)}>
+              {stale ? '仍要应用' : '重新应用'}
+            </button>
+          )}
+        </div>
+        {locked && <div className="prop-warn stale-note">{LOCKED_NOTE}</div>}
+        {undoBlocked && !locked && (
+          <div className="prop-warn stale-note">这条 finding 在应用之后又被改过,已不能一键撤销。</div>
+        )}
+        {/* 忽略过的提案照样能重新应用,所以过期提醒在折叠态也得给 —— 不给的话,
+            那一下会静默盖掉 finding 在忽略之后的改动 */}
+        {stale && <div className="prop-warn stale-note">{STALE_NOTE[proposal.kind]}</div>}
+        {error && <div className="prop-warn">✕ {error}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`prop${meta.danger ? ' drop' : ''}${stale ? ' stale' : ''}`}>
+      <div className="prop-head">
+        <span className="pi">{stale ? '!' : meta.icon}</span>
+        {stale ? '提案已过期' : meta.title}
+        <span className="pt">{meta.tool}</span>
+      </div>
+      {stale && <div className="prop-warn">{STALE_NOTE[proposal.kind]}</div>}
+      {locked && <div className="prop-warn stale-note">{LOCKED_NOTE}</div>}
+      <div className="prop-body">
+        <ProposalDetail proposal={proposal} finding={finding} />
+      </div>
+      <div className="prop-foot">
+        <button
+          className={`pb ${meta.danger ? 'drop' : 'go'}`}
+          disabled={busy || locked}
+          onClick={run(onApply)}
+        >
+          {stale ? '仍要应用' : APPLY_LABEL[proposal.kind]}
+        </button>
+        <button className="pb" disabled={busy} onClick={run(onSkip)}>
+          忽略
+        </button>
+        <span className="why">{FOOT_NOTE[proposal.kind]}</span>
+      </div>
+      {error && <div className="prop-warn">✕ {error}</div>}
+    </div>
+  );
+}
+
+const LOCKED_NOTE = '这条 finding 已提交到 GitHub,内容已锁定 —— 改了会与发出去的评论对不上。';
+
+/** 过期提醒:说清套用会顶掉的**具体是什么**,一句「又被改过」不足以让人判断要不要点。 */
+const STALE_NOTE: Record<FindingProposal['kind'], string> = {
+  update: '这条 finding 在提案之后又被改过,套用会盖掉那次改动。',
+  dismiss: '这条已被剔除,且理由与本提案不同 —— 套用会替换掉现有的剔除理由。',
+  restore: '',
+  create: '',
+};
+
+/** 页脚那句话要与实际能做的事对上:create 在后端与折叠态都不给撤销,别在这里许一个不存在的出口。 */
+const FOOT_NOTE: Record<FindingProposal['kind'], string> = {
+  update: '应用后可撤销',
+  restore: '应用后可撤销',
+  dismiss: '理由会注入下一轮复审',
+  create: '新建后不可撤销,如需去掉请剔除该 finding',
+};
+
+const APPLY_LABEL: Record<FindingProposal['kind'], string> = {
+  update: '✓ 应用',
+  dismiss: '✕ 剔除并记录理由',
+  restore: '↩ 恢复',
+  create: '＋ 记为 finding',
+};
+
+/** 折叠态的一句话交代:改了什么 / 剔除了什么,不必展开就知道这行记的是哪件事。 */
+function summarize(p: FindingProposal, finding: Finding | null): string {
+  if (p.kind === 'create') return `新建 finding「${p.patch.title}」`;
+  if (p.kind === 'dismiss') return `剔除${finding ? `「${finding.title}」` : ''}`;
+  if (p.kind === 'restore') return `恢复${finding ? `「${finding.title}」` : ''}`;
+  const fields = changedFields(p.patch);
+  return fields.length ? `更新 ${fields.join(' · ')}` : '未改动任何字段';
+}
+
+const FIELD_LABEL: Record<keyof ProposalUpdatePatch, string> = {
+  severity: 'severity',
+  category: 'category',
+  title: '标题',
+  body: '说明',
+  suggestion: 'suggestion',
+};
+
+function changedFields(patch: ProposalUpdatePatch): string[] {
+  return (Object.keys(FIELD_LABEL) as (keyof ProposalUpdatePatch)[])
+    .filter((k) => patch[k] !== undefined)
+    .map((k) => FIELD_LABEL[k]);
+}
+
+function ProposalDetail({
+  proposal,
+  finding,
+}: {
+  proposal: FindingProposal;
+  finding: Finding | null;
+}) {
+  if (proposal.kind === 'dismiss' || proposal.kind === 'restore') {
+    return (
+      <>
+        <Row k={proposal.kind === 'dismiss' ? '剔除理由' : '恢复原因'}>
+          <span className="pf-new">{proposal.patch.reason}</span>
+        </Row>
+        {proposal.kind === 'dismiss' && (
+          <Row k="原文">
+            <span className="pf-keep">保留不动(标题 / 说明 / suggestion 均不改写)</span>
+          </Row>
+        )}
+      </>
+    );
+  }
+
+  if (proposal.kind === 'create') {
+    const p = proposal.patch;
+    return (
+      <>
+        <Row k="severity">
+          <span className={`sev sev-${p.severity}`}>
+            {SEV_LABEL[p.severity]}
+            {p.category ? ` · ${p.category}` : ''}
+          </span>
+        </Row>
+        <Row k="标题">
+          <span className="pf-new">{p.title}</span>
+        </Row>
+        <Row k="锚点">
+          <span className="pf-new mono">
+            {p.file}:{p.line}
+          </span>
+        </Row>
+        {p.body && <TextDiff before={null} after={p.body} />}
+        {/* suggestion 会随 finding 一并落库、最终提交给 author 当一键补丁 —— 卡上不给看,
+            就是让 reviewer 在没读过补丁的情况下把它发出去 */}
+        {p.suggestion && <TextDiff label="suggestion" before={null} after={p.suggestion} mono />}
+      </>
+    );
+  }
+
+  const patch = proposal.patch;
+  const fields = changedFields(patch);
+  if (fields.length === 0) return <Row k="改动">{'（无改动字段）'}</Row>;
+  return (
+    <>
+      {patch.severity !== undefined && (
+        <Row k="severity">
+          <span className="pf-sev">
+            {finding && finding.severity !== patch.severity && (
+              <>
+                <span className={`sev sev-${finding.severity} pf-old`}>
+                  {SEV_LABEL[finding.severity]}
+                </span>
+                <span className="pf-arr">→</span>
+              </>
+            )}
+            <span className={`sev sev-${patch.severity}`}>{SEV_LABEL[patch.severity]}</span>
+          </span>
+        </Row>
+      )}
+      {patch.category !== undefined && (
+        <Row k="category">
+          <Swap before={finding?.category ?? null} after={patch.category} />
+        </Row>
+      )}
+      {patch.title !== undefined && (
+        <Row k="标题">
+          <Swap before={finding?.title ?? null} after={patch.title} />
+        </Row>
+      )}
+      {patch.body !== undefined && <TextDiff before={finding?.body ?? null} after={patch.body} />}
+      {patch.suggestion !== undefined && (
+        <TextDiff label="suggestion" before={finding?.suggestion ?? null} after={patch.suggestion} mono />
+      )}
+    </>
+  );
+}
+
+function Row({ k, children }: { k: string; children: React.ReactNode }) {
+  return (
+    <div className="pf">
+      <span className="pf-k">{k}</span>
+      <span className="pf-v">{children}</span>
+    </div>
+  );
+}
+
+/** 短字段的旧→新。旧值缺失或与新值相同时只显示新值,不摆一个空的箭头。 */
+function Swap({ before, after }: { before: string | null; after: string | null }) {
+  const next = after ?? '（清空）';
+  if (before == null || before === after) return <span className="pf-new">{next}</span>;
+  return (
+    <>
+      <span className="pf-old">{before}</span>
+      <span className="pf-arr">→</span>
+      <span className="pf-new">{next}</span>
+    </>
+  );
+}
+
+/**
+ * 长文本(正文 / suggestion)的逐块对照;沿用 diff 栏的红绿两档,不必学新的读法。
+ *
+ * `mono`(suggestion)**逐字照显,不做 trim**:那是会被字面替换进代码的补丁,首行缩进是它的一部分
+ * (见 findingSuggestion)。裁掉的话,卡上看到的和采纳后落库、最终发给 author 的不是同一段。
+ * 「有没有内容」因此只按 null 判,不按 trim 后是否为空 —— 纯空白的补丁也是补丁。
+ */
+function TextDiff({
+  label = '说明',
+  before,
+  after,
+  mono,
+}: {
+  label?: string;
+  before: string | null;
+  after: string | null;
+  mono?: boolean;
+}) {
+  const show = (v: string | null): string | null => (v == null ? null : mono ? v : v.trim() || null);
+  const oldText = show(before);
+  const newText = show(after);
+  if (oldText == null && newText == null) return <Row k={label}>{'（清空）'}</Row>;
+  return (
+    <div className={`pf-diff${mono ? ' mono' : ''}`}>
+      {oldText != null && (
+        <div className="r del">
+          <span className="g">−</span>
+          <span>{oldText}</span>
+        </div>
+      )}
+      {newText != null ? (
+        <div className="r add">
+          <span className="g">＋</span>
+          <span>{newText}</span>
+        </div>
+      ) : (
+        <div className="r add">
+          <span className="g">＋</span>
+          <span className="pf-keep">（清空 {label}）</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -141,6 +141,20 @@ export type UpdateFindingInput = z.infer<typeof updateFindingSchema>;
  */
 export const RESOLUTIONS_REQUIRING_NOTE: readonly FindingResolution[] = ['still_present', 'wont_fix'];
 
+/** dismiss_finding:讨论中 agent 认为该条不成立,给出剔除理由。正文一律不动。 */
+export const dismissFindingSchema = z.object({
+  findingId: z.string().min(1),
+  reason: z.string().min(1),
+});
+export type DismissFindingInput = z.infer<typeof dismissFindingSchema>;
+
+/** restore_finding:讨论中 agent 论证已剔除的那条其实成立,给出恢复原因。 */
+export const restoreFindingSchema = z.object({
+  findingId: z.string().min(1),
+  reason: z.string().min(1),
+});
+export type RestoreFindingInput = z.infer<typeof restoreFindingSchema>;
+
 /** resolve_finding:复审轮次里对上一轮 finding 表态「已修复 / 仍存在」 */
 export const resolveFindingSchema = z
   .object({
@@ -309,6 +323,142 @@ export interface Message {
   role: MessageRole;
   text: string;
   createdAt: number;
+}
+
+// ---- 讨论中的回写提案(见 docs/design/discussion-proposals.md)----
+
+/**
+ * agent 在讨论里想对 finding 做的一件事。追问轮不直接落库 —— 先记成提案,由 reviewer 一键确认。
+ * `create` 是「把这条讨论记成一条 finding」,应用前还没有 finding,故 findingId 为空。
+ */
+export const PROPOSAL_KINDS = ['update', 'dismiss', 'restore', 'create'] as const;
+export type ProposalKind = (typeof PROPOSAL_KINDS)[number];
+
+/** pending 等确认;applied 已落库(可撤销);skipped 被 reviewer 忽略(可重新应用)。 */
+export const PROPOSAL_STATUSES = ['pending', 'applied', 'skipped'] as const;
+export type ProposalStatus = (typeof PROPOSAL_STATUSES)[number];
+
+/** update 提案要写的字段;缺省即不改,与 {@link UpdateFindingInput} 同口径(null=清空)。 */
+export interface ProposalUpdatePatch {
+  severity?: Severity;
+  category?: string | null;
+  title?: string;
+  body?: string;
+  suggestion?: string | null;
+}
+
+/** dismiss / restore 提案的说明。dismiss 的 reason 会成为 dismissReason,注入下一轮复审。 */
+export interface ProposalReasonPatch {
+  reason: string;
+}
+
+export type ProposalPatch = ProposalUpdatePatch | ProposalReasonPatch | ReportFindingInput;
+
+/**
+ * 应用前的旧值,供「↩ 撤销」还原。应用那一刻才拍,故 pending 期间为 null。
+ *
+ * 只拍**该提案真正改动的那几个字段** —— 拍全量的话,撤销会把应用之后 reviewer 自己的编辑
+ * 一并回滚掉:提案只降了个 severity,撤销却连带把他重写过的正文换回旧版。
+ */
+export type ProposalUpdateBefore = ProposalUpdatePatch;
+
+export interface ProposalTriageBefore {
+  triage: Triage;
+  dismissReason: string | null;
+  autoClosed: boolean;
+}
+
+export type ProposalBefore = ProposalUpdateBefore | ProposalTriageBefore;
+
+interface ProposalBase {
+  id: string;
+  reviewId: string;
+  /** 提案出自哪条讨论 */
+  discussionId: string;
+  /** 挂在哪条 agent 消息之后;该 turn 没有回复文本时为 null,就地接在线程末尾 */
+  messageId: string | null;
+  status: ProposalStatus;
+  createdAt: number;
+  resolvedAt: number | null;
+}
+
+/**
+ * 提案的判别联合:kind 决定 patch / before 的形状,也决定应用时走哪条落库路径。
+ * baseUpdatedAt 是提案那一刻 finding 的 updatedAt —— 与当前值不同即说明这条在提案之后又被改过,
+ * 直接套用会盖掉那次改动(UI 据此给「已过期」提醒,但不拦着应用:判断权仍在 reviewer)。
+ */
+export type FindingProposal =
+  | (ProposalBase & {
+      kind: 'update';
+      findingId: string;
+      patch: ProposalUpdatePatch;
+      before: ProposalUpdateBefore | null;
+      baseUpdatedAt: number;
+    })
+  | (ProposalBase & {
+      kind: 'dismiss';
+      findingId: string;
+      patch: ProposalReasonPatch;
+      before: ProposalTriageBefore | null;
+      baseUpdatedAt: number;
+    })
+  | (ProposalBase & {
+      kind: 'restore';
+      findingId: string;
+      patch: ProposalReasonPatch;
+      before: ProposalTriageBefore | null;
+      baseUpdatedAt: number;
+    })
+  | (ProposalBase & {
+      kind: 'create';
+      /** 应用后回填新建 finding 的 id */
+      findingId: string | null;
+      patch: ReportFindingInput;
+      before: null;
+      baseUpdatedAt: null;
+    });
+
+/**
+ * 这条提案是否已被后来的改动追上(只对 update 有意义 —— 它是唯一会覆盖正文字段的一档)。
+ * dismiss/restore 写的是 triage 一格,重复应用不会丢信息,不必拦。
+ *
+ * `skipped` 与 `pending` 同样要判:忽略过的提案仍给「重新应用」,期间 finding 被编辑过的话,
+ * 那一下照样是覆盖。只有 `applied` 不必判 —— 它已经落过库,当前值本就是它写的。
+ */
+export function isProposalStale(p: FindingProposal, finding: Finding | null): boolean {
+  if (p.status === 'applied' || !finding) return false;
+  if (p.kind === 'update') return finding.updatedAt !== p.baseUpdatedAt;
+  // dismiss 不只是翻一格 triage,它还写理由:这条已被剔除且理由与提案的不同时,套用就是把
+  // reviewer 自己写的那句顶掉。判据取「会不会真的替换掉一条不同的理由」而非 updatedAt ——
+  // 后者会被任何无关写入推高(改个标题就算),那样等于逢点必警。
+  if (p.kind === 'dismiss')
+    return finding.triage === 'dismiss' && (finding.dismissReason ?? '') !== p.patch.reason;
+  // restore 只把 triage 翻回 open 并清掉理由 —— 那正是「恢复」本来的语义(见 setTriage),不算覆盖
+  return false;
+}
+
+/**
+ * 已应用的提案是否**不再能安全撤销** —— finding 在应用之后又被改动过。
+ *
+ * 撤销写的是应用前的旧值,只有当前值仍是这条提案写下的那些值时才成立:
+ * 提案把 severity 降到 medium、reviewer 随后手动改成 low,再撤销就会把它顶回 high,
+ * 而这既不是提案的功劳也不是他要的。判据是逐字段比对而非 updatedAt ——
+ * 后者会被任何无关写入(如另一条提案改标题)推高,一律拦下等于永远不给撤销。
+ *
+ * 与 {@link isProposalStale} 是同一件事的两头:那条管「还没应用的还能不能套上去」,
+ * 这条管「已经应用的还能不能收回来」。
+ */
+export function isProposalUndoBlocked(p: FindingProposal, finding: Finding | null): boolean {
+  if (p.status !== 'applied' || p.kind === 'create' || !p.before) return false;
+  if (!finding) return true;
+  if (p.kind === 'update') {
+    return (Object.keys(p.patch) as (keyof ProposalUpdatePatch)[]).some(
+      (k) => (finding[k] ?? null) !== (p.patch[k] ?? null),
+    );
+  }
+  if (p.kind === 'dismiss')
+    return finding.triage !== 'dismiss' || (finding.dismissReason ?? '') !== p.patch.reason;
+  return finding.triage !== 'open';
 }
 
 // ---- Persisted UI state(见 docs/design/architecture.md 持久化表)----

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -6,6 +6,7 @@ import type {
   CodexModelInfo,
   Discussion,
   Finding,
+  FindingProposal,
   Message,
   ReasoningEffort,
   Review,
@@ -55,6 +56,10 @@ export const IpcChannels = {
   reviewAddDiscussion: 'review:add-discussion',
   reviewSendMessage: 'review:send-message',
   reviewClearDiscussion: 'review:clear-discussion',
+  reviewProposals: 'review:proposals',
+  reviewApplyProposal: 'review:apply-proposal',
+  reviewSkipProposal: 'review:skip-proposal',
+  reviewUndoProposal: 'review:undo-proposal',
   reviewSetTriage: 'review:set-triage',
   reviewSetFindingAnchor: 'review:set-finding-anchor',
   reviewAddFinding: 'review:add-finding',
@@ -267,6 +272,7 @@ export type ReviewEvent =
   | { reviewId: string; type: 'round'; payload: ReviewRound }
   | { reviewId: string; type: 'finding'; payload: Finding }
   | { reviewId: string; type: 'message'; payload: Message }
+  | { reviewId: string; type: 'finding-proposal'; payload: FindingProposal }
   | { reviewId: string; type: 'messages-cleared'; discussionId: string }
   | { reviewId: string; type: 'discussion'; payload: Discussion }
   | { reviewId: string; type: 'review'; payload: Review }
@@ -325,6 +331,14 @@ export interface DuetlensApi {
     sendMessage(reviewId: string, discussionId: string, text: string): Promise<Message>;
     /** 清空一条 discussion 的往来消息(finding 卡保留);经 `messages-cleared` 事件回推。 */
     clearDiscussion(reviewId: string, discussionId: string): Promise<void>;
+    /** 该 review 名下 agent 提出的全部回写提案(pending / applied / skipped 都在)。 */
+    proposals(reviewId: string): Promise<FindingProposal[]>;
+    /** 采纳一条提案:按 kind 走与手动操作同一条落库路径,旧值记进提案供撤销。 */
+    applyProposal(reviewId: string, proposalId: string): Promise<FindingProposal>;
+    /** 忽略一条提案(不碰 finding);卡片留在对话里,之后仍可重新应用。 */
+    skipProposal(reviewId: string, proposalId: string): Promise<FindingProposal>;
+    /** 撤销一条已采纳的提案,按旧值还原;create 类不可撤销。 */
+    undoProposal(reviewId: string, proposalId: string): Promise<FindingProposal>;
     /**
      * 用户裁决某条 finding(保留/剔除/复位);落库后经事件流回推更新。
      * reason 只在剔除时有意义(可选),会注入下一轮复审让 agent 不再报同类问题;恢复时自动清空。


### PR DESCRIPTION
Discussion is where a finding actually gets sharpened, but "we agreed" and "it changed" were
separated by a manual relay: the agent reached a conclusion and then had to be told, again,
to write it back. This replaces that sentence with a button.

## What changes

**Follow-up turns propose instead of writing.** A write-finding tool call during a follow-up
no longer touches the finding — it records a pending proposal and renders a confirm card under
the agent's reply. Scan and adversarial self-check turns still apply directly: nobody is there
to confirm, and the self-check relies on `update_finding` to downgrade its own shaky calls.

The tool surface does not fork. The agent still calls `report_finding` / `update_finding`;
we decide what those mean based on the kind of turn (`McpWriteMode`). Adding a parallel set of
`propose_*` tools was rejected — making the model choose between "do" and "suggest doing" buys
a failure mode we already know how to avoid.

**Dismissal is its own verb.** `dismiss_finding` is new, and it fixes a real bug rather than
adding polish: before it, the agent had no way to express "this one does not hold". The only
tool that could touch a finding wrote prose fields, so it put the dismissal reason into `body`.
That destroyed the original text and left a meaningless card in the submit list. Dismissal now
writes `triage` and `dismissReason` only; title, body and suggestion are untouched. Dismissed
cards grew an "expand original" row, because the collapsed state showed nothing but a
struck-through title.

Four intents ship: `update`, `dismiss`, `restore`, and `create` (turn this discussion into a
finding). Re-anchoring is deliberately out — it decides where the comment lands on GitHub and
needs its own schema change.

## Notable decisions

- Propose mode is bound to the turn that is actually running, not to a flag outside the queue.
  Outside it, a scan in flight would have its `report_finding` recorded as a proposal, and the
  scan's teardown would send a queued follow-up back to writing directly.
- Adopting a dismissal does not set `autoClosed`. That flag means "the code no longer has it";
  this is the reviewer's own call after reading an argument, and the next round's regression
  logic must not overturn it.
- Apply and undo are one transaction with the proposal's own status row, and events are only
  emitted after commit.
- Undo restores just the fields the proposal touched, and refuses outright once those fields
  have moved on. Staleness is judged per field, not by `updatedAt` — the latter is bumped by
  any unrelated write.
- Content of a submitted finding stays locked in the authoritative layer, not only in the UI.

Design notes: `docs/design/discussion-proposals.md`.

## Verification

`npm run spike:proposals` (needs `codex login`) covers the loop end to end against real codex
and a real database: a follow-up produces a pending proposal, the finding stays untouched, and
adopting a dismissal preserves the original text.

Three assertions run without codex, each checked against its own regression by reverting the
fix and confirming the failure:

- a mid-apply failure rolls the finding back with the proposal
- a follow-up queued behind a running scan does not steal the scan's write semantics
- scan turns reject `dismiss_finding`

UI was checked in the preview harness in both light and dark.