### PR TITLE
feat(export): let github-pr reviews export a markdown report

### DIFF
--- a/docs/design/findings-submit.md
+++ b/docs/design/findings-submit.md
@@ -67,11 +67,20 @@ GitHub 的 422 只说整份被拒、**不告知是哪条**,得由我们自己指
 
 口径与 review 屏一致:只有表态轮次 === 当前轮次才算本轮结论。`wont_fix` 不走这条 —— 那条说明是作者的原话,不是对问题的重新描述。
 
-## 非 GitHub source:导出 Markdown
+## 导出 Markdown
 
-`local-branch` / `gitbutler-vbranch` 无 PR 可提交,顶栏 CTA 换成「导出 review」。同一条 triage 管线,终点从「提交到 GitHub」换成「生成一份 Markdown 报告」。
+同一条 triage 管线的另一个终点:把保留项渲染成一份 Markdown 报告。`local-branch` / `gitbutler-vbranch` 无 PR 可提交,这是它们唯一的终点,顶栏 CTA 直接换成「导出 review」。
 
 - **布局倒置**:导出屏以**报告本身为主场** —— 左侧宽栏是实时预览(渲染 / 源码可切),右侧窄栏是配置。对照 submit 屏的「左筛选 / 右 finish」。
 - **包含项开关**(suggestion 代码块 / 已剔除项)与分组(按严重度 | 按文件)**实时改写预览与将导出的内容**,所见即所得 —— Markdown 由数据模型实时生成,保证预览 = 复制 = 保存。
 - **无 event 选择**:`Comment / Request changes / Approve` 是 GitHub review 概念,导出屏不涉及。
 - 保存经 Electron 原生保存对话框写本地文件。
+
+### github-pr 也能导出:两个并列终点
+
+存档、贴周报、发到 PR 之外的地方,与「发给作者」是两件事,提交并不覆盖它。故 `github-pr` 下两个终点在同一屏里以顶栏分段并列,共享同一份 findings 与 triage;**两块屏同时挂载、只藏不卸** —— 提交屏里写到一半的 Review 意见、422 后按最新 diff 定位到的失效锚点都不该因为切过去看一眼报告就没了。
+
+- **提交状态进报告**:作者是否已经在 PR 上看到过这条,是读报告的人最先要分辨的事,故每条标 `✓ 已提交` / `待提交` / 追评。非 GitHub source 不写(恒为一格空标)。
+- **范围开关**(全部保留项 | 仅未提交):后者与提交屏的待提交集同口径,用于「这些发不到 GitHub,贴到别处去」。
+- **已提交项在导出屏同样锁定**:从这里改 triage 会把作者已收到的评论从待提交集里抹掉。欠一条复核追评的除外 —— 那条发不发仍是 reviewer 的决定。
+- 文件名取 PR 号(`review-pr-123.md`):PR 标题常是中文,走 slug 会被清成空串、落成同一个 `review-export.md`。

--- a/scripts/spike-submit.ts
+++ b/scripts/spike-submit.ts
@@ -214,6 +214,45 @@ async function main() {
     log('invalid 不改状态 ok');
   }
 
