### PR TITLE
feat(agent): fail closed when the codex contract drifts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Electron 桌面应用:人与 codex agent 协同对话式的 code review。主进
 | 仓库 / issue / 作者外链 | `src/shared/links.ts`(package.json 不重复一份) |
 | 客户端版本号 | `package.json` 的 `version` → 构建期 define 注入 `src/shared/version.ts`;发给 app-server / MCP 的 clientInfo 一律取 `APP_VERSION`,别再写字面量 |
 | 版本改动说明 | `CHANGELOG.md` / `CHANGELOG.en.md`;GitHub release notes 由 `scripts/release-notes.mjs` 抽出对应小节,别在 release 页手写 |
+| 对齐的 codex 版本 / 协议错误判据 | `src/shared/codex.ts`(`CODEX_TARGET_VERSION` / `CODEX_PROTOCOL_ERROR`);`protocol.ts` 表头只指过去,升级 codex 时改这一处 |
 
 ## 运行与自查
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "spike:rerun": "tsx scripts/spike-rerun.ts",
     "spike:absorb": "tsx scripts/spike-absorb.ts",
     "spike:stop-scan": "tsx scripts/spike-stop-scan.ts",
+    "spike:sandbox-guard": "tsx scripts/spike-sandbox-guard.ts",
     "spike:session-busy": "tsx scripts/spike-session-busy.ts",
     "spike:followup-queue": "tsx scripts/spike-followup-queue.ts",
     "spike:proposals": "tsx scripts/spike-proposals.ts",

