### PR TITLE
chore(release): 0.2.2

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -4,6 +4,28 @@ Only **user-visible** changes are recorded here. Internal refactors, docs and CI
 listed — read `git log` for those. Versions follow [Semantic Versioning](https://semver.org/);
 while on `0.x`, the minor position doubles as the breaking-change position.
 
+## [0.2.2] - 2026-07-31
+
+### Fixed
+
+- **A real GitButler repository is no longer mistaken for "not a GitButler project".** GitButler 0.22
+  renamed the JSON output switch from `--format json` to `--json`, and all three call sites still
+  passed the old spelling: the entry screen reported "not a GitButler project (not set up)" and fell
+  back to a plain-git review, branch cards showed 0 changed files, and fetching the diff failed once a
+  review actually started. The spelling the installed `but` accepts is now picked automatically, so
+  both the old and the new CLI work. (#22)
+- **The github theme now actually looks like GitHub.** It used to style only the code half, leaving the
+  app chrome on duetlens blue; the syntax colors themselves were stale — several retired values — and
+  grouped by duetlens' idea of grammar, while GitHub counts literals as constants, gives tags their own
+  slot, does not treat attributes as types, and reserves orange for type and class names. Syntax colors
+  are rebuilt on current Primer tokens, and the chrome moves with them: Primer surfaces, 6px radius,
+  GitHub green primary button. The duetlens and parchment themes render exactly as before. (#23)
+
+### Upgrade notes
+
+- The database schema is unchanged at v16; 0.2.0, 0.2.1 and 0.2.2 can be installed in any direction.
+- The update arrives through the in-app updater; there is no need to download the dmg again.
+
 ## [0.2.1] - 2026-07-30
 
 ### Fixed
@@ -79,6 +101,7 @@ while on `0.x`, the minor position doubles as the breaking-change position.
 
 First public release.
 
+[0.2.2]: https://github.com/xieziyu/duetlens/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/xieziyu/duetlens/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/xieziyu/duetlens/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/xieziyu/duetlens/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 本文件只记**对使用者可见**的变化。内部重构、文档与 CI 调整不单列,查 `git log`。
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/);`0.x` 阶段 minor 位即破坏性变更位。
 
+## [0.2.2] - 2026-07-31
+
+### 修复
+
+- **GitButler 仓库不再被误判成「不是 GitButler 项目」。** `but` 在 0.22 把 JSON 输出开关从 `--format json` 改名成 `--json`,而三处调用还在传旧写法:入口屏因此报「该目录不是 GitButler 项目(未 setup)」并退回纯 git 评审,分支卡片的改动文件数显示为 0,评审真跑起来时取 diff 直接失败。现在会自动挑本机 `but` 认的那种写法,新旧 CLI 都能用。(#22)
+- **github 配色现在真的是 GitHub 的样子。** 之前它只管代码那半边,应用外壳仍是 duetlens 蓝;语法配色本身也停在几个已废弃的旧值上,并且按 duetlens 的语法口味分组 —— 而 GitHub 把字面量算作常量、标签单独占一档、属性不算类型、橙色只留给类型与类名。这版语法色按 Primer 现行 tokens 重做,外壳一并换成 Primer 表面色、6px 圆角与 GitHub 绿主按钮。duetlens 与 parchment 两套配色的渲染结果不变。(#23)
+
+### 升级须知
+
+- 数据库结构不变,仍是 v16,与 0.2.0 / 0.2.1 之间可以来回安装。
+- 更新由应用内 updater 接手,无需重新下载 dmg。
+
 ## [0.2.1] - 2026-07-30
 
 ### 修复
@@ -44,6 +56,7 @@
 
 首个公开版本。
 
+[0.2.2]: https://github.com/xieziyu/duetlens/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/xieziyu/duetlens/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/xieziyu/duetlens/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/xieziyu/duetlens/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duetlens",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
Patch release. Both changes since v0.2.1 are fixes (#22, #23): the `but` JSON flag rename that
made real GitButler repos look unconfigured, and the github theme rebuilt on current Primer
tokens. No schema migration — still v16, so 0.2.0 / 0.2.1 / 0.2.2 install in any direction.

Version lives only in `package.json` — `APP_VERSION` is injected at build time.

## Local gate

- `typecheck`, `lint` clean.
- `release-notes.mjs 0.2.2` extracts both language sections; `release-notes.mjs 9.9.9` exits
  non-zero, so a missing section still blocks a release.
- `rebuild:electron && package`: `CFBundleShortVersionString` and `APP_VERSION` both read 0.2.2,
  signature is adhoc as expected locally.
- Smoke launch survives 8s, so signing reattached after the fuses flip.

Not verified locally: dmg/zip and notarization, which only the release workflow produces.