+  // ---- 并发提交:同一 review 只放行一份(第二次不得再 POST 一遍同样的评论)----
+  {
+    const db = openDatabase(':memory:');
+    const store = new ReviewStore(db);
+    const { review, f1 } = seed(store);
+    // 提交挂在这里不返回,模拟「gh 还没回、submitted 还没落库」的那段窗口
+    let release!: () => void;
+    const inFlight = new Promise<void>((r) => (release = r));
+    let posts = 0;
+    const slow: GitHubSubmitter = {
+      async submit() {
+        posts += 1;
+        // 只挂住第一份:两份都挂的话,守卫一旦失灵第二份就死等,main 停在这里静默退出 0 ——
+        // 那是「测试没跑完」,却看着像通过。放行第二份,断言才有机会红。
+        if (posts === 1) await inFlight;
+        return { status: 'success', url: 'https://gh/x#r1', submittedCount: 2 };
+      },
+    };
+    const manager = new ReviewManager(store, undefined, { submitter: slow });
+
+    const first = manager.submitReview(review.id, { event: 'comment', body: '第一次' });
+    await Promise.resolve(); // 让第一份真正走到 submitter
+    // 屏卸载再进来会从 sub='ready' 重来,所以这一次点击在 UI 上完全合法 —— 得由后端拦
+    const second = await manager.submitReview(review.id, { event: 'comment', body: '重复点的' });
+    assert.equal(second.status, 'failed', '在途时的第二次提交要被拒');
+    assert.match(second.message, /正在提交中/);
+    assert.equal(posts, 1, '只能有一份真的发出去');
+    assert.equal(store.getFinding(f1.id)!.submission, 'unsubmitted', '被拒的那次不改任何状态');
+
+    release();
+    assert.equal((await first).status, 'success');
+    assert.equal(posts, 1);
+    assert.equal(store.getFinding(f1.id)!.submission, 'submitted');
+    // 锁在 finally 里释放:第一份结束后这条 review 还能正常再提交(增量/追评)
+    const later = await manager.submitReview(review.id, { event: 'comment', body: '结束后再补一句' });
+    assert.equal(later.status, 'success', '在途锁必须随请求结束释放');
+    log('并发提交:在途只放行一份 + 结束后解锁 ok');
+  }
+
   // ---- 非 github source:拒绝提交 ----
   {
     const db = openDatabase(':memory:');

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -172,6 +172,8 @@ export class ReviewManager extends EventEmitter {
   private shuttingDown = false;
   /** GitHub 提交层;可注入(spike 用假实现,不烧真 PR)。 */
   private readonly submitter: GitHubSubmitter;
+  /** 正在提交的 review;PR review 是原子提交,并发两份就是把同一批评论发给作者两遍。 */
+  private readonly submitting = new Set<string>();
 
   constructor(
     private readonly store: ReviewStore,
@@ -574,24 +576,35 @@ export class ReviewManager extends EventEmitter {
     if (review.source !== 'github-pr') {
       return { status: 'failed', message: '仅 github-pr source 可提交到 GitHub;本地/vbranch 请用导出。' };
     }
-    const pending = this.store.listFindings(reviewId).filter((f) => isSubmittable(f, review.currentRound));
-
-    // 无 finding 也可提交:Comment/Approve/Request changes 本身就是表态
-    const payload = buildPrReviewPayload(review, pending, input.event, input.body ?? '');
-    const blocked = submitBlocker(payload);
-    if (blocked) return { status: 'failed', message: blocked };
-    const result = await this.submitter.submit(review, payload);
-
-    if (result.status === 'success') {
-      for (const f of pending) {
-        this.store.setSubmission(f.id, 'submitted', result.url, review.currentRound);
-        const updated = this.store.getFinding(f.id);
-        if (updated) this.forward({ reviewId, type: 'finding', payload: updated });
-      }
-      this.store.setReviewStatus(reviewId, 'submitted');
-      this.forward({ reviewId, type: 'status', payload: 'submitted' });
+    // 待提交集在请求发出前就定稿,`submitted` 要等 gh 返回才落库 —— 这段窗口里再进来一次,
+    // 读到的是同一份 pending,于是同样的评论发第二遍。守在这里而不是屏上:提交在途照样能
+    // 离开提交屏(顶栏返回、rail 导航),屏一卸载本地的 in-flight 状态就没了。
+    if (this.submitting.has(reviewId)) {
+      return { status: 'failed', message: '这条 review 正在提交中,等它结束再试(别重复发给作者)。' };
     }
-    return result;
+    this.submitting.add(reviewId);
+    try {
+      const pending = this.store.listFindings(reviewId).filter((f) => isSubmittable(f, review.currentRound));
+
+      // 无 finding 也可提交:Comment/Approve/Request changes 本身就是表态
+      const payload = buildPrReviewPayload(review, pending, input.event, input.body ?? '');
+      const blocked = submitBlocker(payload);
+      if (blocked) return { status: 'failed', message: blocked };
+      const result = await this.submitter.submit(review, payload);
+
+      if (result.status === 'success') {
+        for (const f of pending) {
+          this.store.setSubmission(f.id, 'submitted', result.url, review.currentRound);
+          const updated = this.store.getFinding(f.id);
+          if (updated) this.forward({ reviewId, type: 'finding', payload: updated });
+        }
+        this.store.setReviewStatus(reviewId, 'submitted');
+        this.forward({ reviewId, type: 'status', payload: 'submitted' });
+      }
+      return result;
+    } finally {
+      this.submitting.delete(reviewId);
+    }
   }
 
   /** 清空一条 discussion 的往来消息(finding 卡与锚点保留),便于重新讨论。 */

--- a/src/renderer/screens/SubmitExportScreen.css
+++ b/src/renderer/screens/SubmitExportScreen.css
@@ -1,0 +1,43 @@
+/* github-pr 的两个终点(提交 / 导出)在同一屏内切换的外壳。 */
+.se-pane {
+  height: 100%;
+  min-height: 0;
+}
+/* 屏根用了 display:grid,会盖掉 hidden 的 UA 样式 —— 藏不住就是两块屏叠着渲染 */
+.se-pane[hidden] {
+  display: none;
+}
+
+/* 顶栏分段:占位与两块屏原本的面包屑一致 */
+.se-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2px;
+}
+.se-tabs button {
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11.5px;
+  padding: 4px 12px;
+}
+.se-tabs button:hover {
+  color: var(--text);
+}
+.se-tabs button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.se-tabs button:disabled:hover {
+  color: var(--text-dim);
+}
+.se-tabs button.on {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 0 0 1px var(--agent-line) inset;
+}

--- a/src/renderer/screens/SubmitExportScreen.tsx
+++ b/src/renderer/screens/SubmitExportScreen.tsx
@@ -1,13 +1,14 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import type { Finding } from '@shared/domain';
 import { useReviewStream } from '../review/useReviewStream';
 import { ExportMarkdownScreen } from './export/ExportMarkdownScreen';
 import { SubmitGitHubScreen } from './submit/SubmitGitHubScreen';
 import { ScreenPlaceholder } from '../components/ScreenPlaceholder';
+import './SubmitExportScreen.css';
 
 /**
- * review 的终点步骤:github-pr source 走「提交到 GitHub」(待做),
- * 本地/vbranch source 走「导出 Markdown」。按 review.source 分派。
+ * review 的终点步骤:github-pr 有两个并列终点(提交到 GitHub / 导出 Markdown),顶栏分段切换;
+ * 本地/vbranch 无 PR 可提交,只有导出。
  */
 export function SubmitExportScreen({
   reviewId,
@@ -17,15 +18,18 @@ export function SubmitExportScreen({
   onBack: () => void;
 }) {
   const { review, findings } = useReviewStream(reviewId);
+  const [tab, setTab] = useState<'submit' | 'export'>('submit');
+  // 提交在途:待提交集已在后端定稿,这期间任何改 triage 的入口都得冻住
+  const [submitting, setSubmitting] = useState(false);
 
   const onToggleKeep = useCallback(
     (f: Finding) => {
-      if (!reviewId) return;
+      if (!reviewId || submitting) return;
       // 保留 → dismiss;已剔除 → keep(复位到明确保留态,不回 open)
       const next = f.triage === 'dismiss' ? 'open' : 'dismiss';
       void window.duetlens.review.setTriage(reviewId, f.id, next);
     },
-    [reviewId],
+    [reviewId, submitting],
   );
 
   if (!reviewId || !review) {
@@ -39,7 +43,49 @@ export function SubmitExportScreen({
   }
 
   if (review.source === 'github-pr') {
-    return <SubmitGitHubScreen review={review} findings={findings} onBack={onBack} />;
+    const tabs = (
+      <div className="se-tabs">
+        <button
+          className={tab === 'submit' ? 'on' : ''}
+          onClick={() => setTab('submit')}
+          disabled={submitting}
+        >
+          提交到 GitHub
+        </button>
+        <button
+          className={tab === 'export' ? 'on' : ''}
+          onClick={() => setTab('export')}
+          disabled={submitting}
+          title={submitting ? '提交进行中,结束后可切换' : undefined}
+        >
+          导出 Markdown
+        </button>
+      </div>
+    );
+    /* 两块都挂着、只藏不卸:提交屏里有写到一半的 Review 意见、422 后定位到的失效锚点、
+       现拉的最新 diff —— 切过去看一眼报告再切回来,这些不该没了(重挂还会再拉一次 PR)。 */
+    return (
+      <>
+        <div className="se-pane" hidden={tab !== 'submit'}>
+          <SubmitGitHubScreen
+            review={review}
+            findings={findings}
+            onBack={onBack}
+            tabs={tabs}
+            onBusyChange={setSubmitting}
+          />
+        </div>
+        <div className="se-pane" hidden={tab !== 'export'}>
+          <ExportMarkdownScreen
+            review={review}
+            findings={findings}
+            onBack={onBack}
+            onToggleKeep={onToggleKeep}
+            tabs={tabs}
+          />
+        </div>
+      </>
+    );
   }
 
   return (

--- a/src/renderer/screens/export/ExportMarkdownScreen.css
+++ b/src/renderer/screens/export/ExportMarkdownScreen.css
@@ -427,6 +427,26 @@
 .ck-item.off .t {
   text-decoration: line-through;
 }
+/* 已提交到 GitHub:勾选锁定(与提交屏同一语义),不给可点的手感 */
+.ck-item.locked {
+  cursor: default;
+}
+.ck-item.locked:hover {
+  background: transparent;
+}
+.ck-item.locked .ck {
+  background: var(--surface-3);
+  border-color: var(--border);
+  color: var(--text-faint);
+}
+.ck-item .sub-flag {
+  flex: none;
+  font-size: 10px;
+  color: var(--text-faint);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 1px 5px;
+}
 
 .cfg-foot {
   border-top: 1px solid var(--border);

--- a/src/renderer/screens/export/ExportMarkdownScreen.tsx
+++ b/src/renderer/screens/export/ExportMarkdownScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import type { Finding, Review } from '@shared/domain';
 import {
   buildReviewMarkdown,
@@ -7,6 +7,7 @@ import {
   DEFAULT_EXPORT_OPTIONS,
   type ExportOptions,
 } from '@shared/export-markdown';
+import { isSubmittable, needsRecheckFollowUp } from '@shared/github-review';
 import { renderMarkdown } from './markdown';
 import './ExportMarkdownScreen.css';
 
@@ -18,10 +19,14 @@ interface Props {
   onBack: () => void;
   /** 切换某条 finding 的保留/剔除(经 setTriage 落库);同 diff-review triage 管线。 */
   onToggleKeep: (finding: Finding) => void;
+  /** 终点切换分段(github-pr 才有);给了就顶掉面包屑。 */
+  tabs?: ReactNode;
 }
 
 // 左预览(渲染/源码)+ 右导出配置。
-export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep }: Props) {
+export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep, tabs }: Props) {
+  const isGithub = review.source === 'github-pr';
+  const round = review.currentRound;
   const [opts, setOpts] = useState<ExportOptions>(DEFAULT_EXPORT_OPTIONS);
   const [mode, setMode] = useState<'rendered' | 'raw'>('rendered');
   const [copied, setCopied] = useState(false);
@@ -33,6 +38,7 @@ export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep }:
 
   const keptCount = findings.filter(isKept).length;
   const dropCount = findings.length - keptCount;
+  const pendingCount = findings.filter((f) => isSubmittable(f, round)).length;
 
   const toggleOpt = (key: keyof ExportOptions) =>
     setOpts((o) => ({ ...o, [key]: !o[key] } as ExportOptions));
@@ -62,12 +68,14 @@ export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep }:
           ← 返回 diff
         </button>
         <span className="src-chip">
-          <span className="ic">⎇</span> {review.title ?? review.sourceRef}
+          <span className="ic">⎇</span> {isGithub ? 'GitHub' : (review.title ?? review.sourceRef)}
           <b>{review.sourceRef}</b>
         </span>
-        <span className="crumb">
-          Review · <b>导出 Markdown</b>
-        </span>
+        {tabs ?? (
+          <span className="crumb">
+            Review · <b>导出 Markdown</b>
+          </span>
+        )}
       </div>
 
       <div className="exp-main">
@@ -101,10 +109,34 @@ export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep }:
         <div className="pane config">
           <div className="cfg-head">
             <div className="t">↓ 导出为 Markdown</div>
-            <div className="s">本地分支无 PR 可提交,把这次 review 导出成一份报告,用于分享 / 存档 / 贴到别处。</div>
+            <div className="s">
+              {isGithub
+                ? '把这次 review 导出成一份报告,用于分享 / 存档 / 贴到别处;发给 PR 作者走「提交到 GitHub」。'
+                : '本地分支无 PR 可提交,把这次 review 导出成一份报告,用于分享 / 存档 / 贴到别处。'}
+            </div>
           </div>
 
           <div className="cfg-body">
+            {isGithub && (
+              <>
+                <div className="sec-lbl">范围</div>
+                <div className="grp-seg">
+                  <button
+                    className={opts.scope === 'all' ? 'on' : ''}
+                    onClick={() => setOpts((o) => ({ ...o, scope: 'all' }))}
+                  >
+                    全部保留项 {keptCount}
+                  </button>
+                  <button
+                    className={opts.scope === 'pending' ? 'on' : ''}
+                    onClick={() => setOpts((o) => ({ ...o, scope: 'pending' }))}
+                  >
+                    仅未提交 {pendingCount}
+                  </button>
+                </div>
+              </>
+            )}
+
             <div className="sec-lbl">包含内容</div>
             <label className={'opt' + (opts.suggestion ? ' on' : '')} onClick={() => toggleOpt('suggestion')}>
               <span className="sw" />
@@ -139,15 +171,20 @@ export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep }:
             <div className="ck-list">
               {findings.map((f) => {
                 const kept = isKept(f);
+                // 已提交即锁定,与提交屏同一判据 —— 从这里改 triage 会把作者已收到的评论
+                // 从待提交集里抹掉(欠一条复核追评的除外,那条发不发仍是 reviewer 的决定)
+                const locked = isGithub && f.submission === 'submitted' && !needsRecheckFollowUp(f, round);
                 return (
                   <div
                     key={f.id}
-                    className={'ck-item' + (kept ? ' on' : ' off')}
-                    onClick={() => onToggleKeep(f)}
+                    className={'ck-item' + (kept ? ' on' : ' off') + (locked ? ' locked' : '')}
+                    onClick={() => !locked && onToggleKeep(f)}
+                    title={locked ? '已提交到 GitHub · 锁定' : undefined}
                   >
                     <span className="ck">✓</span>
                     <span className={`dot ${SEV_DOT[f.severity]}`} />
                     <span className="t">{f.title}</span>
+                    {locked && <span className="sub-flag">已提交</span>}
                     <span className="an">
                       {f.file}:{f.line}
                     </span>

--- a/src/renderer/screens/submit/SubmitGitHubScreen.css
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.css
@@ -650,6 +650,10 @@ textarea.summary {
   resize: vertical;
   outline: none;
 }
+textarea.summary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 textarea.summary:focus {
   border-color: var(--agent-line);
 }
@@ -658,6 +662,11 @@ textarea.summary:focus {
   flex-direction: column;
   gap: 8px;
   margin: 0 0 6px;
+}
+/* 提交在途:表态已随 payload 发出,改不动了 */
+.events.frozen {
+  pointer-events: none;
+  opacity: 0.55;
 }
 .event {
   display: flex;

--- a/src/renderer/screens/submit/SubmitGitHubScreen.tsx
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   findingAnchorText,
   findingNarrative,
@@ -48,12 +48,18 @@ interface Props {
   review: Review;
   findings: Finding[];
   onBack: () => void;
+  /** 终点切换分段(github-pr 有导出这个并列终点);给了就顶掉面包屑。 */
+  tabs?: ReactNode;
+  /** 提交在途时上报,好让外壳一并冻住屏外那些能改 triage 的入口。 */
+  onBusyChange?: (busy: boolean) => void;
 }
 
 // 左 findings 筛选 + 右 Finish your review。
-export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
+export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChange }: Props) {
   const reviewId = review.id;
   const [event, setEvent] = useState<GhReviewEvent>('comment');
+  /** 实际发出去的那次表态;结果 banner 只能说这一个,否则事后改选框会让它改口。 */
+  const [sentEvent, setSentEvent] = useState<GhReviewEvent | null>(null);
   const [sub, setSub] = useState<SubState>('ready');
   const [result, setResult] = useState<SubmitReviewResult | null>(null);
   // reviewer 手填的 review 意见:只属于这一次提交,不落库、也不取 agent 的总结
@@ -101,6 +107,9 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
   const staleList = useMemo(() => findings.filter((f) => staleIds.has(f.id)), [findings, staleIds]);
   const reAnchorableCount = staleList.filter((f) => nearestLiveLine(f.file, f.line, diff) != null).length;
 
+  // 派生上报而非在 submit() 里逐条路径手动置位:那样每加一条 return 就漏一次解冻
+  useEffect(() => onBusyChange?.(sub === 'submitting'), [sub, onBusyChange]);
+
   // 进屏即在后台核对一次 PR 最新状态:失效锚点应在提交被拒之前就摆到用户面前。
   const checkedOnce = useRef(false);
   useEffect(() => {
@@ -118,12 +127,24 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
     return (f: Finding) => byKey.get(`${f.file}:${f.line}`);
   }, [diff]);
 
-  const degradeToSummary = (f: Finding) => void window.duetlens.review.setFindingAnchor(reviewId, f.id, 0);
+  /**
+   * 提交在途:后端已按调用那一刻的 findings / event / body 组好 payload 并在发了,
+   * 此后任何改动都进不了这一份,只会让屏上的锚点、正文、表态与 GitHub 上的实际结果对不上。
+   * 三个写锚点的原语与 triage 一起在此拦掉,批量入口走它们、无需各自再挡一遍。
+   */
+  const busy = sub === 'submitting';
+
+  const degradeToSummary = (f: Finding) => {
+    if (busy) return;
+    void window.duetlens.review.setFindingAnchor(reviewId, f.id, 0);
+  };
   /** 撤销降级:行号在降级时留着没清,原样传回即恢复为行评论。 */
   const restoreAnchor = (f: Finding) => {
-    if (f.line > 0) void window.duetlens.review.setFindingAnchor(reviewId, f.id, f.line);
+    if (busy || f.line <= 0) return;
+    void window.duetlens.review.setFindingAnchor(reviewId, f.id, f.line);
   };
   const reAnchor = (f: Finding) => {
+    if (busy) return;
     const line = nearestLiveLine(f.file, f.line, diff);
     if (line != null) void window.duetlens.review.setFindingAnchor(reviewId, f.id, line);
   };
@@ -133,6 +154,7 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
   const degradeAllInline = () => pending.filter(hasAnchor).forEach(degradeToSummary);
 
   const toggleKeep = (f: Finding) => {
+    if (busy) return;
     // 已提交即锁定;唯一例外是欠一条复核追评的,用户仍可决定这条追评发不发
     if (f.submission === 'submitted' && !needsRecheckFollowUp(f, round)) return;
     void window.duetlens.review.setTriage(reviewId, f.id, f.triage === 'dismiss' ? 'open' : 'dismiss');
@@ -145,8 +167,9 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
   );
 
   const submit = async () => {
-    if (blocked || sub === 'submitting') return;
+    if (blocked || busy) return;
     setSub('submitting');
+    setSentEvent(event);
     const res = await window.duetlens.review.submit(reviewId, { event, body });
     setResult(res);
     setSub(res.status);
@@ -192,9 +215,11 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
         <span className="pr-chip">
           <span className="gh">⎇ GitHub</span> <b>{review.sourceRef}</b>
         </span>
-        <span className="crumb">
-          Review · <b>提交 findings</b>
-        </span>
+        {tabs ?? (
+          <span className="crumb">
+            Review · <b>提交 findings</b>
+          </span>
+        )}
       </div>
 
       <div className="sg-main">
@@ -386,7 +411,10 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
               <span className="bi">✓</span>
               <div className="bt">
                 <b>review 已提交</b> ·{' '}
-                {result.submittedCount > 0 ? `${result.submittedCount} 行评论 + 摘要` : EVENT_META[event].label} ·{' '}
+                {result.submittedCount > 0
+                  ? `${result.submittedCount} 行评论 + 摘要`
+                  : EVENT_META[sentEvent ?? event].label}{' '}
+                ·{' '}
                 <a href={result.url} target="_blank" rel="noreferrer">
                   在 GitHub 查看 ↗
                 </a>
@@ -437,10 +465,12 @@ export function SubmitGitHubScreen({ review, findings, onBack }: Props) {
               onChange={(e) => setBody(e.target.value)}
               placeholder="可选 · 你写给作者的话(agent 的总结不会发出去)"
               rows={5}
+              disabled={busy}
             />
 
             <div className="field-lbl mt">提交类型</div>
-            <div className="events">
+            {/* 正文与表态同样已随 payload 发出:在途改它们只会让屏上写的与 GitHub 上的对不上 */}
+            <div className={'events' + (busy ? ' frozen' : '')}>
               {GH_REVIEW_EVENTS.map((ev) => {
                 const m = EVENT_META[ev];
                 return (

--- a/src/shared/export-markdown.ts
+++ b/src/shared/export-markdown.ts
@@ -1,5 +1,6 @@
 /**
- * 把一次 review 的保留 findings 生成一份 Markdown 报告(本地/vbranch source 的终点)。
+ * 把一次 review 的保留 findings 生成一份 Markdown 报告(任何 source 都可导出;
+ * github-pr 下它与「提交到 GitHub」并列,用于存档 / 分享,不替代提交)。
  * 刻意不含 agent 的总结与重点关注文件:那两样是给 reviewer 在 app 里判断用的,
  * 报告是他要发出去的东西,内容该由他自己定。
  * 纯函数:仅依赖入参,便于单测与「预览=复制=保存」内容一致。见 docs/design/findings-submit.md。
@@ -14,6 +15,7 @@ import {
   type Severity,
   type SourceKind,
 } from './domain';
+import { isSubmittable, needsRecheckFollowUp } from './github-review';
 
 export interface ExportOptions {
   /** 含 suggestion 代码块(渲染为 ```suggestion,GitHub 外无一键采纳但保留格式) */
@@ -21,12 +23,18 @@ export interface ExportOptions {
   /** 末尾以删除线列出已剔除项 */
   dismissed: boolean;
   group: 'severity' | 'file';
+  /**
+   * 导出哪些保留项:全部,或只要还没发到 GitHub 的那批(与提交屏的待提交集同口径)。
+   * 仅 github-pr 有区别 —— 其余 source 没有提交这一步,两者恒等。
+   */
+  scope: 'all' | 'pending';
 }
 
 export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
   suggestion: true,
   dismissed: false,
   group: 'severity',
+  scope: 'all',
 };
 
 const SEV_RANK: Record<Severity, number> = { high: 0, medium: 1, low: 2 };
@@ -46,6 +54,13 @@ const isoDate = (ms: number) => new Date(ms).toISOString().slice(0, 10);
 
 /** 报告文件名:review-<分支/PR slug>.md */
 export function exportFileName(review: Review): string {
+  // PR 标题常是中文,走 slug 会被清成空串、落成同一个 review-export.md;PR 号才是稳定标识。
+  // 三条口径对齐 source 侧的 parsePrRef:完整 URL / owner/repo#123 / 纯号(仓库靠 repoPath 推断)
+  if (review.source === 'github-pr') {
+    const ref = (review.sourceRef ?? '').trim();
+    const num = /(?:#|\/pull\/)(\d+)/.exec(ref)?.[1] ?? /^(\d+)$/.exec(ref)?.[1];
+    if (num) return `review-pr-${num}.md`;
+  }
   const raw = review.title ?? review.sourceRef ?? review.id;
   const slug = raw
     .toLowerCase()
@@ -56,18 +71,25 @@ export function exportFileName(review: Review): string {
 }
 
 /**
+ * 提交状态标注。作者是否已经在 PR 上看到过这条,是读报告的人最先要分辨的事;
+ * 非 github source 没有提交这一步,不写(否则每条后面挂一个恒为「待提交」的空标)。
+ */
+function submissionNote(f: Finding, review: Review): string | null {
+  if (review.source !== 'github-pr') return null;
+  if (needsRecheckFollowUp(f, review.currentRound)) return '↻ 上一轮已提交 · 本轮复核仍存在';
+  return f.submission === 'submitted' ? '✓ 已提交' : '待提交';
+}
+
+/**
  * 单条 finding 块;heading 为 finding 标题所用的 markdown 级别(分组下降一级)。
  * 与 GitHub 提交同一口径:本轮复核判定仍存在的,正文取复核说明、首轮 suggestion 一并作废。
  */
-function findingBlock(
-  f: Finding,
-  opts: ExportOptions,
-  heading: string,
-  currentRound: number,
-): string {
+function findingBlock(f: Finding, opts: ExportOptions, heading: string, review: Review): string {
+  const currentRound = review.currentRound;
   const cat = f.category ? ` · ${f.category}` : '';
   let block = `${heading} ${SEVERITY_EMOJI[f.severity]} ${f.severity}${cat} — ${f.title}\n\n`;
-  block += `\`${findingAnchorText(f)}\`\n\n`;
+  const note = submissionNote(f, review);
+  block += `\`${findingAnchorText(f)}\`${note ? ` · ${note}` : ''}\n\n`;
   const narrative = findingNarrative(f, currentRound);
   if (narrative) block += `${narrative}\n\n`;
   const suggestion = findingSuggestion(f, currentRound);
@@ -82,16 +104,17 @@ export function buildReviewMarkdown(
   findings: Finding[],
   opts: ExportOptions = DEFAULT_EXPORT_OPTIONS,
 ): string {
-  const kept = findings.filter(isKept);
+  const pendingOnly = opts.scope === 'pending';
+  const kept = findings.filter((f) => (pendingOnly ? isSubmittable(f, review.currentRound) : isKept(f)));
   const dropped = findings.filter((f) => !isKept(f));
   const title = review.title ?? review.sourceRef ?? review.id;
 
   let md = `# Review — ${title}\n\n`;
   md += `> Duetlens · ${SOURCE_LABEL[review.source]} · \`${review.sourceRef}\` · ${isoDate(review.createdAt)}\n\n`;
 
-  md += `## Findings（保留 ${kept.length}）\n\n`;
+  md += `## Findings（${pendingOnly ? '待提交' : '保留'} ${kept.length}）\n\n`;
   if (kept.length === 0) {
-    md += '_没有保留任何 finding。_\n\n';
+    md += pendingOnly ? '_没有待提交的 finding。_\n\n' : '_没有保留任何 finding。_\n\n';
   } else if (opts.group === 'file') {
     const byFile = new Map<string, Finding[]>();
     for (const f of [...kept].sort(bySeverity)) {
@@ -101,10 +124,10 @@ export function buildReviewMarkdown(
     }
     for (const [file, list] of byFile) {
       md += `### ${file}\n\n`;
-      for (const f of list) md += findingBlock(f, opts, '####', review.currentRound);
+      for (const f of list) md += findingBlock(f, opts, '####', review);
     }
   } else {
-    for (const f of [...kept].sort(bySeverity)) md += findingBlock(f, opts, '###', review.currentRound);
+    for (const f of [...kept].sort(bySeverity)) md += findingBlock(f, opts, '###', review);
   }
 
   if (opts.dismissed && dropped.length) {


### PR DESCRIPTION
Exporting was wired to the source kind: `github-pr` got "submit to GitHub", everything else got "export a Markdown report". But archiving a review, pasting it into a weekly note, or sending it anywhere other than the PR is a different act from sending it to the author — submitting never covered it. Both terminals now sit side by side under a segmented control in the submit/export screen's top bar, sharing one set of findings and one triage pipeline. Local and vbranch sources are untouched: still a breadcrumb, still export-only.

Both panes stay mounted, hidden rather than unmounted. The submit screen holds a half-written review body, the stale anchors located from a freshly pulled diff after a 422, and the diff itself — switching over to glance at the report and back should not throw those away, and a remount would re-fetch the PR.

The report gained what a PR review has and a branch does not:

- Each finding is tagged `✓ 已提交` / `待提交` / recheck follow-up. Whether the author has already seen an item is the first thing a reader of the report needs to tell apart. Non-GitHub sources print no tag rather than one that always reads the same.
- A scope switch, `全部保留项` | `仅未提交`, the latter matching the submit screen's pending set — for "these did not make it to GitHub, they go somewhere else".
- Submitted findings are locked in the export screen's checklist too, on the same predicate as the submit screen. Changing triage from there would erase an item the author already received from the pending set. The exception stays the one that owes a recheck follow-up: whether to send that is still the reviewer's call.
- The file name takes the PR number (`review-pr-482.md`), covering all three ref shapes `parsePrRef` accepts. PR titles are usually Chinese, and the slug path strips them to an empty string, so every export landed on the same `review-export.md`.

`buildReviewMarkdown` was already source-agnostic, so the backend needed nothing for the feature itself. It did need one thing for a bug this surfaced: an in-flight submit could be duplicated. The pending set is frozen before the request goes out and `submitted` is only written once `gh` returns, so a second call inside that window reads the same pending set and sends the same comments again. Leaving the submit screen mid-flight (top-bar back, rail navigation) unmounts it, and re-entering starts from `ready`, which makes that second click perfectly legal on screen. `ReviewManager` now serializes by `reviewId` and rejects the concurrent one; guarding in the renderer would mean chasing every navigation entry point, and the local in-flight state is gone the moment the screen unmounts anyway.

Anything that feeds the payload is frozen while a submit is in flight — triage, the three anchor primitives (the bulk actions route through them), the review body, and the event radios. None of it can reach the request that is already out; it can only make the screen disagree with what landed on GitHub. The success banner reads the event captured at submit time rather than the live one, because that mismatch outlives the in-flight window: after success the radios are editable again, and the banner would have changed its story about what was sent.

Verified in `preview:ui` against the fixture, both themes: the tab switch preserves the submit draft; scope `仅未提交` drops the submitted item from the report while keeping the follow-up; a locked row is a no-op click with `setTriage` never called (idle baseline: called, row flips). For the freeze, `review.submit` was replaced with a never-resolving promise to pin the in-flight state — 3 restore-anchor buttons and 4 checkboxes clicked, `setFindingAnchor`/`setTriage` call count 0 against an idle baseline of 2; switching the event to Approve after success leaves the banner saying Comment. The concurrency guard is covered in `spike:submit` through the public entry point: with the first submit held open, the second is rejected, real POST count stays 1, findings stay `unsubmitted`, and the lock releases so a later submit still succeeds. Removing the guard fails that assertion loudly (`'success'` vs `'failed'`, exit 1) — the fake submitter deliberately holds only the first call, since holding both made the run deadlock and exit 0, which reads as a pass.