--- a/scripts/spike-sandbox-guard.ts
+++ b/scripts/spike-sandbox-guard.ts
@@ -1,0 +1,227 @@
+/**
+ * 确定性验证「只读沙箱注入失效」的判据(不走 codex/不烧 token)。
+ *
+ * 背景:codex 对请求里的未知字段是**静默忽略**的,所以 thread/start 把 sandbox 送出去
+ * 不等于它生效;又因为注入的 approvalPolicy 是 never,策略没落地时 codex 通常**不会来问**,
+ * 没有天然哨兵。握手侧的读回校验在 CodexAgent(需真 codex,见 assertReadOnly),
+ * 这里验的是 turn 内那条兜底:
+ *
+ * 1. 收到本不该出现的审批请求(expected=false)→ 本轮就地判死,归因 sandbox-not-applied。
+ * 2. 受信 MCP 的正常 elicitation(expected=true)→ 照常放行,不许被这条兜底误杀。
+ * 3. 未受信 MCP 的 elicitation 被拒(expected=false 但 gate=mcp)→ 同样不算沙箱失效 ——
+ *    只看 expected 的话,用户自己配的第三方 MCP server 会把好好的一轮判死。
+ * 4. 建会话阶段(握手校验)抛的普通 Error 要保住归因 —— 塌成 other 就等于这套文案白做。
+ * 5. codex 的每种审批方法都得在哨兵集合里(v2 的 commandExecution 曾漏掉),且拒绝的说法
+ *    要按各自的应答类型写 —— 没有通用的 `denied`。
+ *   运行:npm run spike:sandbox-guard
+ */
+import { strict as assert } from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { openDatabase } from '../src/backend/db/database';
+import { ReviewStore } from '../src/backend/db/review-store';
+import { AgentTurnError, ReviewSession } from '../src/backend/review/review-session';
+import { describeRoundFailure } from '../src/backend/review/review-manager';
+import { CodexServerRequest, DECLINE_BY_METHOD } from '../src/backend/agent/codex/protocol';
+import { POLICY_APPROVALS } from '../src/backend/agent/codex/codex-agent';
+import { SANDBOX_NOT_APPLIED_CODE } from '../src/shared/ipc';
+import type {
+  AgentEvent,
+  ConversationalAgent,
+  ConversationHandle,
+} from '../src/backend/agent/conversational-agent';
+
+const log = (m: string) => process.stdout.write(`[sandbox-guard] ${m}\n`);
+
+class StubAgent extends EventEmitter implements ConversationalAgent {
+  constructor(private readonly onTurn: (agent: StubAgent, turnId: string) => void) {
+    super();
+  }
+  async startConversation(): Promise<ConversationHandle> {
+    return { conversationId: 'stub-thread' };
+  }
+  async resumeConversation(): Promise<ConversationHandle> {
+    return { conversationId: 'stub-thread' };
+  }
+  async sendMessage(): Promise<string> {
+    setTimeout(() => this.onTurn(this, 't1'), 0); // 应答之后再发事件,贴近真实次序
+    return 't1';
+  }
+  emitEvent(e: AgentEvent): void {
+    this.emit('event', e);
+  }
+  streamEvents(handler: (e: AgentEvent) => void): () => void {
+    this.on('event', handler);
+    return () => this.off('event', handler);
+  }
+  async interrupt(): Promise<void> {}
+  approve(): void {}
+  /** 判死之后 codex 侧必须真的停手 —— 只结束本地等待的话,那个 turn 还在跑 */
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+function fixture(onTurn: (agent: StubAgent, turnId: string) => void) {
+  const db = openDatabase(':memory:');
+  const store = new ReviewStore(db);
+  const review = store.createReview({
+    source: 'local-branch',
+    sourceRef: 'stub',
+    repoPath: null,
+    title: 'sandbox-guard spike',
+    model: null,
+    reasoningEffort: null,
+    intensity: 'standard',
+  });
+  store.startRound(review.id, 1, {});
+  const agent = new StubAgent(onTurn);
+  const session = new ReviewSession(review.id, store, agent);
+  return { store, review, agent, session, providers: { getDiff: () => '', getFile: async () => '' } };
+}
+
+/** 1. 只读会话里冒出审批请求 —— 策略没落地,本轮必须就地判死。 */
+async function unexpectedApprovalKillsRound(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'approval',
+      method: CodexServerRequest.commandExecutionApproval,
+      decision: 'denied',
+      expected: false,
+      gate: 'policy',
+    });
+    // 之后 turn 即便自称跑完了也不作数:判死要基于策略失效本身
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await assert.rejects(
+    () => f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 }),
+    (e: Error) =>
+      e instanceof AgentTurnError &&
+      e.errorKind === 'sandbox-not-applied' &&
+      e.message.includes(SANDBOX_NOT_APPLIED_CODE),
+    '只读会话里出现审批请求 = 沙箱没落地,本轮要以 sandbox-not-applied 失败',
+  );
+  assert.equal(f.agent.disposed, true, '判死还不够:codex 侧的 turn 必须被真的拆掉,否则它还在跑');
+  log('✓ 意料外的审批请求 → 本轮判死并拆会话');
+  return () => f.session.dispose();
+}
+
+/** 2. 受信 MCP 的正常 elicitation 走的是同一个事件 —— 不许被兜底误杀。 */
+async function expectedApprovalIsHarmless(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'approval',
+      method: 'mcp_server_elicitation',
+      decision: 'accepted',
+      expected: true,
+      gate: 'mcp',
+      server: 'duetlens',
+    });
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  assert.notEqual(f.store.getReview(f.review.id)?.status, 'failed', '自建 MCP 的审批是正常流程');
+  log('✓ 受信 MCP 的 elicitation 照常放行');
+  return () => f.session.dispose();
+}
+
+/**
+ * 3. 未受信 MCP server 的 elicitation 被拒 —— 同样是 expected=false,但它**不是**沙箱哨兵:
+ * 用户自己在 config.toml 里配的第三方 MCP server 就会发,被拒只说明我们没批准那次工具调用。
+ * 据此判死会把本可继续的审核拦腰砍断,还倒打一耙让用户去升 codex。
+ */
+async function declinedMcpElicitationIsNotABreach(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'approval',
+      method: 'mcpServer/elicitation/request',
+      decision: 'declined',
+      expected: false,
+      gate: 'mcp',
+      server: 'some-third-party',
+    });
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  assert.notEqual(
+    f.store.getReview(f.review.id)?.status,
+    'failed',
+    '第三方 MCP 的 elicitation 被拒不等于沙箱失效,不该判死这一轮',
+  );
+  log('✓ 未受信 MCP 的 elicitation 被拒 → 不误判为沙箱失效');
+  return () => f.session.dispose();
+}
+
+/**
+ * 4. 建会话阶段抛的是普通 Error(没有 turn,也就没有 codexErrorInfo 可映射)。
+ * 归因要认得出这两类,否则界面只给一句泛泛的失败、还把「重试」摆成主操作 ——
+ * 而这两类重试必然复现。握手校验正是走这条路,是沙箱判据最主要的入口。
+ *
+ * 反过来也要钉住:协议判据只认 JSON-RPC 错误码那个尾巴。source / gh / git 的报错里
+ * 「Invalid request」「missing field」这类词面随处可见,扫 prose 会把它们全打成版本不匹配。
+ */
+function launchFailuresKeepTheirKind(): void {
+  const cases: [string, string][] = [
+    [`${SANDBOX_NOT_APPLIED_CODE} codex 没有按只读沙箱起会话(sandbox=workspaceWrite)`, 'sandbox-not-applied'],
+    ['Invalid request: missing field `turnId` (code -32600)', 'codex-version-mismatch'],
+    ['Invalid request: unknown variant `turn/nope` (code -32600)', 'codex-version-mismatch'],
+    ['Could not resolve host: github.com', 'other'],
+    // 下面这些**不是**协议问题,而且是两个相反方向的误伤。判成 codex-version-mismatch
+    // 就会把真实原因盖掉,还扣一个不可重试的「去升级 codex」。
+    //
+    // 一、词面像但没有 JSON-RPC 尾巴 —— source / gh / git 的报错:
+    ['HTTP 400: Invalid request — pull request not found', 'other'],
+    ['fatal: missing field `url` in .gitmodules', 'other'],
+    ['gh: unknown variant of --json field', 'other'],
+    // 二、有尾巴但是 codex 自己的**业务**拒绝 —— 这条是真机原文,codex 把 -32600
+    //     也用在业务条件上,所以光认错误码同样会翻车:
+    ['no active turn to interrupt (code -32600)', 'other'],
+  ];
+  for (const [message, expected] of cases) {
+    const got = describeRoundFailure(new Error(message)).errorKind;
+    assert.equal(got, expected, `「${message.slice(0, 40)}…」应归到 ${expected},实得 ${got}`);
+  }
+  log('✓ 建会话失败保住各自归因,不塌成 other');
+}
+
+/**
+ * 5. 审批方法表与哨兵集合必须同步。这次漏的就是 v2 的 `item/commandExecution/requestApproval`
+ * —— 它掉进「未知反向请求」那一档、`gate` 被标成 mcp,于是**真正的命令执行审批**悄悄绕过了哨兵:
+ * 沙箱失效时既不判死也不拆会话。故用不变式钉住,而不是靠记得。
+ */
+function everyApprovalIsASentinel(): void {
+  for (const [name, method] of Object.entries(CodexServerRequest)) {
+    if (method === CodexServerRequest.mcpElicitation) continue; // 工具确认,不是策略哨兵
+    assert.ok(
+      POLICY_APPROVALS.has(method),
+      `${name}(${method})没进哨兵集合 —— 沙箱失效时这类审批会被当成普通 MCP 请求放过`,
+    );
+  }
+  // permissions 的应答里没有 decision 字段(要回一份授权档),表达不了拒绝 ——
+  // 它是唯一只能回 JSON-RPC 错误的一条;再多一条就说明有人加了方法却没想清楚怎么拒。
+  assert.deepEqual(
+    [...POLICY_APPROVALS].filter((m) => DECLINE_BY_METHOD[m] === undefined),
+    [CodexServerRequest.permissionsApproval],
+    '除 permissions 外,每种审批都得有按其应答类型写的拒绝说法',
+  );
+  log('✓ 审批方法表与哨兵集合同步,拒绝说法齐备');
+}
+
+async function main(): Promise<void> {
+  everyApprovalIsASentinel();
+  launchFailuresKeepTheirKind();
+  for (const t of [
+    unexpectedApprovalKillsRound,
+    expectedApprovalIsHarmless,
+    declinedMcpElicitationIsNotABreach,
+  ]) {
+    const dispose = await t();
+    await dispose(); // MCP server 不关,event loop 就一直醒着,进程退不了
+  }
+  log('全部通过');
+}
+
+main().catch((e) => {
+  process.stderr.write(`[sandbox-guard] 失败: ${(e as Error).stack}\n`);
+  process.exit(1);
+});

