### PR TITLE
feat(submit): keep the file anchor when a finding drops to the summary

### DIFF
--- a/docs/design/findings-submit.md
+++ b/docs/design/findings-submit.md
@@ -19,7 +19,7 @@ diff-review 是工作面,submit 是终点步骤,靠**顶栏常驻主 CTA** 连�
 保留项组成**一次 GitHub PR review**:
 
 - 有 `file:line` 锚点的 → **inline 行评论**(带 `suggestion` 的用 suggestion 块)。
-- `file=null`(整体 / 架构类)的 → 并入 **review 摘要 body**,连同 codex 审核总结。
+- 没有行锚点、或被降级的(见下) → 并入 **review 摘要 body**,连同 codex 审核总结。**摘要条目自带 `file:line`** —— 它脱离了 inline 的位置,不写出锚点,作者就只剩一段不知道说的是哪儿的结论,而这些条目往往正是锚在改动之外、最需要按图索骥的那批。
 - 用户选 **event**:`Comment` / `Request changes` / `Approve`。
 - **零 finding 也可提交** —— event 本身就是表态。仅照搬 GitHub 的硬约束:`Comment` / `Request changes` 至少要有 body 或一条行评论。
 
@@ -30,6 +30,8 @@ diff-review 是工作面,submit 是终点步骤,靠**顶栏常驻主 CTA** 连�
 **PR review 是一次原子提交** —— GitHub 要么整份落地、要么整份失败,**没有「部分成功」**。所以结果只有三类:成功 / 整体失败(认证过期 / 网络 / PR 已关闭,未提交任何评论)/ **422 行锚点失效**。
 
 **422 才是「部分不可提交」的真实形态**:某条 finding 的 `file:line` 已不在最新 diff 的新增侧,作为 inline 会让整份被拒。逐条处理(降级为摘要评论 / 改锚点到最近改动行 / 剔除此条)后整份重提,并给成批入口。
+
+**降级只记一格 `anchorDropped`,不动行号** —— 降级要解决的是「不能作为 inline 发」,不是「不知道在哪儿」:锚点留着,摘要条目才写得出 `file:line`,用户也才能一键改回行评论。
 
 ### 失效锚点靠「现拉最新 diff」定位
 

