### PR TITLE
feat(review): fold dismissed findings into their own group

### DIFF
--- a/src/renderer/screens/ReviewScreen.css
+++ b/src/renderer/screens/ReviewScreen.css
@@ -4057,6 +4057,10 @@
 .fg-toggle .fg-folded.wontfix {
   color: var(--agent-2);
 }
+/* 剔除是归档不是信号,不给它色相:轮次标记已把整条色轴让出去了 */
+.fg-toggle .fg-folded.dropped {
+  color: var(--text-faint);
+}
 
 .card.finding.resolved {
   opacity: 0.74;

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -809,12 +809,19 @@ function RightPanel({
     () => filtered.filter((f) => isFixedResolved(f, currentRound)),
     [filtered, currentRound],
   );
+  // 「采纳」会把这组的条目转成剔除态,那一刻它就不再等 reviewer 表态,该走剔除组而不是继续占着这里。
   const wontFix = useMemo(
-    () => filtered.filter((f) => isWontFixThisRound(f, currentRound)),
+    () => filtered.filter((f) => isWontFixThisRound(f, currentRound) && f.triage !== 'dismiss'),
+    [filtered, currentRound],
+  );
+  // reviewer 主动剔除的同理:结论已经下了,划着删除线待在严重度分组里只是占位。
+  // 判定已修复的自动剔除除外 —— 那是 agent 的结论,自有一组。
+  const droppedList = useMemo(
+    () => filtered.filter((f) => f.triage === 'dismiss' && !isFixedResolved(f, currentRound)),
     [filtered, currentRound],
   );
   const shown = useMemo(
-    () => filtered.filter((f) => !isSettled(f, currentRound)),
+    () => filtered.filter((f) => !isSettled(f, currentRound) && f.triage !== 'dismiss'),
     [filtered, currentRound],
   );
   // findings 分组:按严重度(high▸low)或按文件;渲染统一走 groups 列表。
@@ -855,8 +862,8 @@ function RightPanel({
     }
     return main;
   }, [shown, grouping, diff]);
-  const kept = shown.filter((f) => f.triage !== 'dismiss').length;
-  const dropped = shown.filter((f) => f.triage === 'dismiss').length;
+  const kept = shown.length;
+  const dropped = droppedList.length;
   const coverage = useMemo(() => {
     let a = 0;
     let d = 0;
@@ -910,7 +917,7 @@ function RightPanel({
               </button>
             </div>
           )}
-          {shown.length === 0 && fixed.length === 0 && wontFix.length === 0 &&
+          {shown.length === 0 && fixed.length === 0 && wontFix.length === 0 && droppedList.length === 0 &&
             (categoryFilter ? (
               <p className="empty-note">无 {categoryFilter} 分类的 findings。</p>
             ) : scanning ? (
@@ -939,7 +946,7 @@ function RightPanel({
                 </div>
               </div>
             ))}
-          {shown.length > 0 && (
+          {kept + dropped > 0 && (
             <div className="fp-toolbar">
               <span className="fp-tally">
                 保留 <b>{kept}</b> · 剔除 {dropped}
@@ -977,6 +984,17 @@ function RightPanel({
           </FoldedGroup>
           {/* 作者已回应的默认展开:这组还等着 reviewer 决定接不接受作者的说法 */}
           <FoldedGroup label="◇ 作者已回应,未改动" tone="wontfix" findings={wontFix} defaultOpen>
+            {(f) => (
+              <FindingRow
+                key={f.id}
+                finding={f}
+                currentRound={currentRound}
+                onPick={onPickFinding}
+                onTriage={onTriage}
+              />
+            )}
+          </FoldedGroup>
+          <FoldedGroup label="✕ 已剔除" tone="dropped" findings={droppedList}>
             {(f) => (
               <FindingRow
                 key={f.id}
@@ -1035,7 +1053,7 @@ function RightPanel({
   );
 }
 
-/** 本轮已有结论的一组 finding:折叠起来不占主列表,标题上带条数。空组不渲染。 */
+/** 已经有结论(agent 判定或 reviewer 剔除)的一组 finding:折叠起来不占主列表,标题上带条数。空组不渲染。 */
 function FoldedGroup({
   label,
   tone,
@@ -1044,7 +1062,7 @@ function FoldedGroup({
   children,
 }: {
   label: string;
-  tone: 'fixed' | 'wontfix';
+  tone: 'fixed' | 'wontfix' | 'dropped';
   findings: Finding[];
   defaultOpen?: boolean;
   children: (f: Finding) => React.ReactNode;
@@ -1127,8 +1145,9 @@ function FindingRow({
           {f.resolutionNote}
         </div>
       )}
-      {/* 「✓ 已修复 · 自动剔除」标签已经说明了为何剔除,不必再拿理由行重复一遍 */}
-      {dismissed && f.dismissReason && !fixedResolved && (
+      {/* 「✓ 已修复 · 自动剔除」标签已经说明了为何剔除;「采纳」则是把作者的说法原样抄成理由。
+          后者只在上面那条复核结论**当前真的渲染着**时才算重复 —— 它随轮次消失,理由行得接着说下去。 */}
+      {dismissed && f.dismissReason && !fixedResolved && (!resolution || f.dismissReason !== f.resolutionNote) && (
         <div className="fr-note reason">理由:{f.dismissReason}</div>
       )}
       <div className="fr-foot">


### PR DESCRIPTION
A dismissed finding is a finding you are done with, the same as one the recheck closed as fixed — but only the latter got a folded group. Dismissed ones stayed in their severity/file bucket wearing a strikethrough, so the HIGH group kept counting decisions you had already made.

They now go to a `✕ 已剔除` group at the bottom, collapsed by default, next to the two that were already there. The `保留 N · 剔除 M` tally above the list is unchanged and doubles as the signpost to it; the per-row `↩ 恢复` is the way back out. The group label is `--text-faint` rather than a red — the CSS already decided that the round axis stays out of the hue competition, and a dismissal is an archive, not a signal.

Inline cards in the diff column are untouched: they are anchored to code lines, and aggregating them would throw away the anchor.

The four buckets are now a disjoint partition instead of an `isSettled` fallthrough:

```
fixed    = dismiss &&  isFixedResolved   // agent's call, its own group
dropped  = dismiss && !isFixedResolved   // yours, including 「采纳」
wontFix  = wont_fix && !dismiss          // only what still needs your word
shown    = the rest
```

That fixes a pre-existing misfiling this change surfaced: `✓ 采纳` sets `triage` to `dismiss`, but the item kept sitting in `◇ 作者已回应,未改动` — a group that is default-open precisely because it is waiting on you, when there was nothing left to wait for.

Two rendering details around the reason line, both from `采纳` copying `resolutionNote` verbatim into `dismissReason`:

- The two identical sentences printed one under the other. The reason line is now suppressed when it repeats the resolution note.
- That suppression must key on whether the resolution note is *currently rendered*, not on the strings matching. `currentResolution` returns null once `lastSeenRound` falls behind, so on the next round the note disappears on its own — a plain equality test would have taken the reason line with it and left the row with no stated grounds at all.

Verified in `preview:ui` against the fixture, in both themes: 采纳 empties the wontfix group and moves the row into 已剔除 with the note printed once; 恢复 puts it back and restores the tally; running round 3 drops the resolution note and the reason line takes over. The row with its own hand-written reason and no resolution note keeps showing it throughout, so the dedup is not over-reaching.

One thing deliberately left alone: an accepted finding that was already submitted keeps its green `.submitted` border inside the 已剔除 group instead of the dashed dismissed styling. `.submitted` outranking `.dismissed` predates this change, and "this one did reach the PR" is real information worth keeping on screen.