--- a/src/backend/agent/codex/codex-agent.ts
+++ b/src/backend/agent/codex/codex-agent.ts
@@ -4,14 +4,20 @@ import { APP_VERSION } from '@shared/version';
 import {
   CodexItemType,
   CodexNotification,
+  CodexServerRequest,
   codexErrorKind,
   type CodexErrorNotification,
   type CodexModel,
   type CodexTurnError,
   type McpServerElicitationAction,
   type McpServerElicitationRequestParams,
+  type EffectiveThreadPolicy,
   type McpToolCallItem,
+  type ThreadResumeResponse,
+  type ThreadStartResponse,
 } from './protocol';
+import { CODEX_TARGET_VERSION } from '@shared/codex';
+import { SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
 import type {
   AgentEvent,
   ConversationHandle,
@@ -22,6 +28,40 @@ import type {
 
 /** 注入 bearer 令牌的 env 变量名(codex config 的 bearer_token_env_var 指向它)。 */
 const MCP_TOKEN_ENV = 'DUETLENS_MCP_TOKEN';
+
+/**
+ * 把关执行/写入/权限的反向审批 —— 只读 + approvalPolicy=never 的会话里一条都不该出现,
+ * 故可当沙箱注入是否失效的哨兵。`mcpElicitation` **不在此列**:那是工具调用的确认,
+ * 用户自己在 config.toml 里配的第三方 MCP server 也会发,被拒不能说明我们的注入没生效。
+ */
+export const POLICY_APPROVALS: ReadonlySet<string> = new Set([
+  CodexServerRequest.execCommandApproval,
+  CodexServerRequest.applyPatchApproval,
+  CodexServerRequest.commandExecutionApproval,
+  CodexServerRequest.fileChangeApproval,
+  CodexServerRequest.permissionsApproval,
+]);
+
+/** 抹平大小写与分隔符再比:`readOnly` / `read-only` / `read_only` 说的是同一件事。 */
+const norm = (v: string | undefined): string => (v ?? '').toLowerCase().replace(/[^a-z]/g, '');
+
+/**
+ * 证实只读注入**真的落地**,否则拒绝开工。见 {@link SANDBOX_NOT_APPLIED_CODE} ——
+ * 请求发出去不算数,codex 会静默吞掉它不认识的字段。
+ *
+ * 读不到策略同样判死(失败关闭):这一侧宁可误伤 —— 误伤是「装不上、去升级」,
+ * 漏判是「审核 agent 在未知策略下对你的仓库动手,且没有任何提示」。
+ */
+function assertReadOnly(res: ThreadStartResponse | ThreadResumeResponse): void {
+  const sandbox = (res as EffectiveThreadPolicy).sandbox?.type;
+  const approval = (res as EffectiveThreadPolicy).approvalPolicy;
+  if (norm(sandbox) === 'readonly' && norm(approval) === 'never') return;
+  const seen = `sandbox=${sandbox ?? '(未回显)'}, approvalPolicy=${approval ?? '(未回显)'}`;
+  throw new Error(
+    `${SANDBOX_NOT_APPLIED_CODE} codex 没有按只读沙箱起会话(${seen})。` +
+      `本机 codex ${res.thread.cliVersion ?? '版本未知'},这版 Duetlens 对齐的是 ${CODEX_TARGET_VERSION}。`,
+  );
+}
 
 export interface CodexAgentOptions {
   codexBin?: string;
@@ -54,13 +94,21 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
         method: 'mcpServer/elicitation/request',
         decision: accepted ? 'accepted' : 'declined',
         expected: accepted,
+        gate: 'mcp',
         server: p.serverName,
         message: p.message,
       });
     });
     this.server.on('unexpected-approval', (method: string, params: unknown) => {
       const server = (params as { serverName?: string } | undefined)?.serverName;
-      this.emitEvent({ kind: 'approval', method, decision: 'denied', expected: false, server });
+      this.emitEvent({
+        kind: 'approval',
+        method,
+        decision: 'denied',
+        expected: false,
+        gate: POLICY_APPROVALS.has(method) ? 'policy' : 'mcp',
+        server,
+      });
     });
   }
 
