### PR TITLE
fix(renderer): ignore keys fired during IME composition

### DIFF
--- a/src/renderer/keys.ts
+++ b/src/renderer/keys.ts
@@ -1,0 +1,12 @@
+import type { KeyboardEvent } from 'react';
+
+/**
+ * 输入法组合期的按键不是确认/取消的意图:候选窗里 Enter 是选词、Esc 是撤候选,派发出来的
+ * keydown 与"提交""放弃编辑"长得一模一样。凡是靠**裸** Enter / Esc 触发动作的 handler
+ * 都要先让位(带 ⌘/Ctrl 的组合键不会被输入法吃掉,不受影响)。
+ *
+ * keyCode 229 是兜底:个别输入法不置 isComposing,但组合期一律报 229。
+ */
+export function imeComposing(e: KeyboardEvent): boolean {
+  return e.nativeEvent.isComposing || e.keyCode === 229;
+}

--- a/src/renderer/screens/PromptRulesScreen.tsx
+++ b/src/renderer/screens/PromptRulesScreen.tsx
@@ -9,6 +9,7 @@ import {
   type PromptSectionKey,
   type ReviewPromptView,
 } from '@shared/prompt';
+import { imeComposing } from '../keys';
 import './PromptRulesScreen.css';
 
 // 三层审核规则提示词编辑器。
@@ -333,6 +334,7 @@ export function PromptRulesScreen({
       value={draft}
       onChange={(e) => setDraft(e.target.value)}
       onKeyDown={(e) => {
+        if (imeComposing(e)) return;
         if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
           e.preventDefault();
           onCommit();

--- a/src/renderer/screens/entry/BranchPicker.tsx
+++ b/src/renderer/screens/entry/BranchPicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { imeComposing } from '../../keys';
 import { GitButlerIcon, LocalBranchIcon } from './icons';
 
 /** 一个可审核目标(普通 git 分支或 GitButler 虚拟分支)在选择器里的展示形态。 */
@@ -95,6 +96,7 @@ export function BranchPicker({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return;
     if (e.key === 'Escape') {
       setOpen(false);
       return;

--- a/src/renderer/screens/review/AnnotateComposer.tsx
+++ b/src/renderer/screens/review/AnnotateComposer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Severity } from '@shared/domain';
+import { imeComposing } from '../../keys';
 import { CategorySelect } from './CategorySelect';
 import { describeSendFailure } from './round-error';
 
@@ -102,6 +103,7 @@ export function AnnotateComposer({ label, snippet, onSend, onCreate, onCancel }:
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return;
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
       e.preventDefault();
       void submit();

--- a/src/renderer/screens/review/CategorySelect.tsx
+++ b/src/renderer/screens/review/CategorySelect.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { FINDING_CATEGORIES } from '@shared/domain';
+import { imeComposing } from '../../keys';
 
 /**
  * finding 的 category 选择器:输入即筛选,但**只认列表里的值** ——
@@ -43,6 +44,7 @@ export function CategorySelect({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return;
     if (e.key === 'Escape') {
       // 展开时 Esc 只关下拉;冒到 composer 上会连整张卡一起取消
       if (!open) return;

--- a/src/renderer/screens/review/DiffFindBar.tsx
+++ b/src/renderer/screens/review/DiffFindBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { imeComposing } from '../../keys';
 import type { FindOptions } from './diff-find';
 
 export interface DiffFindBarProps {
@@ -47,6 +48,7 @@ export function DiffFindBar({
       : `${current + 1} / ${total}${capped ? '+' : ''}`;
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (imeComposing(e)) return;
     if (e.key === 'Escape') {
       e.stopPropagation();
       onClose();

--- a/src/renderer/screens/review/FileTree.tsx
+++ b/src/renderer/screens/review/FileTree.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo, type RefObject } from 'react';
 import type { DiffFile, FileStatus } from '@shared/diff';
 import type { Finding } from '@shared/domain';
+import { imeComposing } from '../../keys';
 import { containsHits, matchFilePath, parseFileQuery } from './file-filter';
 
 /** 文件状态字母标记(对齐 GitHub 惯例:A/D/M/R)。 */
@@ -97,6 +98,7 @@ export function FileTree({
 
   // 检索框内的移动键:↵ 跳首个筛选结果,↑/↓ 在筛选结果间挪选中(手不离键盘也能翻过一串候选)
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (imeComposing(e)) return;
     if (e.key === 'Escape') {
       e.stopPropagation();
       if (query) onQueryChange('');

--- a/src/renderer/screens/review/InlineCard.tsx
+++ b/src/renderer/screens/review/InlineCard.tsx
@@ -7,6 +7,7 @@ import {
   type Triage,
 } from '@shared/domain';
 import type { FindingEditInput } from '@shared/ipc';
+import { imeComposing } from '../../keys';
 import { CategorySelect } from './CategorySelect';
 import { renderMarkdown } from './markdown';
 import { currentResolution, isNewThisRound } from './rounds';
@@ -160,6 +161,7 @@ function DismissedCard({
             value={reason}
             onChange={(e) => setReason(e.target.value)}
             onKeyDown={(e) => {
+              if (imeComposing(e)) return;
               if (e.key === 'Enter') save();
               if (e.key === 'Escape') {
                 setReason(finding.dismissReason ?? '');
@@ -347,6 +349,7 @@ function CardEdit({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return;
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
       e.preventDefault();
       save();

--- a/src/renderer/screens/review/RerunPanel.tsx
+++ b/src/renderer/screens/review/RerunPanel.tsx
@@ -9,6 +9,7 @@ import {
   type ReviewIntensity,
   type ReviewRound,
 } from '@shared/domain';
+import { imeComposing } from '../../keys';
 import { LaunchError } from './LaunchError';
 
 /**
@@ -69,6 +70,7 @@ export function RerunPanel({
         className="rerun-panel"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
+          if (imeComposing(e)) return;
           if (e.key === 'Escape') onClose();
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !running) void run();
         }}


### PR DESCRIPTION
Enter that confirms an IME candidate and Escape that cancels one arrive as plain keydown events, indistinguishable from a real submit or cancel. Every handler acting on a bare key fired on them: the dismiss-reason input saved half-typed text, and the composer / editor Escape paths threw away whole drafts.

Adds a shared imeComposing() guard (isComposing, with keyCode 229 as a fallback) and bails out first in the 8 affected handlers. Cmd/Ctrl+Enter paths are immune on their own, but share the guard where the same handler also acts on a bare Escape.

Verified in the UI preview: during composition Enter no longer saves and Escape no longer rolls back, while a plain Enter still saves. The real IME event sequence still needs a manual pass in the app.