### PR TITLE
fix(source): accept both but json output flags

### DIFF
--- a/src/backend/source/but-cli.ts
+++ b/src/backend/source/but-cli.ts
@@ -1,0 +1,30 @@
+import { run } from './exec';
+
+/** JSON 输出开关在 but 0.22 由 `--format json` 改名为 `--json`。 */
+const MODERN = ['--json'];
+const LEGACY = ['--format', 'json'];
+
+/** 上一次跑通的写法;首次调用与切换 but 版本后由 butJson 自行纠正。 */
+let known: string[] = MODERN;
+
+/**
+ * 跑 `but <args>` 并要 JSON 输出,两种 flag 写法自动择一。
+ * 只有 clap 的「未知参数」才换写法重试 —— 不是 GitButler 项目、分支不存在这类真错误照常抛出。
+ */
+export async function butJson(args: string[], cwd?: string): Promise<string> {
+  const [first, second] = known === LEGACY ? [LEGACY, MODERN] : [MODERN, LEGACY];
+  try {
+    const out = await run('but', [...args, ...first], cwd);
+    known = first;
+    return out;
+  } catch (err) {
+    if (!isUnknownArg(err)) throw err;
+  }
+  const out = await run('but', [...args, ...second], cwd);
+  known = second;
+  return out;
+}
+
+function isUnknownArg(err: unknown): boolean {
+  return String((err as { stderr?: string }).stderr ?? '').includes('unexpected argument');
+}

--- a/src/backend/source/gitbutler-source.ts
+++ b/src/backend/source/gitbutler-source.ts
@@ -1,9 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { run } from './exec';
+import { butJson } from './but-cli';
 import type { PreparedSource, ReviewTarget, Source } from './source';
 
-/** `but diff --format json` 的最小结构(只取重建 unified diff 所需字段)。 */
+/** `but diff` JSON 输出的最小结构(只取重建 unified diff 所需字段)。 */
 interface ButDiffJson {
   changes: ButChange[];
 }
@@ -17,7 +17,7 @@ interface ButChange {
 }
 
 /**
- * GitButler 虚拟分支 source:diff 走 `but diff <branch> --format json`(重建成标准 unified),
+ * GitButler 虚拟分支 source:diff 走 `but diff <branch>` 的 JSON 输出(重建成标准 unified),
  * 文件读工作区磁盘内容(applied vbranch 的改动已落在 worktree,即新侧)。
  * target.ref = 虚拟分支名;target.repoPath = 已 setup 的 GitButler 项目目录。
  */
@@ -33,11 +33,7 @@ export class GitButlerSource implements Source {
   }
 
   async getDiff(): Promise<string> {
-    const out = await run(
-      'but',
-      ['diff', this.branch(), '--format', 'json', '--no-tui'],
-      this.target.repoPath,
-    );
+    const out = await butJson(['diff', this.branch(), '--no-tui'], this.target.repoPath);
     return toUnifiedDiff(JSON.parse(out) as ButDiffJson);
   }
 

--- a/src/backend/source/source-discovery.ts
+++ b/src/backend/source/source-discovery.ts
@@ -16,6 +16,7 @@ import type {
   RepoRemoteInfo,
   VbranchSummary,
 } from '@shared/source-discovery';
+import { butJson } from './but-cli';
 import { run } from './exec';
 import { parsePrRef } from './github-pr-source';
 
@@ -256,7 +257,7 @@ export async function detectGitButler(repoPath: string): Promise<GitButlerStatus
   const repoName = path.basename(path.resolve(repoPath));
   let json: string;
   try {
-    json = await run('but', ['status', '--format', 'json'], repoPath);
+    json = await butJson(['status'], repoPath);
   } catch {
     return { isWorkspace: false, repoName, branches: [] };
   }
@@ -286,7 +287,7 @@ export async function detectGitButler(repoPath: string): Promise<GitButlerStatus
 /** 虚拟分支相对 base 的净改动文件数;取不到(分支刚被改名 / but 报错)记 0,不阻断列举。 */
 async function countDiffFiles(repoPath: string, branch: string): Promise<number> {
   try {
-    const out = await run('but', ['diff', branch, '--format', 'json', '--no-tui'], repoPath);
+    const out = await butJson(['diff', branch, '--no-tui'], repoPath);
     return (JSON.parse(out) as { changes?: unknown[] }).changes?.length ?? 0;
   } catch {
     return 0;

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -690,7 +690,7 @@ export function installPreviewApi(): void {
       rerun: async (_r, input) => {
         if (params.get('retry') === 'error')
           throw new Error(
-            "Error invoking remote method 'review:rerun': Error: Command failed: but diff feat/entry-branch-picker --format json --no-tui\nNo ID found for entity No ID found for entity\n",
+            "Error invoking remote method 'review:rerun': Error: Command failed: but diff feat/entry-branch-picker --no-tui --json\nNo ID found for entity No ID found for entity\n",
           );
         const round: ReviewRound = {
           reviewId: 'demo',
@@ -728,7 +728,7 @@ export function installPreviewApi(): void {
         // ?retry=error:重跑/重试在**开跑前**就失败(source 没了),自查 LaunchError 的呈现
         if (params.get('retry') === 'error')
           throw new Error(
-            "Error invoking remote method 'review:retry-round': Error: Command failed: but diff feat/entry-branch-picker --format json --no-tui\nNo ID found for entity No ID found for entity\n",
+            "Error invoking remote method 'review:retry-round': Error: Command failed: but diff feat/entry-branch-picker --no-tui --json\nNo ID found for entity No ID found for entity\n",
           );
         const failed = rounds[rounds.length - 1];
         const round: ReviewRound = {


### PR DESCRIPTION
GitButler 0.22 renamed the JSON output switch from `--format json` to `--json`. All three `but` call sites still passed the old flag, so the CLI rejected them with `error: unexpected argument '--format' found`.

The user-visible symptom: on a real GitButler workspace the entry screen reported "该目录不是 GitButler 项目(未 setup)" and fell back to plain-git review — `detectGitButler` swallowed the failure, and `but --version` still succeeded, so `inspectRepo` landed on `not-setup`. The other two sites failed more quietly: branch file counts showed 0, and `GitButlerSource.getDiff` threw once a review actually started.

New `but-cli.ts` wraps the JSON invocations and picks the flag spelling that the installed CLI accepts, so both old and new `but` keep working. Only clap's "unexpected argument" triggers the retry — real errors (not a GitButler project, unknown branch) still propagate. The last working spelling is remembered and self-corrects if the `but` binary is swapped.

The JSON payload shape is unchanged across the rename, so nothing downstream needed touching.

Verified with a spike: modern `--json` path, fallback to `--format json` against a stubbed old CLI, self-heal after switching back, real errors still thrown, and `inspectRepo` returning `mode=gitbutler` / `degraded=null` on this repo.