@@ -98,6 +146,7 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
       model: opts.model || undefined,
       config: this.threadConfig(opts),
     });
+    this.acceptOrStop(res);
     return { conversationId: res.thread.id, model: res.model || undefined };
   }
 
@@ -112,7 +161,21 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
       model: opts.model || undefined,
       config: this.threadConfig(opts),
     });
+    this.acceptOrStop(res);
     return { conversationId: res.thread.id, model: res.model || undefined };
+  }
+
+  /**
+   * 校验不过就顺手把自己起的子进程收掉 —— 这一步已经在 launchServer 之后,
+   * 光抛错的话会留下一个谁也用不了的 codex 进程活到 app 退出。
+   */
+  private acceptOrStop(res: ThreadStartResponse | ThreadResumeResponse): void {
+    try {
+      assertReadOnly(res);
+    } catch (e) {
+      this.dispose();
+      throw e;
+    }
   }
 
   /** 起子进程(带 MCP 令牌 env)并握手。 */

--- a/src/backend/agent/codex/codex-app-server.ts
+++ b/src/backend/agent/codex/codex-app-server.ts
@@ -5,6 +5,7 @@ import { JsonRpcConnection } from './jsonrpc';
 import {
   CodexMethod,
   CodexServerRequest,
+  DECLINE_BY_METHOD,
   type InitializeParams,
   type McpServerElicitationRequestParams,
   type McpServerElicitationRequestResponse,
@@ -108,7 +109,11 @@ export class CodexAppServer extends EventEmitter {
   /**
    * 反向请求处理。**架构必需件**:elicitation 不应答则 turn 卡死。
    * - 自建受信 MCP 工具的 elicitation → 自动 accept。
-   * - exec / applyPatch 审批 → review-only 应用一律 denied(只读 sandbox 下本不该出现)。
+   * - 各类审批 → review-only 应用一律拒绝(只读 sandbox 下本不该出现),并抛给上层观测。
+   *
+   * 拒绝的说法按方法族取自 {@link DECLINE_BY_METHOD};表里没有的(permissions、
+   * 以及将来新增的反向请求)应答形状我们并不知道,**猜一个结构回过去等于回了句听不懂的话** ——
+   * 一律回 JSON-RPC 错误,让 codex 明确收到「这边不接」。
    */
   private handleServerRequest(method: string, params: unknown): unknown {
     if (method === CodexServerRequest.mcpElicitation) {
@@ -121,16 +126,9 @@ export class CodexAppServer extends EventEmitter {
       return decision;
     }
 
-    if (
-      method === CodexServerRequest.execCommandApproval ||
-      method === CodexServerRequest.applyPatchApproval
-    ) {
-      this.emit('unexpected-approval', method, params);
-      return { decision: 'denied' };
-    }
-
-    // 其余反向请求:拒绝,并抛给上层观测
     this.emit('unexpected-approval', method, params);
-    return { decision: 'denied' };
+    const decline = DECLINE_BY_METHOD[method];
+    if (decline === undefined) throw new Error(`只读审核会话不接受反向请求: ${method}`);
+    return decline;
   }
 }

--- a/src/backend/agent/codex/protocol.ts
+++ b/src/backend/agent/codex/protocol.ts
@@ -1,5 +1,6 @@
 /**
- * codex app-server 协议的最小子集(手写,对齐 codex-cli 0.145.0 `generate-ts` 导出)。
+ * codex app-server 协议的最小子集(手写,对齐 `generate-ts` 导出;
+ * 对齐到哪个版本见 shared/codex.ts 的 `CODEX_TARGET_VERSION`)。
  * 只覆盖 Duetlens spike/骨架用到的方法与事件;全量类型可用
  *   `codex app-server generate-ts --out <DIR>`(见 npm script `codex:gen-types`)
  * 重导比对。协议标 experimental,升级 codex 后应重新导出回归。
@@ -40,8 +41,18 @@ export interface ThreadStartParams {
   ephemeral?: boolean;
 }
 
-export interface ThreadStartResponse {
-  thread: { id: string; sessionId: string; [k: string]: unknown };
+/**
+ * thread/start 与 thread/resume 都会**回显本次生效的策略**(形状与请求不同:请求送
+ * `sandbox: 'read-only'` 这个 SandboxMode,应答回的是 SandboxPolicy 结构体)。
+ * 这几个字段是只读注入能否被证实的唯一途径,见 {@link SANDBOX_NOT_APPLIED_CODE}。
+ */
+export interface EffectiveThreadPolicy {
+  approvalPolicy?: string;
+  sandbox?: { type?: string; [k: string]: unknown } | null;
+}
+
+export interface ThreadStartResponse extends EffectiveThreadPolicy {
+  thread: { id: string; sessionId: string; cliVersion?: string; [k: string]: unknown };
   model: string;
   cwd: string;
   [k: string]: unknown;
@@ -59,8 +70,8 @@ export interface ThreadResumeParams {
   model?: string;
 }
 
-export interface ThreadResumeResponse {
-  thread: { id: string; [k: string]: unknown };
+export interface ThreadResumeResponse extends EffectiveThreadPolicy {
+  thread: { id: string; cliVersion?: string; [k: string]: unknown };
   model: string;
   cwd: string;
   [k: string]: unknown;
@@ -193,11 +204,26 @@ export const CodexMethod = {
 /** server→client 反向请求(需应答) */
 export const CodexServerRequest = {
   mcpElicitation: 'mcpServer/elicitation/request',
+  /** legacy 命名;v2 turn 走的是 commandExecutionApproval,两套都还在表里,故都要认 */
   execCommandApproval: 'execCommandApproval',
   applyPatchApproval: 'applyPatchApproval',
+  commandExecutionApproval: 'item/commandExecution/requestApproval',
   fileChangeApproval: 'item/fileChange/requestApproval',
   permissionsApproval: 'item/permissions/requestApproval',
 } as const;
+
+/**
+ * 拒绝一次审批要按**该方法自己的应答类型**说,不同族的说法不一样,没有通用的 `denied`:
+ * - legacy(exec/applyPatch)是 `ReviewDecision`,拒绝是对象变体 `{ denied: { rejection } }`;
+ * - v2(commandExecution/fileChange)是各自的 decision 枚举,拒绝一律是 `'decline'`;
+ * - permissions 的应答里**根本没有 decision 字段**(要回一份授权档),表达不了拒绝 —— 只能回错误。
+ */
+export const DECLINE_BY_METHOD: Readonly<Record<string, unknown>> = {
+  [CodexServerRequest.execCommandApproval]: { decision: { denied: { rejection: '只读审核会话' } } },
+  [CodexServerRequest.applyPatchApproval]: { decision: { denied: { rejection: '只读审核会话' } } },
+  [CodexServerRequest.commandExecutionApproval]: { decision: 'decline' },
+  [CodexServerRequest.fileChangeApproval]: { decision: 'decline' },
+};
 
 /** server→client 单向通知(流事件) */
 export const CodexNotification = {

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -21,7 +21,8 @@ import type {
 import type { AgentErrorKind } from '@shared/agent-events';
 import { changedFilesBetween, parseUnifiedDiff, type DiffFile } from '@shared/diff';
 import type { AddFindingInput, BusyReview, FindingEditInput, LatestDiffResult, LiveCapacity, RecentReview, RerunInput, ReviewEvent, ReviewStartStage, SubmitReviewInput, SubmitReviewResult } from '@shared/ipc';
-import { LIVE_SESSION_LIMIT_CODE } from '@shared/ipc';
+import { LIVE_SESSION_LIMIT_CODE, SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
+import { isCodexProtocolError } from '@shared/codex';
 import type { PromptSaveInput, ReviewPromptView } from '@shared/prompt';
 import { buildPrReviewPayload, isSubmittable, submitBlocker } from '@shared/github-review';
 import type { McpContentProviders } from '../mcp/duetlens-mcp-server';
@@ -141,10 +142,20 @@ const SESSION_FORWARDERS: {
  * 轮次失败的落库形态。turn 失败带得到 agent 归因;编排层自己抛的(source/网络/gh)只有原文,
  * 归到 'other' —— 宁可不分类,也不按 message 猜。
  */
-function describeRoundFailure(cause: unknown): { errorMessage: string; errorKind: AgentErrorKind } {
+export function describeRoundFailure(cause: unknown): {
+  errorMessage: string;
+  errorKind: AgentErrorKind;
+} {
   if (cause instanceof AgentTurnError) return { errorMessage: cause.detail, errorKind: cause.errorKind };
   const message = cause instanceof Error ? cause.message : String(cause ?? '');
-  return { errorMessage: message || '未知错误', errorKind: 'other' };
+  // 建会话阶段抛的是普通 Error(没有 turn,也就没有 codexErrorInfo 可映射)。不在这里认出来的话,
+  // 这两类都落成 'other' —— 文案泛泛,还带 retryable,把用户往「再试一次」上引,而这两类重试必然复现。
+  const kind: AgentErrorKind = message.includes(SANDBOX_NOT_APPLIED_CODE)
+    ? 'sandbox-not-applied'
+    : isCodexProtocolError(message)
+      ? 'codex-version-mismatch'
+      : 'other';
+  return { errorMessage: message || '未知错误', errorKind: kind };
 }
 
 /**
@@ -958,6 +969,10 @@ export class ReviewManager extends EventEmitter {
         (e: unknown) => {
           this.settleRound(review.id, round, 'failed', e);
           this.forward({ reviewId: review.id, type: 'status', payload: 'failed' });
+          // 会话根本没建起来(如握手时的只读校验被拒):它已入表却永远用不了,还攥着
+          // codex 子进程、MCP server、source 与一个 live 名额。就地拆,别等 LRU 或用户手动释放。
+          // 释放本身再失败也不能盖掉上面已落库的原始失败,更不能变成进程级 unhandled rejection
+          if (!session.isOpen()) void this.teardown(review.id).catch(() => undefined);
         },
       );
   }

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -23,7 +23,7 @@ import {
   type WriteSummaryInput,
 } from '@shared/domain';
 import { findDuplicate, isRestatedFinding } from '@shared/finding-dedupe';
-import { FOLLOWUP_REPLY_FAILED_CODE } from '@shared/ipc';
+import { FOLLOWUP_REPLY_FAILED_CODE, SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
 import type { AgentErrorKind } from '@shared/agent-events';
 import type { AgentEvent, ConversationalAgent } from '../agent/conversational-agent';
 import type { ReviewStore } from '../db/review-store';
@@ -509,6 +509,14 @@ export class ReviewSession {
   }
 
   /**
+   * codex thread 是否真的建起来过。**没建起来的会话是死的**:追问会被闸门挡下,
+   * 而它照样占着 codex 子进程、MCP server 与一个 live 名额,故建会话失败时要就地拆掉。
+   */
+  isOpen(): boolean {
+    return this.conversationId !== undefined;
+  }
+
+  /**
    * agent 手上是否有活:建/续会话中,或有在跑的 turn。并发上限逐出会话时据此避让 ——
    * 拆掉忙碌会话等于凭空打断别人的机审,那一轮只会以一句莫名其妙的失败收场。
    */
@@ -825,6 +833,22 @@ export class ReviewSession {
 
     cleanup.push(
       this.agent.streamEvents((e) => {
+        // 注入的 approvalPolicy 是 never,codex 本不该来问这类审批;问了就说明只读策略没生效。
+        // 与握手时的读回校验同一个判据,这里是它的兜底。
+        if (e.kind === 'approval' && !e.expected && e.gate === 'policy') {
+          finish({
+            kind: 'turn-failed',
+            turnId: mine ?? '',
+            error: `${SANDBOX_NOT_APPLIED_CODE} codex 在只读会话里请求了 ${e.method} 审批,已拒绝并中止本轮。`,
+            errorKind: 'sandbox-not-applied',
+          });
+          // 定性只结束**我们这边**的等待,codex 的 turn 还在跑 —— 而这条分支的前提正是
+          // 「不知道它在什么策略下跑」。拆掉会话让它真的停手:打断需要对方配合,
+          // 这里已经不能假定对方守规矩;何况会话留着,下一条追问又会喂进同一个坏策略里。
+          // 拆的过程再出错也别变成进程级 unhandled rejection —— 判死已经落下了
+          void this.dispose().catch(() => undefined);
+          return;
+        }
         if (e.kind === 'message-delta') {
           if (!identified) heldDeltas.set(e.turnId, (heldDeltas.get(e.turnId) ?? '') + e.text);
           else if (isMine(e.turnId)) reply += e.text;

--- a/src/renderer/screens/review/round-error.ts
+++ b/src/renderer/screens/review/round-error.ts
@@ -1,5 +1,6 @@
 import type { AgentErrorKind } from '@shared/agent-events';
-import { FOLLOWUP_REPLY_FAILED_CODE } from '@shared/ipc';
+import { CODEX_TARGET_VERSION, isCodexProtocolError } from '@shared/codex';
+import { FOLLOWUP_REPLY_FAILED_CODE, SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
 
 /**
  * 失败归因 → 用户能读懂的结论与处置。原文一律另行原样呈现 ——
@@ -13,6 +14,19 @@ export interface RoundErrorCopy {
   /** 重试是否有意义(决定「重试本轮」是主按钮还是次按钮) */
   retryable: boolean;
 }
+
+/**
+ * codex 版本相关的两条结论。轮次失败(按 errorKind 分档)与开跑前失败(按特征串认)
+ * 是两条渲染路径,但同一件事只该有一份措辞 —— 故在此定义一次,两张表都引它。
+ */
+const SANDBOX_BREACH = {
+  title: 'codex 没有按只读沙箱起会话,已中止',
+  advice: `本机 codex 与这版 Duetlens 对不上,注入的只读策略没有生效 —— 继续跑等于让审核 agent 在未知策略下动你的仓库,所以直接停了。这版对齐的是 codex ${CODEX_TARGET_VERSION},升级后再跑。`,
+};
+const VERSION_MISMATCH = {
+  title: '本机 codex 版本与这版 Duetlens 对不上',
+  advice: `这版对齐的是 codex ${CODEX_TARGET_VERSION}。在终端跑 codex --version 看看本机是哪个版本,升到相近版本再试。`,
+};
 
 const COPY: Record<AgentErrorKind, RoundErrorCopy> = {
   'usage-limit': {
@@ -45,6 +59,8 @@ const COPY: Record<AgentErrorKind, RoundErrorCopy> = {
     advice: '多为模型名不可用或内容触发策略拦截。换个模型再试;仍失败请看下方原文。',
     retryable: false,
   },
+  'sandbox-not-applied': { ...SANDBOX_BREACH, retryable: false },
+  'codex-version-mismatch': { ...VERSION_MISMATCH, retryable: false },
   other: {
     title: '这一轮机审没能跑完',
     advice: '',
@@ -62,8 +78,22 @@ export function describeRoundError(kind: AgentErrorKind | null): RoundErrorCopy 
 // 因而没有归因可落库 —— 只有底层命令的原文。这里按可辨认的特征串给出人话结论,
 // 认不出就只给通用结论;原文一律照常呈现,不靠猜来替代证据。
 
-/** 特征串 → 结论。顺序即优先级:越具体的排前面。 */
-const LAUNCH_PATTERNS: { match: RegExp; title: string; advice: string }[] = [
+/**
+ * 特征 → 结论。顺序即优先级:越具体的排前面。
+ * 判据多数是特征串;需要「几个条件同时成立」才作数的(如协议错)给谓词。
+ */
+const LAUNCH_PATTERNS: {
+  match: RegExp | ((raw: string) => boolean);
+  title: string;
+  advice: string;
+}[] = [
+  { match: new RegExp(SANDBOX_NOT_APPLIED_CODE), ...SANDBOX_BREACH },
+  {
+    // codex 的 JSON-RPC 参数/方法校验失败。与业务无关,一律是版本对不上 ——
+    // 不认出来的话,用户看到的就是一句「Invalid request: missing field ... (code -32600)」。
+    match: isCodexProtocolError,
+    ...VERSION_MISMATCH,
+  },
   {
     // `but diff <branch>` 解析不出该虚拟分支
     match: /No ID found for entity/i,
@@ -128,7 +158,9 @@ export function stripIpcWrapper(message: string): string {
  */
 export function describeLaunchError(message: string, fallbackTitle = '这一轮没能开跑'): LaunchErrorCopy {
   const raw = stripIpcWrapper(message);
-  const hit = LAUNCH_PATTERNS.find((p) => p.match.test(raw));
+  const hit = LAUNCH_PATTERNS.find((p) =>
+    typeof p.match === 'function' ? p.match(raw) : p.match.test(raw),
+  );
   return {
     title: hit?.title ?? fallbackTitle,
     advice: hit?.advice ?? '',

--- a/src/shared/agent-events.ts
+++ b/src/shared/agent-events.ts
@@ -25,6 +25,10 @@ export const AGENT_ERROR_KINDS = [
   'unauthorized',
   /** 请求被拒(参数/策略)—— 重试无用 */
   'bad-request',
+  /** 只读沙箱注入没落地(见 SANDBOX_NOT_APPLIED_CODE)—— 换模型没用,要升 codex */
+  'sandbox-not-applied',
+  /** 本机 codex 与这版对齐的协议对不上(见 CODEX_PROTOCOL_ERROR)—— 重试必然复现 */
+  'codex-version-mismatch',
   'other',
 ] as const;
 export type AgentErrorKind = (typeof AGENT_ERROR_KINDS)[number];
@@ -43,7 +47,20 @@ export type AgentEvent =
   // 不碰我们 DB 里的锚点/finding;不主动 thread/compact/start)。
   | { kind: 'compaction'; phase: 'started' | 'completed' }
   // 反向审批的统一观测面:受信工具 elicitation 自动 accept 为 expected;其余一律拒绝且 expected=false。
-  | { kind: 'approval'; method: string; decision: 'accepted' | 'declined' | 'denied'; expected: boolean; server?: string; message?: string }
+  | {
+      kind: 'approval';
+      method: string;
+      decision: 'accepted' | 'declined' | 'denied';
+      expected: boolean;
+      /**
+       * 这条反向请求把关的是什么。**只有 `policy` 能当沙箱哨兵** —— 它是执行/写入/权限类
+       * 审批,只读会话里根本不该出现;`mcp` 是工具侧的 elicitation,被拒只说明我们没批准
+       * 那次调用(用户自己配的第三方 MCP server 就会走这条),不能据此断定注入失效。
+       */
+      gate: 'policy' | 'mcp';
+      server?: string;
+      message?: string;
+    }
   | { kind: 'turn-completed'; turnId: string }
   | { kind: 'turn-failed'; turnId: string; error: string; errorKind: AgentErrorKind }
   // agent 自己还会重试的中途失败:一轮可能这样静默耗掉几十秒,不外发的话进度条是纯黑盒。

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -1,0 +1,33 @@
+/**
+ * 与本机 codex 的版本契约。放 shared:backend 起会话时据此校验,renderer 出错时据此给结论。
+ *
+ * app-server **没有版本协商**:initialize 只在 userAgent 串里带版本,没有 capabilities 列表,
+ * 而 thread/start 的应答里有 `thread.cliVersion`。所以「对不对得上」只能事后从失败里认,
+ * 认不出就会以裸 JSON-RPC 错误码糊到用户脸上。
+ */
+
+/** 手写协议子集(backend/agent/codex/protocol.ts)对齐的 codex 版本。 */
+export const CODEX_TARGET_VERSION = '0.145.0';
+
+/**
+ * JSON-RPC 错误码的尾巴。只由 jsonrpc.ts 拼接 codex 的错误应答时产生,来源唯一 ——
+ * 但**不足以**定性:codex 把 -32600 也用在业务条件上(如「no active turn to interrupt」)。
+ */
+const RPC_REJECTED = /\(code -3260[01]\)/;
+
+/**
+ * serde 反序列化失败的措辞。单看同样**不足以**定性:`Invalid request` / `missing field`
+ * 这类词满世界都是 —— GitHub 的 400、git 的报错都可能带。
+ */
+const SERDE_SHAPE = /Invalid request|missing field|unknown variant|unknown field|invalid type/i;
+
+/**
+ * 本机 codex 与这版 Duetlens 的协议对不上:少了必填字段、方法改了名、枚举换了值。
+ *
+ * **两个条件缺一不可** —— 各自都会误伤,而且是相反方向的误伤:光认措辞会把 gh / git 的
+ * 报错打成版本不匹配,光认错误码会把 codex 自己的业务拒绝打成版本不匹配。两类误判的代价
+ * 一样:真实原因被盖掉,还给用户扣一个不可重试的「去升级 codex」。
+ */
+export function isCodexProtocolError(message: string): boolean {
+  return RPC_REJECTED.test(message) && SERDE_SHAPE.test(message);
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -189,6 +189,19 @@ export const LIVE_SESSION_LIMIT_CODE = 'DUETLENS_LIVE_SESSION_LIMIT';
  */
 export const FOLLOWUP_REPLY_FAILED_CODE = 'DUETLENS_FOLLOWUP_REPLY_FAILED';
 
+/**
+ * 只读沙箱注入没有落地 —— **安全性判据,不是普通失败**。
+ *
+ * codex 对请求里的未知字段是**静默忽略**的(实测多送一个字段照常走到业务逻辑),
+ * 所以 thread/start 把 `sandbox` 送出去不等于它生效:字段哪天改名或换枚举,我们会
+ * 「发送成功」而 codex 按自己的默认策略跑,审核 agent 就不再是只读的,且全程无一句报错。
+ * 又因为注入的 `approvalPolicy` 是 never,这种情况下 codex **不会来问**,没有天然的哨兵。
+ *
+ * 故一律失败关闭:握手读回策略、turn 里收到本不该出现的审批请求,两处都判死本轮。
+ * 嵌进 message 的理由同 {@link FOLLOWUP_REPLY_FAILED_CODE}:IPC 只把 message 串过去。
+ */
+export const SANDBOX_NOT_APPLIED_CODE = 'DUETLENS_SANDBOX_NOT_APPLIED';
+
 /** 正在跑的一条审核;满载提示逐条列出,可跳过去看或叫停。 */
 export interface BusyReview {
   reviewId: string;


### PR DESCRIPTION
Follow-up to #19. That PR fixed one instance of codex protocol drift; this one addresses the class, because the user's codex version is whatever they happen to have installed.

Two facts drove the design, both probed against real codex at no token cost (`thread/start` does not call the model):

- **There is no version negotiation.** `initialize` returns the version only inside a userAgent string, with no capabilities list. `thread/start` does echo `thread.cliVersion`.
- **Parameter validation is asymmetric.** A missing required field is a hard `-32600`. An *unknown* field is silently ignored — I sent a junk field and the request still reached the business logic.

The second one is the dangerous half, and it had no sentinel. We inject `sandbox: read-only` and `approvalPolicy: never` at `thread/start`. If either field is ever renamed, we "send successfully", codex runs under its own default policy, the review agent is no longer read-only, and nothing anywhere reports it. Because the injected `approvalPolicy` is `never`, codex would not even ask for approval in that state.

## What this does

**Prove the injection landed, don't assume it.** `thread/start` echoes the effective policy, so `assertReadOnly` reads it back and refuses to start the session otherwise. Missing values fail closed too — a false positive is "won't launch, go upgrade", a false negative is "the agent works in your repo under an unknown policy, silently". Comparison normalises case and separators so a cosmetic rename (`readOnly` / `read-only`) does not lock everyone out.

**Treat a policy approval as proof of failure.** An exec / command-execution / file-change / permissions approval cannot occur in a correctly configured session, so it kills the round and tears the session down. Ending the local wait is not enough: the codex turn keeps running, which is the whole hazard, and a surviving session would feed the next follow-up into the same bad policy.

**Say why, in terms of what the user can do.** Protocol rejections previously reached the UI as a raw `-32600` line, and both new failure modes would have flattened into a generic retryable error on the round path — the UI would have offered "retry" as the primary action for a failure that reproduces deterministically. Both now have their own `AgentErrorKind`.

## Review rounds

Three rounds of local review; findings that changed the code:

- The sentinel was too broad. `expected: false` also covers a declined elicitation from a third-party MCP server the user configured themselves — that would have killed a healthy round and told them to upgrade codex. The discriminator moved to the agent boundary (`gate: 'policy' | 'mcp'`) rather than matching codex method names in the provider-neutral session layer.
- The sentinel was also too narrow: `item/commandExecution/requestApproval` was missing from `CodexServerRequest` entirely, so the actual v2 command-execution approval bypassed it. Fixed, and a spike now pins *every* approval method to the sentinel set, so a new one cannot be added without classifying it.
- Verifying that turned up something the review had not: our refusal payload was invalid for every approval family. There is no universal `denied` — the legacy pair takes an object variant, the v2 pair takes `'decline'`, and permissions has no `decision` field at all and now gets a JSON-RPC error instead of a guessed body.
- The launch path leaked. A rejected handshake left the codex child process, the MCP server, the source and a live-session slot behind.
- The protocol classifier over-matched, and my first fix for it was wrong in the opposite direction. Matching prose catches gh and git errors; matching the `-32600` code alone catches codex's own business rejections (`no active turn to interrupt (code -32600)` is real output). It now requires both, and the spike pins both failure directions.

One finding was rejected: `cliVersion` is declared in the generated `v2/Thread.ts` as a required field, `ThreadStartResponse.thread` is that type, real responses carry it, and the failure message printed `本机 codex 0.145.0` rather than the claimed "版本未知".

## Verification

`typecheck`, `lint`, the eight spikes touching `ReviewSession`, and the real-codex handshake check all pass. New `spike:sandbox-guard` has 5 cases; every assertion in it was confirmed red against the code it guards.

Not verified: the corrected refusal payloads have only been checked against the generated type declarations. Provoking a real approval request needs a deliberately non-read-only session running a turn that writes files, which costs tokens and is worth more than it proves.

`shared/codex.ts` is now the single source for the targeted codex version and the protocol-error test; `protocol.ts` points at it instead of restating the version.