--- a/scripts/spike-export.ts
+++ b/scripts/spike-export.ts
@@ -41,6 +41,7 @@ function mkFinding(p: Partial<Finding> & Pick<Finding, 'id' | 'severity' | 'titl
     category: null,
     body: '',
     suggestion: null,
+    anchorDropped: false,
     triage: 'open',
     dismissReason: null,
     submission: 'unsubmitted',

--- a/scripts/spike-submit.ts
+++ b/scripts/spike-submit.ts
@@ -9,6 +9,7 @@ import { ReviewStore } from '../src/backend/db/review-store';
 import { ReviewManager } from '../src/backend/review/review-manager';
 import {
   buildPrReviewPayload,
+  hasAnchor,
   isAnchorLive,
   isStaleAnchor,
   isSubmittable,
@@ -259,9 +260,11 @@ async function main() {
     const manager = new ReviewManager(store, undefined, {
       submitter: new FakeSubmitter({ status: 'success', url: 'u', submittedCount: 0 }),
     });
-    // 降级为摘要:line=0 脱锚 → 从 inline 移到 review body
+    // 降级为摘要:line=0 只脱锚 → 从 inline 移到 review body,行号留着给摘要写锚点
     manager.setFindingAnchor(review.id, stale.id, 0);
-    assert.equal(store.getFinding(stale.id)!.line, 0, 'line 置 0');
+    assert.equal(store.getFinding(stale.id)!.line, 99, '降级不清行号');
+    assert.equal(store.getFinding(stale.id)!.anchorDropped, true, '记为已脱锚');
+    assert.equal(hasAnchor(store.getFinding(stale.id)!), false, '脱锚后不再作为 inline 提交');
     const degraded = buildPrReviewPayload(
       store.getReview(review.id)!,
       [store.getFinding(live.id)!, store.getFinding(stale.id)!],
@@ -269,6 +272,12 @@ async function main() {
     );
     assert.equal(degraded.comments.length, 1, '降级后只剩 1 条 inline');
     assert.match(degraded.body, /失效锚点/, '降级项并入 review body');
+    assert.match(degraded.body, /`src\/p\.ts:99`/, '摘要条目自带 file:line,否则作者无从定位');
+
+    // 改回行评论:降级留着的行号原样传回即可复原
+    manager.setFindingAnchor(review.id, stale.id, store.getFinding(stale.id)!.line);
+    assert.equal(hasAnchor(store.getFinding(stale.id)!), true, '传回原行号即撤销降级');
+    manager.setFindingAnchor(review.id, stale.id, 0);
 
     // 改锚点:把另一条改到最近活行 → 回到 inline
     const stale2 = store.addFinding(review.id, { severity: 'low', title: '再失效', body: 'x', file: 'src/p.ts', line: 88 });

--- a/src/backend/db/review-store.ts
+++ b/src/backend/db/review-store.ts
@@ -80,6 +80,7 @@ interface FindingRow {
   body: string;
   file: string;
   line: number;
+  anchor_dropped: number;
   suggestion: string | null;
   triage: string;
   dismiss_reason: string | null;
@@ -190,6 +191,7 @@ function toFinding(r: FindingRow): Finding {
     body: r.body,
     file: r.file,
     line: r.line,
+    anchorDropped: r.anchor_dropped === 1,
     suggestion: r.suggestion,
     triage: (r.triage === 'keep' ? 'open' : r.triage) as Triage,
     dismissReason: r.dismiss_reason,
@@ -759,10 +761,21 @@ export class ReviewStore {
     });
   }
 
-  /** 改锚点行(提交屏修锚点 / 降级为摘要):line=0 表示脱锚,归入 review 摘要。 */
+  /**
+   * 改锚点行(提交屏修锚点 / 降级为摘要):line=0 表示脱锚,归入 review 摘要。
+   * 脱锚只置 anchor_dropped,原行号照留 —— 摘要条目要写出 file:line,且据此可改回行评论。
+   */
   setFindingAnchor(findingId: string, line: number): void {
     this.withReviewTouch({ finding: findingId }, (ts) => {
-      this.db.prepare('UPDATE findings SET line = ?, updated_at = ? WHERE id = ?').run(line, ts, findingId);
+      if (line > 0) {
+        this.db
+          .prepare('UPDATE findings SET line = ?, anchor_dropped = 0, updated_at = ? WHERE id = ?')
+          .run(line, ts, findingId);
+        return;
+      }
+      this.db
+        .prepare('UPDATE findings SET anchor_dropped = 1, updated_at = ? WHERE id = ?')
+        .run(ts, findingId);
     });
   }
 

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -203,7 +203,15 @@ CREATE INDEX idx_proposals_review ON finding_proposals(review_id);
 CREATE INDEX idx_proposals_discussion ON finding_proposals(discussion_id);
 `;
 
-const MIGRATIONS: string[] = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13];
+// 「降级为摘要评论」从此记在独立一格,不再靠把 line 清成 0 来表达 —— 摘要条目要写出 file:line
+// 给作者定位,清掉行号等于把这信息扔了,也让降级不可回退。存量的 line=0 行只能按脱锚回填,
+// 原行号已不可追溯(findingAnchorText 对它只给文件名)。
+const V14 = `
+ALTER TABLE findings ADD COLUMN anchor_dropped INTEGER NOT NULL DEFAULT 0;
+UPDATE findings SET anchor_dropped = 1 WHERE line <= 0;
+`;
+
+const MIGRATIONS: string[] = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14];
 
 export function migrate(db: Database): void {
   const current = db.pragma('user_version', { simple: true }) as number;

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -15,7 +15,7 @@ import type {
 } from '@shared/ipc';
 import type { PrSummary } from '@shared/source-discovery';
 import { scanDoneStatus } from '@shared/domain';
-import { isSubmittable } from '@shared/github-review';
+import { hasAnchor, isSubmittable } from '@shared/github-review';
 import type { Discussion, Finding, FindingProposal, Message, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
 import { mergeLayers } from '@shared/prompt';
 import { APP_VERSION } from '@shared/version';
@@ -163,6 +163,7 @@ function mkFinding(p: Partial<Finding> & Pick<Finding, 'id' | 'severity' | 'titl
     category: null,
     body: '',
     suggestion: null,
+    anchorDropped: false,
     triage: 'open',
     dismissReason: null,
     submission: 'unsubmitted',
@@ -253,6 +254,8 @@ const FINDINGS: Finding[] = [
     body: 'appVersion 比较未校验格式,非法值被静默视为相等;文件不在本次改动内,agent 顺 import 读到并 off-diff 提出。',
     file: 'src/shared/config.ts',
     line: 42,
+    // 已在提交屏降级为摘要条目:锚点不在 diff 新增侧,作为 inline 会让整份被 422 拒
+    anchorDropped: true,
   }),
   // 第 1 轮就提交给 author、第 2 轮复核仍存在 —— 提交屏据此追发一条带复核说明的评论
   mkFinding({
@@ -862,7 +865,11 @@ export function installPreviewApi(): void {
       },
       setFindingAnchor: async (_r, findingId, line) => {
         const f = findings.find((x) => x.id === findingId)!;
-        const next = { ...f, line, updatedAt: Date.now() };
+        // 与后端同一口径:line=0 只置降级位,原行号留着(摘要要写出 file:line,也才能改回行评论)
+        const next =
+          line > 0
+            ? { ...f, line, anchorDropped: false, updatedAt: Date.now() }
+            : { ...f, anchorDropped: true, updatedAt: Date.now() };
         emit(next);
         return next;
       },
@@ -883,6 +890,7 @@ export function installPreviewApi(): void {
           file: input.file,
           line: input.line,
           suggestion: input.suggestion ?? null,
+          anchorDropped: false,
           triage: 'open',
           dismissReason: null,
           submission: 'unsubmitted',
@@ -928,6 +936,7 @@ export function installPreviewApi(): void {
           file: d.file!,
           line: d.line!,
           suggestion: null,
+          anchorDropped: false,
           triage: 'open',
           dismissReason: null,
           submission: 'unsubmitted',
@@ -973,7 +982,7 @@ export function installPreviewApi(): void {
           };
           emit(next);
         }
-        return { status: 'success', url, submittedCount: pending.filter((f) => f.file && f.line > 0).length };
+        return { status: 'success', url, submittedCount: pending.filter(hasAnchor).length };
       },
       openInBrowser: async () => {
         const url = 'https://github.com/xieziyu/podcast-go/pull/482';

--- a/src/renderer/screens/submit/SubmitGitHubScreen.css
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.css
@@ -381,6 +381,30 @@
   color: var(--text-dim);
   font-weight: 500;
 }
+/* 降级为摘要条目:锚点仍显示(摘要正文里也会写出它),这里只标它不再是 inline 行评论 */
+.f-degraded {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10.5px;
+  padding: 2px 7px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-faint);
+}
+.f-degraded button {
+  font-size: 10.5px;
+  color: var(--text-dim);
+  background: none;
+  border: none;
+  border-left: 1px solid var(--border);
+  padding: 0 0 0 6px;
+  cursor: pointer;
+}
+.f-degraded button:hover {
+  color: var(--text);
+}
 .origin {
   font-family: var(--mono);
   font-size: 10.5px;

--- a/src/renderer/screens/submit/SubmitGitHubScreen.tsx
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { findingNarrative, findingSuggestion, type Finding, type Review } from '@shared/domain';
+import {
+  findingAnchorText,
+  findingNarrative,
+  findingSuggestion,
+  type Finding,
+  type Review,
+} from '@shared/domain';
 import type { DiffFile } from '@shared/diff';
 import type { SubmitReviewResult } from '@shared/ipc';
 import {
@@ -90,6 +96,8 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
     [findings, diff, round],
   );
   const inlineCount = pending.filter(hasAnchor).length;
+  // 降级 / 无锚点的条目走 review body 的「整体意见」,与草稿正文一起构成摘要
+  const summaryCount = pending.filter((f) => !hasAnchor(f)).length;
   const keptCount = findings.filter((f) => f.triage !== 'dismiss').length;
   const staleList = useMemo(() => findings.filter((f) => staleIds.has(f.id)), [findings, staleIds]);
   const reAnchorableCount = staleList.filter((f) => nearestLiveLine(f.file, f.line, diff) != null).length;
@@ -112,6 +120,10 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
   }, [diff]);
 
   const degradeToSummary = (f: Finding) => void window.duetlens.review.setFindingAnchor(reviewId, f.id, 0);
+  /** 撤销降级:行号在降级时留着没清,原样传回即恢复为行评论。 */
+  const restoreAnchor = (f: Finding) => {
+    if (f.line > 0) void window.duetlens.review.setFindingAnchor(reviewId, f.id, f.line);
+  };
   const reAnchor = (f: Finding) => {
     const line = nearestLiveLine(f.file, f.line, diff);
     if (line != null) void window.duetlens.review.setFindingAnchor(reviewId, f.id, line);
@@ -171,7 +183,8 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
   const btnLabel = (() => {
     const parts: string[] = [];
     if (inlineCount > 0) parts.push(`${inlineCount} 行评论`);
-    if (summary.trim()) parts.push('摘要');
+    if (summaryCount > 0) parts.push(`摘要(含 ${summaryCount} 条)`);
+    else if (summary.trim()) parts.push('摘要');
     return `提交到 GitHub · ${parts.length ? parts.join(' + ') : `仅 ${EVENT_META[event].label}`} →`;
   })();
 
@@ -291,8 +304,17 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
                   </div>
                   <div className="f-top">
                     <span className="f-anchor">
-                      📍 <b>{f.file}</b>:{f.line}
+                      📍 <b>{f.file}</b>
+                      {f.line > 0 ? `:${f.line}` : ''}
                     </span>
+                    {f.anchorDropped && !isDismissed && (
+                      <span className="f-degraded">
+                        并入摘要
+                        {!locked && f.line > 0 && (
+                          <button onClick={() => restoreAnchor(f)}>改回行评论</button>
+                        )}
+                      </span>
+                    )}
                     <span className={'origin' + (f.origin === 'agent' ? ' agent' : ' human')}>
                       <span className="d" />
                       {f.origin === 'agent' ? 'agent' : '你 · ' + (f.origin === 'promoted' ? '由 discussion 提升' : '手动新增')}
@@ -325,9 +347,11 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
                   )}
                   {isSubmitted && (
                     <div className={'f-status ' + (canFollowUp ? 'followup' : 'done')}>
-                      {canFollowUp
-                        ? `↻ 上一轮已提交 · 本轮复核仍存在,将追发一条复核评论 · inline ${f.file}:${f.line}`
-                        : `已提交 · inline ${f.file}:${f.line}`}
+                      {(canFollowUp
+                        ? '↻ 上一轮已提交 · 本轮复核仍存在,将追发一条复核评论 · '
+                        : '已提交 · ') +
+                        (hasAnchor(f) ? 'inline ' : '摘要内 ') +
+                        findingAnchorText(f)}
                     </div>
                   )}
                   {isStale && !isDismissed && !locked && (

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -256,6 +256,11 @@ export interface Finding {
   body: string;
   file: string;
   line: number;
+  /**
+   * 提交屏把这条从 inline 行评论降级为摘要条目(见 {@link hasAnchor})。
+   * 锚点值本身留着不清 —— 摘要里要写出 `file:line`,失效锚点也还能改回行评论。
+   */
+  anchorDropped: boolean;
   suggestion: string | null;
   triage: Triage;
   /** reviewer 剔除时可选填的理由;复审时注入,让 agent 不再报同类问题 */
@@ -315,6 +320,14 @@ export function findingSuggestion(f: Finding, currentRound: number): string | nu
   // 首行缩进是补丁的一部分(会被逐字替换进代码),只能削首尾空行与行尾空白,不能 trim
   const s = f.suggestion?.replace(/^[ \t]*\n+/, '').replace(/\s+$/, '') ?? '';
   return s || null;
+}
+
+/**
+ * 锚点的人读形式 `file:line`,提交摘要 / 导出 / 提交屏共用。
+ * 行号缺失(存量脱锚数据把行号清成了 0)时只给文件名,别写出 `path:0` 这种假位置。
+ */
+export function findingAnchorText(f: Finding): string {
+  return f.line > 0 ? `${f.file}:${f.line}` : f.file;
 }
 
 export interface Message {

--- a/src/shared/export-markdown.ts
+++ b/src/shared/export-markdown.ts
@@ -4,6 +4,7 @@
  */
 import {
   SEVERITY_EMOJI,
+  findingAnchorText,
   findingNarrative,
   findingSuggestion,
   type Finding,
@@ -67,7 +68,7 @@ function findingBlock(
 ): string {
   const cat = f.category ? ` · ${f.category}` : '';
   let block = `${heading} ${SEVERITY_EMOJI[f.severity]} ${f.severity}${cat} — ${f.title}\n\n`;
-  block += `\`${f.file}:${f.line}\`\n\n`;
+  block += `\`${findingAnchorText(f)}\`\n\n`;
   const narrative = findingNarrative(f, currentRound);
   if (narrative) block += `${narrative}\n\n`;
   const suggestion = findingSuggestion(f, currentRound);
@@ -115,7 +116,7 @@ export function buildReviewMarkdown(
     md += `## 已剔除（${dropped.length}）\n\n`;
     for (const f of dropped) {
       const cat = f.category ? ` · ${f.category}` : '';
-      md += `- ~~${f.title}~~（${f.severity}${cat} · ${f.file}:${f.line}）\n`;
+      md += `- ~~${f.title}~~（${f.severity}${cat} · ${findingAnchorText(f)}）\n`;
     }
     md += '\n';
   }

--- a/src/shared/github-review.ts
+++ b/src/shared/github-review.ts
@@ -4,6 +4,7 @@
  */
 import {
   SEVERITY_EMOJI,
+  findingAnchorText,
   findingNarrative,
   findingSuggestion,
   recheckNote,
@@ -37,8 +38,9 @@ export interface PrReviewPayload {
   comments: PrReviewComment[];
 }
 
-/** finding 是否有可作为 inline 锚点的位置(新侧行号 > 0)。当前模型 finding 恒有锚点。 */
-export const hasAnchor = (f: Finding): boolean => Boolean(f.file) && f.line > 0;
+/** finding 是否作为 inline 行评论提交:有新侧行号,且没被提交屏降级为摘要条目。 */
+export const hasAnchor = (f: Finding): boolean =>
+  Boolean(f.file) && f.line > 0 && !f.anchorDropped;
 
 /** 严重度圆点 + 加粗的「[severity · category] 标题」,inline 与整体意见共用。 */
 function headline(f: Finding): string {
@@ -92,7 +94,12 @@ export function buildPrReviewPayload(
   if (review.summaryBody?.trim()) parts.push(review.summaryBody.trim());
   if (unanchored.length) {
     const lines = unanchored.map((f) => {
-      const block = [followUpLead(f, review.currentRound), findingNarrative(f, review.currentRound)]
+      // 锚点必须写进正文:摘要条目脱离了 inline 的位置,少了 file:line 作者无从判断说的是哪儿。
+      const block = [
+        followUpLead(f, review.currentRound),
+        f.file ? `\`${findingAnchorText(f)}\`` : '',
+        findingNarrative(f, review.currentRound),
+      ]
         .filter(Boolean)
         .join('\n\n');
       const head = `- ${headline(f)}`;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -344,7 +344,10 @@ export interface DuetlensApi {
      * reason 只在剔除时有意义(可选),会注入下一轮复审让 agent 不再报同类问题;恢复时自动清空。
      */
     setTriage(reviewId: string, findingId: string, triage: Triage, reason?: string | null): Promise<Finding>;
-    /** 改一条 finding 的行锚点(提交屏修 422 失效锚点):line>0 改锚,line=0 脱锚(降级为摘要)。 */
+    /**
+     * 改一条 finding 的行锚点(提交屏修 422 失效锚点):line>0 改锚(并撤销降级),line=0 脱锚
+     * (降级为摘要);脱锚保留原行号,故传回原 line 即可把它改回行评论。
+     */
     setFindingAnchor(reviewId: string, findingId: string, line: number): Promise<Finding>;
     /** 用户手动新增一条锚定 finding(origin=manual),同 agent finding 的 schema/提交路径。 */
     addFinding(reviewId: string, input: AddFindingInput): Promise<Finding>;


### PR DESCRIPTION
Degrading a finding to a summary entry used to clear its anchor line to `0`. The author then got a verdict in the review body with no file and no line — and those entries are usually the off-diff ones, the ones that need pointing at most. Clearing the line also made the degrade irreversible: `nearestLiveLine(file, 0)` can only pick the first live line back.

The drop is now its own column (`anchor_dropped`, migration V14, existing `line = 0` rows backfilled), so the anchor survives it.

- every `整体意见` entry carries `` `file:line` `` under its headline; the export report uses the same helper, so degraded findings no longer render as `path:0`
- a degraded finding can go back to an inline comment — the submit screen offers it on the card
- the submit button counts what actually goes into the summary (`3 行评论 + 摘要(含 1 条)`); those entries were invisible in the label before

`npm run spike:submit` covers the new semantics: the line stays, `hasAnchor` turns false, the body contains the anchor, and passing the line back restores the inline comment.