### PR TITLE
fix(review): repair the stop-scan path

### DIFF
--- a/scripts/spike-stop-scan.ts
+++ b/scripts/spike-stop-scan.ts
@@ -284,6 +284,34 @@ async function stopWhenAgentGivesNoTurnId(): Promise<() => Promise<void>> {
   return () => f.session.dispose();
 }
 
+/**
+ * 8. 追问排在扫描后面:扫描自然收尾、队里的追问接着开跑,此时按停止 ——
+ * 叫停的对象是**本轮机审**,不能顺手把用户的追问打断、更不能把整轮记成已停止。
+ */
+async function stopDoesNotHitFollowup(): Promise<() => Promise<void>> {
+  const f = fixture({ onInterrupt: async () => undefined });
+  const scan = f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  await new Promise((r) => setTimeout(r, 10));
+
+  // 扫描还在跑时就排一条追问(UI 允许);它要等扫描 turn 收尾才真正发出
+  const discussion = f.store.addUserDiscussion(f.review.id, { file: 'a.ts', line: 1 });
+  const followup = f.session.sendMessage(discussion.id, '这里为什么这么写?');
+  f.agent.emitEvent({ kind: 'turn-completed', turnId: 't1' }); // 扫描自然收尾
+  await scan;
+  await new Promise((r) => setTimeout(r, 10)); // 追问的 turn 起来并认领 t2
+
+  await f.session.stopScan();
+  assert.deepEqual(f.agent.interrupts, [], '扫描已自然收尾,叫停不该去打断用户的追问');
+
+  f.agent.emitEvent({ kind: 'message-delta', text: '因为要复用同一条流。', turnId: 't2' });
+  f.agent.emitEvent({ kind: 'turn-completed', turnId: 't2' });
+  const msg = await followup;
+  assert.equal(msg.role, 'agent', '追问没被殃及,要照常拿到 agent 回复');
+  assert.equal(msg.text, '因为要复用同一条流。');
+  log('✓ 扫描收尾后叫停不殃及队里的追问');
+  return () => f.session.dispose();
+}
+
 async function main(): Promise<void> {
   const cases = [
     failedDuringInterrupt,
@@ -293,6 +321,7 @@ async function main(): Promise<void> {
     deltaWithoutTurnIdStillCounts,
     stopBeforeTurnIdArrives,
     stopWhenAgentGivesNoTurnId,
+    stopDoesNotHitFollowup,
   ];
   for (const t of cases) {
     const dispose = await t();

--- a/scripts/spike-stop-scan.ts
+++ b/scripts/spike-stop-scan.ts
@@ -8,6 +8,10 @@
  * 4. 被叫停那轮**补发**的终局与残余 delta —— 哪怕赶在下一轮 turn/start 应答之前到达,
  *    也不许被追问的等待认领、不许混进追问的回复。
  * 5. delta 不带 turnId(该字段是可选的)—— 归属判不了就得照收,不能把回复吞光。
+ * 6. turn/start 应答还没回来(拿不到 turnId)时按停止 —— 打断点名不到 turn,
+ *    不许谎称已停止(codex 那边还在跑),要如实抛回。
+ * 7. agent 压根不给 turnId —— 与 6 长得一样但等下去也不会有,结论必须不同,
+ *    否则用户被卡在一个永远不成立的「稍等再停」里。
  *   运行:npm run spike:stop-scan
  */
 import { strict as assert } from 'node:assert';
@@ -29,10 +33,16 @@ interface Script {
   onInterrupt: (agent: StubAgent) => Promise<void>;
   /** turn/start 应答返回 turnId 之前做什么 —— 复现「事件早于应答」那段窗口 */
   beforeTurnId?: (agent: StubAgent, turnId: string) => void;
+  /** turn/start 应答挂在这里不返回 —— 复现「turn 已发出、id 还没到手」那段窗口 */
+  holdTurnId?: () => Promise<void>;
+  /** sendMessage 返回空串 —— 接口允许的「这个 agent 不给 turnId」 */
+  emptyTurnId?: boolean;
 }
 
 class StubAgent extends EventEmitter implements ConversationalAgent {
   turn = 0;
+  /** 收到的每次打断:打断点名到哪个 turn 是协议必填项,得断言而不能只看它被调过 */
+  readonly interrupts: { conversationId: string; turnId: string }[] = [];
   constructor(private readonly script: Script) {
     super();
   }
@@ -46,7 +56,8 @@ class StubAgent extends EventEmitter implements ConversationalAgent {
   async sendMessage(): Promise<string> {
     const turnId = `t${++this.turn}`;
     this.script.beforeTurnId?.(this, turnId);
-    return turnId;
+    await this.script.holdTurnId?.();
+    return this.script.emptyTurnId ? '' : turnId;
   }
   emitEvent(e: AgentEvent): void {
     this.emit('event', e);
@@ -55,7 +66,8 @@ class StubAgent extends EventEmitter implements ConversationalAgent {
     this.on('event', handler);
     return () => this.off('event', handler);
   }
-  interrupt(): Promise<void> {
+  interrupt(conversationId: string, turnId: string): Promise<void> {
+    this.interrupts.push({ conversationId, turnId });
     return this.script.onInterrupt(this);
   }
   approve(): void {}
@@ -102,6 +114,11 @@ async function failedDuringInterrupt(): Promise<() => Promise<void>> {
   await f.session.stopScan();
   await scan; // 不该抛:用户按的是「停止」,不是这一轮挂了
   assert.equal(f.session.isStopped(), true, '打断成功即算已停止');
+  assert.deepEqual(
+    f.agent.interrupts,
+    [{ conversationId: 'stub-thread', turnId: 't1' }],
+    '打断要点名到正在跑的那个 turn(turnId 是 codex 的必填项)',
+  );
   assert.notEqual(f.store.getReview(f.review.id)?.status, 'failed', 'review 不该落到失败态');
   log('✓ 打断在途收到 turn-failed → 记为已停止,start 正常 resolve');
   return () => f.session.dispose();
@@ -213,6 +230,60 @@ async function deltaWithoutTurnIdStillCounts(): Promise<() => Promise<void>> {
   return () => f.session.dispose();
 }
 
+/**
+ * 6. turn/start 应答还没回来 —— 打断点名不到 turn(codex 侧 turnId 必填),
+ * 谎称已停止的话 codex 会继续跑到底、继续烧 token,故如实抛回让用户重按。
+ */
+async function stopBeforeTurnIdArrives(): Promise<() => Promise<void>> {
+  let release!: () => void;
+  const held = new Promise<void>((r) => {
+    release = r;
+  });
+  const f = fixture({ onInterrupt: async () => undefined, holdTurnId: () => held });
+  const scan = f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  await new Promise((r) => setTimeout(r, 10));
+  // 结论要与用例 7 的「停不下来」互斥 —— 只断言笼统的「turn id」的话,
+  // 两种成因给同一句话也能过,而它们对用户的下一步正好相反(重按 vs 别按了)
+  await assert.rejects(
+    () => f.session.stopScan(),
+    (e: Error) => /稍等/.test(e.message) && !/停不下来/.test(e.message),
+    '应答在途要说「稍等再停」,点名不到 turn 就不算停住了',
+  );
+  assert.equal(f.session.isStopped(), false, '没停成不许记已停止');
+  assert.equal(f.agent.interrupts.length, 0, '没有可打断的对象就不该发打断请求');
+
+  // 应答回来后这一轮照常跑完:那次没成功的叫停不许改写它的终局
+  release();
+  await new Promise((r) => setTimeout(r, 10));
+  f.agent.emitEvent({ kind: 'turn-completed', turnId: 't1' });
+  await scan;
+  log('✓ turnId 未到手时按停止 → 如实抛回,轮次照常跑完');
+  return () => f.session.dispose();
+}
+
+/**
+ * 7. agent 压根不给 turnId(sendMessage 返回空串,接口允许)—— 与「应答未回」不是一回事:
+ * 等下去也不会有,提示「稍等再停」就是把用户卡在一个永远不成立的重试里。
+ */
+async function stopWhenAgentGivesNoTurnId(): Promise<() => Promise<void>> {
+  const f = fixture({ onInterrupt: async () => undefined, emptyTurnId: true });
+  const scan = f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  await new Promise((r) => setTimeout(r, 10));
+  await assert.rejects(
+    () => f.session.stopScan(),
+    (e: Error) => /停不下来/.test(e.message) && !/稍等/.test(e.message),
+    '没有 id 可打断要如实说,不能伪装成「等一下就好」',
+  );
+  assert.equal(f.session.isStopped(), false, '没停成不许记已停止');
+  assert.equal(f.agent.interrupts.length, 0, '没有 id 就不该发打断请求');
+
+  // 这一轮照常跑完:停不下来不等于这一轮就此作废
+  f.agent.emitEvent({ kind: 'turn-completed', turnId: 't1' });
+  await scan;
+  log('✓ agent 不给 turnId 时按停止 → 说清停不下来,不提示「稍等再试」');
+  return () => f.session.dispose();
+}
+
 async function main(): Promise<void> {
   const cases = [
     failedDuringInterrupt,
@@ -220,6 +291,8 @@ async function main(): Promise<void> {
     followupStillAnswered,
     lateEventsDoNotLeak,
     deltaWithoutTurnIdStillCounts,
+    stopBeforeTurnIdArrives,
+    stopWhenAgentGivesNoTurnId,
   ];
   for (const t of cases) {
     const dispose = await t();

--- a/src/backend/agent/codex/codex-agent.ts
+++ b/src/backend/agent/codex/codex-agent.ts
@@ -147,8 +147,8 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
     return () => this.off('event', handler);
   }
 
-  async interrupt(conversationId: string): Promise<void> {
-    await this.server.turnInterrupt(conversationId);
+  async interrupt(conversationId: string, turnId: string): Promise<void> {
+    await this.server.turnInterrupt({ threadId: conversationId, turnId });
   }
 
   // 受信工具的反向审批由 CodexAppServer 自动 accept;此口子留给未来非受信场景。

--- a/src/backend/agent/codex/codex-app-server.ts
+++ b/src/backend/agent/codex/codex-app-server.ts
@@ -14,6 +14,7 @@ import {
   type ThreadResumeResponse,
   type ThreadStartParams,
   type ThreadStartResponse,
+  type TurnInterruptParams,
   type TurnStartParams,
   type TurnStartResponse,
 } from './protocol';
@@ -90,8 +91,8 @@ export class CodexAppServer extends EventEmitter {
     return this.rpcOrThrow().request<TurnStartResponse>(CodexMethod.turnStart, params);
   }
 
-  async turnInterrupt(threadId: string): Promise<unknown> {
-    return this.rpcOrThrow().request(CodexMethod.turnInterrupt, { threadId });
+  async turnInterrupt(params: TurnInterruptParams): Promise<unknown> {
+    return this.rpcOrThrow().request(CodexMethod.turnInterrupt, params);
   }
 
   stop(): void {

--- a/src/backend/agent/codex/protocol.ts
+++ b/src/backend/agent/codex/protocol.ts
@@ -1,5 +1,5 @@
 /**
- * codex app-server 协议的最小子集(手写,对齐 codex-cli 0.144.1 `generate-ts` 导出)。
+ * codex app-server 协议的最小子集(手写,对齐 codex-cli 0.145.0 `generate-ts` 导出)。
  * 只覆盖 Duetlens spike/骨架用到的方法与事件;全量类型可用
  *   `codex app-server generate-ts --out <DIR>`(见 npm script `codex:gen-types`)
  * 重导比对。协议标 experimental,升级 codex 后应重新导出回归。
@@ -100,6 +100,17 @@ export interface TurnStartParams {
 
 export interface TurnStartResponse {
   turn: { id: string; status: string; [k: string]: unknown };
+}
+
+// ---- turn/interrupt ----
+
+/**
+ * 打断是**针对某一个 turn** 的:`turnId` 必填,少了会在参数反序列化阶段就被
+ * `-32600 Invalid request` 顶回来,根本走不到打断逻辑。
+ */
+export interface TurnInterruptParams {
+  threadId: string;
+  turnId: string;
 }
 
 /**

--- a/src/backend/agent/conversational-agent.ts
+++ b/src/backend/agent/conversational-agent.ts
@@ -40,10 +40,17 @@ export interface ConversationalAgent {
   startConversation(opts: StartConversationOptions): Promise<ConversationHandle>;
   /** 按 conversationId 从磁盘续接会话(app 重启后追问);须重新注入 MCP。 */
   resumeConversation(opts: ResumeConversationOptions): Promise<ConversationHandle>;
-  /** 发起一轮 turn;返回该 turn 的 id(agent 未给则空串),供调用方只认自己那一轮的终局事件。 */
+  /**
+   * 发起一轮 turn;返回该 turn 的 id,供调用方只认自己那一轮的终局事件。
+   *
+   * 返回空串表示这个 agent 不给 id:终局与 delta 的归属退回「来什么认什么」尚可将就,
+   * 但 {@link interrupt} 点名不到 turn —— 这样的 agent 跑出来的轮次**叫停不了**。
+   * codex 协议里没有 thread 级打断可退,故这不是能补的降级路径;要支持叫停就必须给出非空 id。
+   */
   sendMessage(conversationId: string, text: string): Promise<string>;
   streamEvents(handler: (e: AgentEvent) => void): () => void;
-  interrupt(conversationId: string): Promise<void>;
+  /** 打断指定 turn。turnId 必须是 {@link sendMessage} 给回的那个 —— 打断作用于具体一轮,不是整条会话。 */
+  interrupt(conversationId: string, turnId: string): Promise<void>;
   /** 反向审批的显式应答口子;受信工具默认自动 accept(见 CodexAppServer)。 */
   approve(requestId: string, decision: 'accept' | 'decline'): void;
   dispose(): void;

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -96,6 +96,13 @@ type TurnOutcome =
   | { kind: 'stopped' }
   | { kind: 'failed'; error: string; errorKind: AgentErrorKind };
 
+/**
+ * 一个 turn 是为谁跑的。**叫停只作用于机审那几个** —— 追问 turn 也要等终局、
+ * 也登记在 {@link ReviewSession.stopTargets} 里,但它是用户刚问出去的那句话,不该被
+ * 「停止机审」顺手打断(扫描自然收尾后,队里的追问紧接着就开跑)。
+ */
+type TurnKind = 'scan' | 'followup';
+
 /** turn 的终局:agent 侧的完成/失败,或我们主动叫停/释放会话。 */
 type TurnEnd =
   | Extract<AgentEvent, { kind: 'turn-completed' | 'turn-failed' }>
@@ -121,6 +128,8 @@ interface TurnWaiter {
  * 故由 {@link ReviewSession.stopScan} 取快照逐个通知,而不是置一个全局旗子。
  */
 interface StopTarget {
+  /** 这次等待是为谁跑的;叫停只挑 `scan` 的下手 */
+  kind: TurnKind;
   /**
    * 要打断的那个 turn。**两种「没有」必须分开**,处置相反:
    *   `undefined` —— turn/start 应答还没回来,稍等就有;
@@ -327,7 +336,7 @@ export class ReviewSession {
     this.recordModel(handle.model);
     this.setStatus('scanning');
 
-    const outcome = await this.runTurn(opts.scanPrompt ?? DEFAULT_SCAN_PROMPT);
+    const outcome = await this.runTurn('scan', opts.scanPrompt ?? DEFAULT_SCAN_PROMPT);
     if (outcome.kind === 'failed') {
       this.setStatus('failed');
       const label = opts.round && opts.round > 1 ? `第 ${opts.round} 轮复审` : '首轮扫描';
@@ -336,7 +345,7 @@ export class ReviewSession {
     // 对抗档:同一 thread 追加一轮自检。已有扫描结论,自检失败不推翻本轮 —— 吞掉错误保留成果。
     // 叫停是"到此为止",自检轮当然也不再跑;扫描 turn 恰好抢在打断前跑完也照样算叫停。
     if (outcome.kind === 'ok' && !this.stopped && opts.intensity === 'adversarial') {
-      await this.runTurn(ADVERSARIAL_SELFCHECK_PROMPT);
+      await this.runTurn('scan', ADVERSARIAL_SELFCHECK_PROMPT);
     }
     const source = this.store.getReview(this.reviewId)?.source;
     this.setStatus(source ? scanDoneStatus(source) : 'reviewing');
@@ -412,10 +421,11 @@ export class ReviewSession {
     // 记在 session 上的话,后一条会把前一条的篮子清掉,提案就再也挂不上那句回复。
     const collected: string[] = [];
     try {
-      const outcome = await this.runTurn(this.buildFollowupPrompt(discussion, text, history), {
-        discussionId,
-        collected,
-      });
+      const outcome = await this.runTurn(
+        'followup',
+        this.buildFollowupPrompt(discussion, text, history),
+        { discussionId, collected },
+      );
       if (outcome.kind === 'failed')
         throw new AgentTurnError(`追问失败: ${outcome.error}`, outcome.errorKind, outcome.error);
       if (outcome.kind === 'stopped') return userMsg;
@@ -461,7 +471,9 @@ export class ReviewSession {
     // 在途期间到达的终局一律先扣住,由打断的成败来定性 —— 成了算「已停止」,
     // 没成就还它本来的面目(那一轮确实是自己挂的/跑完的),别让两边各说一套。
     // 快照也要在此刻取:被叫停的是**现在**在跑的那个 turn,之后新起的追问与这次叫停无关。
-    const targets = [...this.stopTargets];
+    // 只挑机审那几个 turn。追问 turn 同样登记在这里,但扫描自然收尾后队里的追问会
+    // 紧接着开跑 —— 不筛掉的话「停止机审」会把用户刚问出去的那句话打断,还把整轮记成已停止。
+    const targets = [...this.stopTargets].filter((t) => t.kind === 'scan');
     // 打断点名到 turn,故快照要连 turnId 一起取。一个能打断的都没有时分三种,处置各不同:
     //   - 一个 target 都没有:轮次正卡在两个 turn 之间(如对抗档扫描轮与自检轮),
     //     没有在跑的 turn 可打断 —— 直接算停下,后面那个 turn 由 stopped 旗子拦住。
@@ -687,7 +699,7 @@ export class ReviewSession {
    * 跑一轮 turn(串行入队):累积 message-delta 作为 agent 回复文本,resolve 于 turn 结束。
    * 前一轮失败不阻断后续轮(链上 catch)。
    */
-  private runTurn(text: string, propose?: ProposeContext): Promise<TurnOutcome> {
+  private runTurn(kind: TurnKind, text: string, propose?: ProposeContext): Promise<TurnOutcome> {
     const run = async (): Promise<TurnOutcome> => {
       // 排在队里的那些:轮到自己时会话可能已经拆了,别再发一轮出去等终局
       if (this.disposed) throw new SessionDisposedError();
@@ -698,7 +710,7 @@ export class ReviewSession {
       this.enterTurnMode(propose);
       try {
         // 订阅要先于发起:极快的 turn(乃至 stub)会在 turn/start 应答之前就把 delta 与终局发出来
-        const waiter = this.awaitTurnEnd();
+        const waiter = this.awaitTurnEnd(kind);
         try {
           waiter.identify(await this.agent.sendMessage(conversationId, text));
         } catch (e) {
@@ -747,7 +759,7 @@ export class ReviewSession {
    * 那条迟到的终局会被下一次追问当成自己的(追问提前返回空回复),残余文本还会混进追问的答案。
    * turnId 要到 turn/start 应答才知道,故认领之前先扣住,认领后再逐条比对。
    */
-  private awaitTurnEnd(): TurnWaiter {
+  private awaitTurnEnd(kind: TurnKind): TurnWaiter {
     type TerminalEvent = Extract<AgentEvent, { kind: 'turn-completed' | 'turn-failed' }>;
     const cleanup: (() => void)[] = [];
     let settle!: (end: TurnEnd) => void;
@@ -774,6 +786,7 @@ export class ReviewSession {
       finish(stoppedMe ? { kind: 'stopped' } : e);
     };
     const target: StopTarget = {
+      kind,
       turnId: () => (identified ? (mine ?? '') : undefined),
       begin: (g) => {
         gate = g;

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -121,6 +121,12 @@ interface TurnWaiter {
  * 故由 {@link ReviewSession.stopScan} 取快照逐个通知,而不是置一个全局旗子。
  */
 interface StopTarget {
+  /**
+   * 要打断的那个 turn。**两种「没有」必须分开**,处置相反:
+   *   `undefined` —— turn/start 应答还没回来,稍等就有;
+   *   `''` —— 应答回来了但 agent 不给 id({@link ConversationalAgent.sendMessage} 允许),等下去也不会有。
+   */
+  turnId: () => string | undefined;
   /** 打断已发出、结果未知:此后到达的终局先扣住,等 gate 出结果再定性 */
   begin: (gate: Promise<void>) => void;
   /** 打断成功:本次等待就地按「已停止」收尾,不再等 codex 的终局 */
@@ -456,13 +462,28 @@ export class ReviewSession {
     // 没成就还它本来的面目(那一轮确实是自己挂的/跑完的),别让两边各说一套。
     // 快照也要在此刻取:被叫停的是**现在**在跑的那个 turn,之后新起的追问与这次叫停无关。
     const targets = [...this.stopTargets];
+    // 打断点名到 turn,故快照要连 turnId 一起取。一个能打断的都没有时分三种,处置各不同:
+    //   - 一个 target 都没有:轮次正卡在两个 turn 之间(如对抗档扫描轮与自检轮),
+    //     没有在跑的 turn 可打断 —— 直接算停下,后面那个 turn 由 stopped 旗子拦住。
+    //   - id 还没到手:turn/start 应答在途,这一轮**确实在跑**。谎称已停止的话
+    //     codex 会继续跑到底、继续烧 token,故如实抛回让用户重按 —— 重按一下就好了。
+    //   - agent 压根不给 id:等下去也不会有。同样的「稍等再停」会把用户卡在一个
+    //     永远不成立的重试里,所以要说的是「这一轮停不下来」。
+    const live = targets.map((t) => ({ t, turnId: t.turnId() }));
+    if (live.length > 0 && !live.some((x) => x.turnId))
+      throw new Error(
+        live.some((x) => x.turnId === undefined)
+          ? '本轮刚发出去,还没拿到可打断的 turn id,请稍等一下再停'
+          : 'agent 没有给出 turn id,这一轮打断不了,停不下来',
+      );
+
     let openGate!: () => void;
     const gate = new Promise<void>((resolve) => {
       openGate = resolve;
     });
     for (const t of targets) t.begin(gate);
     try {
-      await this.agent.interrupt(conversationId);
+      for (const { turnId } of live) if (turnId) await this.agent.interrupt(conversationId, turnId);
       this.stopped = true;
       for (const t of targets) t.stop();
     } finally {
@@ -742,6 +763,9 @@ export class ReviewSession {
       settle(e);
     };
 
+    // 本次等待认领的 turn(identify 时填);叫停要拿它点名打断,故声明在 target 之前
+    let mine: string | undefined;
+    let identified = false;
     // 叫停波及本次等待时由 stopScan 填入;没被波及就一直是空 —— 后起的 turn 照自己的终局收尾
     let gate: Promise<void> | null = null;
     let stoppedMe = false;
@@ -750,6 +774,7 @@ export class ReviewSession {
       finish(stoppedMe ? { kind: 'stopped' } : e);
     };
     const target: StopTarget = {
+      turnId: () => (identified ? (mine ?? '') : undefined),
       begin: (g) => {
         gate = g;
       },
@@ -766,8 +791,6 @@ export class ReviewSession {
     this.liveWaiters.add(abort);
     cleanup.push(() => this.liveWaiters.delete(abort));
 
-    let mine: string | undefined;
-    let identified = false;
     /** 认领前无从判断归属的事件,先按 turnId 分组扣住(无 id 的归到 undefined 这组) */
     const heldEnds: TerminalEvent[] = [];
     const heldDeltas = new Map<string | undefined, string>();

--- a/src/renderer/screens/review/LaunchError.tsx
+++ b/src/renderer/screens/review/LaunchError.tsx
@@ -4,8 +4,15 @@ import { describeLaunchError } from './round-error';
  * 「这一轮没能开跑」的统一呈现:重跑面板与进度条失败卡共用一份 ——
  * 两处各写各的必然漂移,而这类错误的原文又长又是给机器看的,糊进段落谁也读不下去。
  */
-export function LaunchError({ message }: { message: string }): React.JSX.Element {
-  const { title, advice, raw } = describeLaunchError(message);
+export function LaunchError({
+  message,
+  fallbackTitle,
+}: {
+  message: string;
+  /** 认不出特征时的兜底结论;缺省即「这一轮没能开跑」 */
+  fallbackTitle?: string;
+}): React.JSX.Element {
+  const { title, advice, raw } = describeLaunchError(message, fallbackTitle);
   return (
     <div className="launch-err">
       <div className="le-head">

--- a/src/renderer/screens/review/ScanProgressBar.tsx
+++ b/src/renderer/screens/review/ScanProgressBar.tsx
@@ -143,7 +143,7 @@ export function ScanProgressBar({
       </div>
       {stopError && (
         <div className="sb-stoperr">
-          <LaunchError message={stopError} />
+          <LaunchError message={stopError} fallbackTitle="没能停下这一轮" />
         </div>
       )}
 

--- a/src/renderer/screens/review/round-error.ts
+++ b/src/renderer/screens/review/round-error.ts
@@ -122,11 +122,15 @@ export function stripIpcWrapper(message: string): string {
     .trim();
 }
 
-export function describeLaunchError(message: string): LaunchErrorCopy {
+/**
+ * @param fallbackTitle 认不出特征时的兜底结论。默认按「开跑失败」措辞;
+ *   叫停失败复用的是同一份呈现,但说成「没能开跑」正好把因果说反了。
+ */
+export function describeLaunchError(message: string, fallbackTitle = '这一轮没能开跑'): LaunchErrorCopy {
   const raw = stripIpcWrapper(message);
   const hit = LAUNCH_PATTERNS.find((p) => p.match.test(raw));
   return {
-    title: hit?.title ?? '这一轮没能开跑',
+    title: hit?.title ?? fallbackTitle,
     advice: hit?.advice ?? '',
     raw,
   };


### PR DESCRIPTION
Pressing "停止机审" failed with `Invalid request: missing field turnId (code -32600)`, the round kept burning tokens to completion, and the error card claimed the round "没能开跑". Investigating that turned up two more defects on the same path.

## 1. `turn/interrupt` was missing `turnId`

codex 0.145.0 declares `TurnInterruptParams = { threadId, turnId }`, but we only sent `threadId`, so the request died in parameter deserialization and never reached the interrupt logic. The turn id was available all along (`sendMessage` returns it) but was dropped at the `ConversationalAgent.interrupt` signature.

Verified against real codex, no tokens spent (`thread/start` does not call the model):

```
{"threadId":"019face3-…"}                          -> Invalid request: missing field `turnId` (code -32600)
{"threadId":"019face3-…","turnId":"no-such-turn"}  -> no active turn to interrupt (code -32600)
```

The first line is the reported error verbatim; the second shows the new shape clearing deserialization.

The stop target now carries the turn id, and the two "no id" states are kept apart because the user's next move is opposite in each: the id has not arrived yet (press again in a moment) versus the agent never gives one (this round cannot be interrupted at all). The `sendMessage` contract now documents that second case instead of quietly implying a fallback exists. There is none: `turn/interrupt` is the only stop in codex's `ClientRequest` and it requires a turn id.

## 2. Stopping could interrupt a queued follow-up

Pre-existing, unrelated to the protocol bug. Follow-up turns registered the same kind of stop target as scan turns, so once the scan turn ended and a queued follow-up started, `stopScan()` interrupted the user's question and recorded the round as `stopped`. Turns are now tagged `scan` or `followup` and only the former is stoppable.

Reachability on the real agent is low: the window between the scan turn ending and `settleRound` marking the round done is entirely microtasks, while a follow-up cannot obtain a turn id without a codex stdio round trip. Fixed anyway, because session-level correctness should not depend on `ReviewManager`'s status check, and the case is genuinely red at the session level.

## 3. A failed stop was titled as a failed launch

The stop error reused `LaunchError`, whose fallback title says the round never started, which is the opposite of what happened. Callers can now pass their own fallback title.

## Verification

`typecheck`, `lint`, and `spike:stop-scan` (8 cases, 3 new) all pass. Each new assertion was confirmed red against the pre-fix code.

One of those red checks was itself informative: case 7 initially passed against the broken code because case 6's matcher only looked for "turn id", which both messages contain. Tightening case 6 to require the "稍等" wording and reject "停不下来" is what actually pins the distinction.

The stub agent is why this class of bug survived: it can pin state-machine behaviour but never touches the wire shape, and `protocol.ts` was still aligned to codex 0.144.1 while the machine had moved to 0.145.0. The header is now updated, and I re-checked the used subset (`turn/start`, `thread/start`, every notification name) against a fresh `generate-ts` export; `turn/interrupt` was the only drift.