### PR TITLE
fix(submit): rename the summary section heading in review body

### DIFF
--- a/scripts/spike-submit.ts
+++ b/scripts/spike-submit.ts
@@ -15,6 +15,7 @@ import {
   isSubmittable,
   nearestLiveLine,
   needsRecheckFollowUp,
+  SUMMARY_HEADING,
 } from '../src/shared/github-review';
 import { parseUnifiedDiff } from '../src/shared/diff';
 import type { GitHubSubmitter } from '../src/backend/review/github-submitter';
@@ -170,7 +171,7 @@ async function main() {
       line: 0,
     });
     const payload = buildPrReviewPayload(store.getReview(review.id)!, [store.getFinding(f.id)!], 'comment', '');
-    const tail = payload.body.split('### 整体意见')[1];
+    const tail = payload.body.split(SUMMARY_HEADING)[1];
     const orphan = tail
       .split('\n')
       .filter((l) => l.trim() && !l.startsWith('- ') && !l.startsWith('  '));

--- a/src/renderer/screens/submit/SubmitGitHubScreen.tsx
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.tsx
@@ -101,7 +101,7 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
     [findings, diff, round],
   );
   const inlineCount = pending.filter(hasAnchor).length;
-  // 降级 / 无锚点的条目走 review body 的「整体意见」,与草稿正文一起构成摘要
+  // 降级 / 无锚点的条目并进 review body 末尾一节,与草稿正文一起构成摘要
   const summaryCount = pending.filter((f) => !hasAnchor(f)).length;
   const keptCount = findings.filter((f) => f.triage !== 'dismiss').length;
   const staleList = useMemo(() => findings.filter((f) => staleIds.has(f.id)), [findings, staleIds]);

--- a/src/shared/github-review.ts
+++ b/src/shared/github-review.ts
@@ -42,7 +42,13 @@ export interface PrReviewPayload {
 export const hasAnchor = (f: Finding): boolean =>
   Boolean(f.file) && f.line > 0 && !f.anchorDropped;
 
-/** 严重度圆点 + 加粗的「[severity · category] 标题」,inline 与整体意见共用。 */
+/**
+ * review body 里这批条目的小标题。写给 PR 作者看,不用「锚点 / 降级」这类 app 内部词;
+ * 也不叫「整体意见」—— 上面那段 reviewer 手填的才是,而这里混着有 file:line 的具体条目。
+ */
+export const SUMMARY_HEADING = '### 其他意见(未落在改动行上)';
+
+/** 严重度圆点 + 加粗的「[severity · category] 标题」,inline 条目与摘要条目共用。 */
 function headline(f: Finding): string {
   const cat = f.category ? ` · ${f.category}` : '';
   return `${SEVERITY_EMOJI[f.severity]} **[${f.severity}${cat}] ${f.title}**`;
@@ -109,7 +115,7 @@ export function buildPrReviewPayload(
       const head = `- ${headline(f)}`;
       return block ? `${head}\n\n${indentContinuation(block)}` : head;
     });
-    parts.push(`### 整体意见\n\n${lines.join('\n\n')}`);
+    parts.push(`${SUMMARY_HEADING}\n\n${lines.join('\n\n')}`);
   }
 
   return { event: GH_EVENT_API[event], body: parts.join('\n\n'), comments };


### PR DESCRIPTION
The section merged into the review body holds findings that could not be posted as inline comments: architectural ones with no line at all, plus off-diff/degraded ones that still carry a concrete `file:line`. Calling it an overall opinion contradicted the latter, and the reviewer's own prose sitting right above it is the real overall opinion.

New heading: `### 其他意见(未落在改动行上)`. It is written for the PR author, so it avoids app-internal vocabulary such as anchor or degrade.

The heading is now exported as `SUMMARY_HEADING`; spike-submit.ts split on a duplicated literal, which would have silently yielded undefined once the two drifted.