### PR TITLE
fix(suggestion): align patch indentation to the anchored line

### DIFF
--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -138,7 +138,10 @@ const TOOLS = [
         body: { type: 'string', description: '问题说明与影响' },
         file: { type: 'string', description: '相对仓库根的路径' },
         line: { type: 'number', description: '新侧行号' },
-        suggestion: { type: 'string', description: '可选:给 author 的建议代码' },
+        suggestion: {
+          type: 'string',
+          description: '可选:给 author 的建议代码,会逐字替换锚定行 —— 须带该行的前导缩进',
+        },
       },
       required: ['severity', 'title', 'body', 'file', 'line'],
     },
@@ -160,7 +163,10 @@ const TOOLS = [
         category: { type: ['string', 'null'], description: `${CATEGORY_HINT};传 null 清空分类` },
         title: { type: 'string' },
         body: { type: 'string' },
-        suggestion: { type: ['string', 'null'], description: '建议代码;传 null 删掉原有 suggestion' },
+        suggestion: {
+          type: ['string', 'null'],
+          description: '建议代码,须带锚定行的前导缩进;传 null 删掉原有 suggestion',
+        },
       },
       required: ['finding_id'],
     },

--- a/src/backend/prompt/review-prompt.ts
+++ b/src/backend/prompt/review-prompt.ts
@@ -64,6 +64,7 @@ export const BUILTIN_PROTOCOL = `## 上报协议(固定,不随以上偏好改变
 - category 只能取:${FINDING_CATEGORIES.join(' / ')};用英文原词,不要自造、缩写或翻译。
 - file 用相对仓库根的路径;line 锚**新侧**行号。
 - suggestion 可选;给出时必须是能直接套用的字面补丁(会逐字替换锚定行),不是示意片段 —— 拿不准就不要给。
+  必须连同锚定行的前导缩进一起给(多行则各行都带自己那一层),顶到行首的补丁会把作者的代码改坏。
 - 超出 diff 范围的隐患照常 report_finding,并在正文里说明为何 off-diff。
 - 收尾必须调用一次 write_summary:body 是总结正文,呈现在 Summary 屏供 reviewer 判断;
   只写在对话回复里不算 —— 那段文字不会进入总结,屏上仍是「尚未生成」。

--- a/src/backend/review/github-submitter.ts
+++ b/src/backend/review/github-submitter.ts
@@ -29,21 +29,24 @@ export class GhReviewSubmitter implements GitHubSubmitter {
       return { status: 'failed', message: `无法解析 PR 引用:${(e as Error).message}` };
     }
 
-    // 实时 head sha:review comment 锚到当前 head commit;顺带取 PR url 兜底
-    let commitId: string;
+    // PR url 兜底;head sha 仅在 payload 没带时才用这里读到的
+    let liveHead: string;
     let prUrl: string;
     try {
       const metaJson = await run('gh', [
         'pr', 'view', num, '--repo', nwo, '--json', 'headRefOid,url',
       ]);
       const meta = JSON.parse(metaJson) as { headRefOid: string; url: string };
-      commitId = meta.headRefOid;
+      liveHead = meta.headRefOid;
       prUrl = meta.url;
     } catch (e) {
       return { status: 'failed', message: `读取 PR 元数据失败(认证/网络/PR 已关闭?):${(e as Error).message}` };
     }
 
-    const requestBody = JSON.stringify({ commit_id: commitId, ...payload });
+    // payload 带了 sha 就钉死它:那是 suggestion 补缩进所依据的那份 diff 所属的 commit。
+    // 再读一次实时 head 的话,两次读之间的推送会让「按 A 的行补的缩进」提交到 B。
+    const { commitId, ...apiPayload } = payload;
+    const requestBody = JSON.stringify({ commit_id: commitId ?? liveHead, ...apiPayload });
     try {
       const out = await run(
         'gh',

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -24,7 +24,7 @@ import type { AddFindingInput, BusyReview, FindingEditInput, LatestDiffResult, L
 import { LIVE_SESSION_LIMIT_CODE, SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
 import { isCodexProtocolError } from '@shared/codex';
 import type { PromptSaveInput, ReviewPromptView } from '@shared/prompt';
-import { buildPrReviewPayload, isSubmittable, submitBlocker } from '@shared/github-review';
+import { buildPrReviewPayload, hasAnchor, isSubmittable, submitBlocker } from '@shared/github-review';
 import type { McpContentProviders } from '../mcp/duetlens-mcp-server';
 import type { ReviewStore } from '../db/review-store';
 import { CodexAgent } from '../agent/codex/codex-agent';
@@ -597,8 +597,33 @@ export class ReviewManager extends EventEmitter {
     try {
       const pending = this.store.listFindings(reviewId).filter((f) => isSubmittable(f, review.currentRound));
 
+      // suggestion 要按锚定行补齐缩进(见 alignSuggestion),而 GitHub 是拿 PR head 套这条补丁的
+      // —— 基准只能是 head 上的那一行。审核快照会错两次:作者调过这行的缩进,或 reviewer 已按
+      // 最新 diff 重锚(那个行号在快照里指向的是另一行)。提交屏预览也用最新 diff,取它才对得上。
+      // 没有带 suggestion 的行评论时不拉:摘要条目不带补丁,空手 Approve 更不该为此
+      // 多一次网络往返和一处失败面。
+      let anchorDiff: DiffFile[] = [];
+      let anchorSha: string | null = null;
+      if (pending.some((f) => f.suggestion && hasAnchor(f))) {
+        const latest = await this.getLatestDiff(reviewId);
+        // 拉不到就**不补**,而不是退回快照:快照里的同一个行号可能已指向别的行(reviewer 按最新
+        // diff 重锚过),据它补出来的缩进是凭空捏的。捏错比不补更伤,而拿不到基准就不该猜。
+        if (latest.ok) {
+          anchorDiff = latest.diff;
+          // sha 必须跟着 diff 一起走:提交层据它钉 commit_id,免得再独立读一次 head
+          anchorSha = latest.headSha;
+        }
+      }
+
       // 无 finding 也可提交:Comment/Approve/Request changes 本身就是表态
-      const payload = buildPrReviewPayload(review, pending, input.event, input.body ?? '');
+      const payload = buildPrReviewPayload(
+        review,
+        pending,
+        input.event,
+        input.body ?? '',
+        anchorDiff,
+        anchorSha,
+      );
       const blocked = submitBlocker(payload);
       if (blocked) return { status: 'failed', message: blocked };
       const result = await this.submitter.submit(review, payload);

--- a/src/renderer/screens/SubmitExportScreen.tsx
+++ b/src/renderer/screens/SubmitExportScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { Finding } from '@shared/domain';
+import type { DiffFile } from '@shared/diff';
 import { useReviewStream } from '../review/useReviewStream';
 import { ExportMarkdownScreen } from './export/ExportMarkdownScreen';
 import { SubmitGitHubScreen } from './submit/SubmitGitHubScreen';
@@ -21,6 +22,9 @@ export function SubmitExportScreen({
   const [tab, setTab] = useState<'submit' | 'export'>('submit');
   // 提交在途:待提交集已在后端定稿,这期间任何改 triage 的入口都得冻住
   const [submitting, setSubmitting] = useState(false);
+  // 提交屏据以判定锚点的那份 diff(可能已是现拉的最新);转给导出屏,好让两边给 suggestion
+  // 补的缩进出自同一行。undefined = 提交屏还没报 / 本 source 没有提交这一步,导出屏自己读快照。
+  const [submitDiff, setSubmitDiff] = useState<DiffFile[] | undefined>(undefined);
 
   const onToggleKeep = useCallback(
     (f: Finding) => {
@@ -73,6 +77,7 @@ export function SubmitExportScreen({
             onBack={onBack}
             tabs={tabs}
             onBusyChange={setSubmitting}
+            onDiffChange={setSubmitDiff}
           />
         </div>
         <div className="se-pane" hidden={tab !== 'export'}>
@@ -82,6 +87,7 @@ export function SubmitExportScreen({
             onBack={onBack}
             onToggleKeep={onToggleKeep}
             tabs={tabs}
+            diff={submitDiff}
           />
         </div>
       </>

--- a/src/renderer/screens/export/ExportMarkdownScreen.tsx
+++ b/src/renderer/screens/export/ExportMarkdownScreen.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { Finding, Review } from '@shared/domain';
+import type { DiffFile } from '@shared/diff';
 import {
   buildReviewMarkdown,
   exportFileName,
@@ -21,10 +22,23 @@ interface Props {
   onToggleKeep: (finding: Finding) => void;
   /** 终点切换分段(github-pr 才有);给了就顶掉面包屑。 */
   tabs?: ReactNode;
+  /**
+   * 给 suggestion 补缩进所依据的 diff(见 alignSuggestion)。github-pr 下由提交屏转来 ——
+   * 那边会现拉最新 diff 并据它重锚,这里再去读审核快照的话,同一个 file:line 可能是另一行。
+   * 不给则自己读快照:其余 source 没有提交这一步,锚点不会动。
+   */
+  diff?: DiffFile[];
 }
 
 // 左预览(渲染/源码)+ 右导出配置。
-export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep, tabs }: Props) {
+export function ExportMarkdownScreen({
+  review,
+  findings,
+  onBack,
+  onToggleKeep,
+  tabs,
+  diff,
+}: Props) {
   const isGithub = review.source === 'github-pr';
   const round = review.currentRound;
   const [opts, setOpts] = useState<ExportOptions>(DEFAULT_EXPORT_OPTIONS);
@@ -32,7 +46,18 @@ export function ExportMarkdownScreen({ review, findings, onBack, onToggleKeep, t
   const [copied, setCopied] = useState(false);
   const [savedPath, setSavedPath] = useState<string | null>(null);
 
-  const md = useMemo(() => buildReviewMarkdown(review, findings, opts), [review, findings, opts]);
+  // 上层没给就自己读审核快照;读不到就原样导出,不挡预览
+  const [ownDiff, setOwnDiff] = useState<DiffFile[]>([]);
+  useEffect(() => {
+    if (diff) return;
+    void window.duetlens.review.diff(review.id).then(setOwnDiff);
+  }, [diff, review.id]);
+
+  const anchorDiff = diff ?? ownDiff;
+  const md = useMemo(
+    () => buildReviewMarkdown(review, findings, opts, anchorDiff),
+    [review, findings, opts, anchorDiff],
+  );
   const fileName = useMemo(() => exportFileName(review), [review]);
   const rendered = useMemo(() => renderMarkdown(md), [md]);
 

--- a/src/renderer/screens/review/InlineCard.tsx
+++ b/src/renderer/screens/review/InlineCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  alignSuggestion,
   isAutoClosedFixed,
   type Finding,
   type FindingResolution,
@@ -261,12 +262,15 @@ function CardView({
                 <span className="csd-code">{originalLine || ' '}</span>
               </div>
             )}
-            {finding.suggestion.split('\n').map((l, i) => (
-              <div className="csd-row add" key={i}>
-                <span className="csd-gut">＋</span>
-                <span className="csd-code">{l || ' '}</span>
-              </div>
-            ))}
+            {/* 与提交/导出同一口径:补丁没写缩进就按锚定行补齐,卡上看到的即将来发出去的 */}
+            {alignSuggestion(finding.suggestion, originalLine)
+              .split('\n')
+              .map((l, i) => (
+                <div className="csd-row add" key={i}>
+                  <span className="csd-gut">＋</span>
+                  <span className="csd-code">{l || ' '}</span>
+                </div>
+              ))}
           </div>
         </div>
       )}

--- a/src/renderer/screens/submit/SubmitGitHubScreen.tsx
+++ b/src/renderer/screens/submit/SubmitGitHubScreen.tsx
@@ -10,6 +10,7 @@ import type { DiffFile } from '@shared/diff';
 import type { SubmitReviewResult } from '@shared/ipc';
 import {
   GH_REVIEW_EVENTS,
+  anchorLineIndex,
   buildPrReviewPayload,
   hasAnchor,
   isStaleAnchor,
@@ -52,10 +53,22 @@ interface Props {
   tabs?: ReactNode;
   /** 提交在途时上报,好让外壳一并冻住屏外那些能改 triage 的入口。 */
   onBusyChange?: (busy: boolean) => void;
+  /**
+   * 上报本屏当前据以判定锚点的那份 diff。导出屏要用同一份给 suggestion 补缩进 ——
+   * 它自己读审核快照的话,重锚之后同一个 file:line 指向的可能是另一行(见 alignSuggestion)。
+   */
+  onDiffChange?: (diff: DiffFile[]) => void;
 }
 
 // 左 findings 筛选 + 右 Finish your review。
-export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChange }: Props) {
+export function SubmitGitHubScreen({
+  review,
+  findings,
+  onBack,
+  tabs,
+  onBusyChange,
+  onDiffChange,
+}: Props) {
   const reviewId = review.id;
   const [event, setEvent] = useState<GhReviewEvent>('comment');
   /** 实际发出去的那次表态;结果 banner 只能说这一个,否则事后改选框会让它改口。 */
@@ -109,6 +122,8 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
 
   // 派生上报而非在 submit() 里逐条路径手动置位:那样每加一条 return 就漏一次解冻
   useEffect(() => onBusyChange?.(sub === 'submitting'), [sub, onBusyChange]);
+  // 含 syncLatest 拉到的最新 diff:导出屏据此与本屏看到的补丁保持一致
+  useEffect(() => onDiffChange?.(diff), [diff, onDiffChange]);
 
   // 进屏即在后台核对一次 PR 最新状态:失效锚点应在提交被拒之前就摆到用户面前。
   const checkedOnce = useRef(false);
@@ -118,14 +133,8 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
     void syncLatest();
   }, [inlineCount, syncLatest]);
 
-  // suggestion diff 的「原行」文本:按 file+新侧行号从最新 diff 取,取不到则只渲染增行。
-  const originalLineOf = useMemo(() => {
-    const byKey = new Map<string, string>();
-    for (const file of diff)
-      for (const hunk of file.hunks)
-        for (const l of hunk.lines) if (l.newLine != null) byKey.set(`${file.path}:${l.newLine}`, l.text);
-    return (f: Finding) => byKey.get(`${f.file}:${f.line}`);
-  }, [diff]);
+  // suggestion diff 的「原行」文本:取不到则只渲染增行,且补丁不补缩进。
+  const originalLineOf = useMemo(() => anchorLineIndex(diff), [diff]);
 
   /**
    * 提交在途:后端已按调用那一刻的 findings / event / body 组好 payload 并在发了,
@@ -162,8 +171,8 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
 
   // 按钮可用性走后端同一套判定(手填正文一并传进去,与实际提交内容一致)
   const blocked = useMemo(
-    () => submitBlocker(buildPrReviewPayload(review, pending, event, body)),
-    [review, pending, event, body],
+    () => submitBlocker(buildPrReviewPayload(review, pending, event, body, diff)),
+    [review, pending, event, body, diff],
   );
 
   const submit = async () => {
@@ -298,7 +307,8 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
             const isStale = staleIds.has(f.id);
             // 卡片按实际提交的内容预览:有本轮复核说明就只发它,首轮 suggestion 随首轮正文一起作废
             const narrative = findingNarrative(f, round);
-            const suggestion = findingSuggestion(f, round);
+            const orig = originalLineOf(f);
+            const suggestion = findingSuggestion(f, round, orig);
             const canReAnchor = isStale && nearestLiveLine(f.file, f.line, diff) != null;
             const cls =
               // 前缀不能省:裸 .finding 会漏到审核屏的内联卡与批注 composer(它们也带 .finding)
@@ -347,15 +357,12 @@ export function SubmitGitHubScreen({ review, findings, onBack, tabs, onBusyChang
                         <span className="dia">◇</span> suggestion
                       </div>
                       <div className="f-sugg-diff">
-                        {(() => {
-                          const orig = originalLineOf(f);
-                          return orig != null ? (
-                            <div className="fsd-row del">
-                              <span className="fsd-gut">−</span>
-                              <span className="fsd-code">{orig || ' '}</span>
-                            </div>
-                          ) : null;
-                        })()}
+                        {orig != null && (
+                          <div className="fsd-row del">
+                            <span className="fsd-gut">−</span>
+                            <span className="fsd-code">{orig || ' '}</span>
+                          </div>
+                        )}
                         {suggestion.split('\n').map((l, i) => (
                           <div className="fsd-row add" key={i}>
                             <span className="fsd-gut">＋</span>

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -371,15 +371,40 @@ export function findingNarrative(f: Finding, currentRound: number): string {
 }
 
 /**
+ * 补齐补丁的前导缩进。suggestion 会被逐字替换进锚定行,而模型给补丁时惯于把语句顶到行首,
+ * 照发下去作者一点「采纳」就抹掉了那一行的缩进 —— TS 里是格式炸掉,Python / YAML 里是改坏语义。
+ * 缩进按锚定行补齐,多行补丁整体右移以保住行间的相对层级。
+ *
+ * 判据只能是「首行写没写缩进」—— 补丁是个字面量,没有别的信号可问。代价是刻意退到第 0 列的补丁
+ * (如把一段挪出缩进块)会被当成漏写补回去。模型漏写是常态、刻意退到顶层是个例,这里按前者取舍;
+ * 写了缩进的一律原样放行,所以「减掉一层但仍在块内」这种照旧表达得出来。
+ */
+export function alignSuggestion(suggestion: string, anchorLine?: string | null): string {
+  if (/^[ \t]/.test(suggestion)) return suggestion;
+  const indent = /^[ \t]+/.exec(anchorLine ?? '')?.[0];
+  if (!indent) return suggestion;
+  return suggestion
+    .split('\n')
+    .map((l) => (l.trim() ? indent + l : l))
+    .join('\n');
+}
+
+/**
  * 同上三处共用的一键补丁:复核说明取代首轮正文时,首轮 suggestion 一并作废。
  * 它与首轮正文同源、同样写在作者这次改动之前,而 `resolve_finding` 没有刷新它的入口 ——
  * 挂到当前锚点上就是一键覆盖作者刚改的代码,比一段对不上的描述更伤。
+ *
+ * `anchorLine` 是锚定行原文(取自 diff 新侧),给了就据它补齐缩进,见 {@link alignSuggestion}。
  */
-export function findingSuggestion(f: Finding, currentRound: number): string | null {
+export function findingSuggestion(
+  f: Finding,
+  currentRound: number,
+  anchorLine?: string | null,
+): string | null {
   if (recheckNote(f, currentRound) !== null) return null;
   // 首行缩进是补丁的一部分(会被逐字替换进代码),只能削首尾空行与行尾空白,不能 trim
   const s = f.suggestion?.replace(/^[ \t]*\n+/, '').replace(/\s+$/, '') ?? '';
-  return s || null;
+  return s ? alignSuggestion(s, anchorLine) : null;
 }
 
 /**

--- a/src/shared/export-markdown.ts
+++ b/src/shared/export-markdown.ts
@@ -15,7 +15,8 @@ import {
   type Severity,
   type SourceKind,
 } from './domain';
-import { isSubmittable, needsRecheckFollowUp } from './github-review';
+import type { DiffFile } from './diff';
+import { anchorLineIndex, isSubmittable, needsRecheckFollowUp } from './github-review';
 
 export interface ExportOptions {
   /** 含 suggestion 代码块(渲染为 ```suggestion,GitHub 外无一键采纳但保留格式) */
@@ -84,7 +85,13 @@ function submissionNote(f: Finding, review: Review): string | null {
  * 单条 finding 块;heading 为 finding 标题所用的 markdown 级别(分组下降一级)。
  * 与 GitHub 提交同一口径:本轮复核判定仍存在的,正文取复核说明、首轮 suggestion 一并作废。
  */
-function findingBlock(f: Finding, opts: ExportOptions, heading: string, review: Review): string {
+function findingBlock(
+  f: Finding,
+  opts: ExportOptions,
+  heading: string,
+  review: Review,
+  anchorLine?: string,
+): string {
   const currentRound = review.currentRound;
   const cat = f.category ? ` · ${f.category}` : '';
   let block = `${heading} ${SEVERITY_EMOJI[f.severity]} ${f.severity}${cat} — ${f.title}\n\n`;
@@ -92,18 +99,21 @@ function findingBlock(f: Finding, opts: ExportOptions, heading: string, review: 
   block += `\`${findingAnchorText(f)}\`${note ? ` · ${note}` : ''}\n\n`;
   const narrative = findingNarrative(f, currentRound);
   if (narrative) block += `${narrative}\n\n`;
-  const suggestion = findingSuggestion(f, currentRound);
+  const suggestion = findingSuggestion(f, currentRound, anchorLine);
   if (opts.suggestion && suggestion) {
     block += '```suggestion\n' + suggestion + '\n```\n\n';
   }
   return block;
 }
 
+/** diff 只用来给 suggestion 补齐锚定行的缩进;缺省时补丁原样导出。 */
 export function buildReviewMarkdown(
   review: Review,
   findings: Finding[],
   opts: ExportOptions = DEFAULT_EXPORT_OPTIONS,
+  diff: DiffFile[] = [],
 ): string {
+  const anchorLineOf = anchorLineIndex(diff);
   const pendingOnly = opts.scope === 'pending';
   const kept = findings.filter((f) => (pendingOnly ? isSubmittable(f, review.currentRound) : isKept(f)));
   const dropped = findings.filter((f) => !isKept(f));
@@ -124,10 +134,11 @@ export function buildReviewMarkdown(
     }
     for (const [file, list] of byFile) {
       md += `### ${file}\n\n`;
-      for (const f of list) md += findingBlock(f, opts, '####', review);
+      for (const f of list) md += findingBlock(f, opts, '####', review, anchorLineOf(f));
     }
   } else {
-    for (const f of [...kept].sort(bySeverity)) md += findingBlock(f, opts, '###', review);
+    for (const f of [...kept].sort(bySeverity))
+      md += findingBlock(f, opts, '###', review, anchorLineOf(f));
   }
 
   if (opts.dismissed && dropped.length) {

--- a/src/shared/github-review.ts
+++ b/src/shared/github-review.ts
@@ -31,11 +31,16 @@ export interface PrReviewComment {
   body: string;
 }
 
-/** 一次 PR review 的请求体(commit_id 由提交层补,它需要实时 head sha)。 */
 export interface PrReviewPayload {
   event: 'COMMENT' | 'REQUEST_CHANGES' | 'APPROVE';
   body: string;
   comments: PrReviewComment[];
+  /**
+   * 补缩进所依据的那份 diff 属于哪个 head sha。给了就钉成 `commit_id` ——
+   * 否则提交层会再独立读一次 head,两次读之间的推送会让「按 A 的行补的缩进」提交到 B。
+   * 缺省(没用上 diff / 拉不到)时仍由提交层读实时 head。
+   */
+  commitId?: string;
 }
 
 /** finding 是否作为 inline 行评论提交:有新侧行号,且没被提交屏降级为摘要条目。 */
@@ -61,11 +66,23 @@ function followUpLead(f: Finding, currentRound: number): string {
     : '';
 }
 
+/**
+ * 按 file + 新侧行号索引 diff 的行原文。suggestion 要据锚定行补齐缩进(见 alignSuggestion),
+ * 提交、导出与两处预览都要问同一个来源,否则屏上看到的补丁和发出去的不是一份。
+ */
+export function anchorLineIndex(diff: DiffFile[]): (f: Finding) => string | undefined {
+  const byKey = new Map<string, string>();
+  for (const file of diff)
+    for (const hunk of file.hunks)
+      for (const l of hunk.lines) if (l.newLine != null) byKey.set(`${file.path}:${l.newLine}`, l.text);
+  return (f) => byKey.get(`${f.file}:${f.line}`);
+}
+
 /** 一条 finding → inline 评论正文:标题 + 正文 + 可选 suggestion 块。 */
-function commentBody(f: Finding, currentRound: number): string {
+function commentBody(f: Finding, currentRound: number, anchorLine?: string): string {
   const parts = [followUpLead(f, currentRound), headline(f), findingNarrative(f, currentRound)];
   let body = parts.filter(Boolean).join('\n\n');
-  const suggestion = findingSuggestion(f, currentRound);
+  const suggestion = findingSuggestion(f, currentRound, anchorLine);
   if (suggestion) body += '\n\n```suggestion\n' + suggestion + '\n```';
   return body;
 }
@@ -83,21 +100,27 @@ const indentContinuation = (s: string): string =>
  *
  * body 是 reviewer 在提交屏手填的意见,**不取 review.summaryBody** ——
  * agent 的总结只呈现给 reviewer 自己,发给 PR 作者的话得由人自己写下。
+ *
+ * diff 只用来给 suggestion 补齐锚定行的缩进;缺省(取不到 diff)时补丁原样发出。
+ * headSha 是这份 diff 所属的 commit —— 与 diff 同源才有意义,别单独传。
  */
 export function buildPrReviewPayload(
   review: Review,
   findings: Finding[],
   event: GhReviewEvent,
   body: string,
+  diff: DiffFile[] = [],
+  headSha: string | null = null,
 ): PrReviewPayload {
   const anchored = findings.filter(hasAnchor);
   const unanchored = findings.filter((f) => !hasAnchor(f));
+  const anchorLineOf = anchorLineIndex(diff);
 
   const comments: PrReviewComment[] = anchored.map((f) => ({
     path: f.file,
     line: f.line,
     side: 'RIGHT',
-    body: commentBody(f, review.currentRound),
+    body: commentBody(f, review.currentRound, anchorLineOf(f)),
   }));
 
   const parts: string[] = [];
@@ -118,7 +141,12 @@ export function buildPrReviewPayload(
     parts.push(`${SUMMARY_HEADING}\n\n${lines.join('\n\n')}`);
   }
 
-  return { event: GH_EVENT_API[event], body: parts.join('\n\n'), comments };
+  return {
+    event: GH_EVENT_API[event],
+    body: parts.join('\n\n'),
+    comments,
+    ...(headSha ? { commitId: headSha } : {}),
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem

Agent-reported suggestions arrive with the leading indentation stripped. Spotted on a real
review (PR #4072): the stored value is literally `await emitInfo(this.logger, log, ...)`
with no leading whitespace, while the anchored line sits six columns in. Both suggestions in
that review were unindented, so it is stable behaviour, not a one-off.

The renderer was innocent: the removed line and the added line go through the same
`white-space: pre-wrap` span, and nothing in the ingress path trims. The prompt contract said
the patch must be applicable verbatim but never said it must carry the anchored line's
indentation, so the model dropped it.

This is not only a display issue. The suggestion block is submitted to GitHub as-is, so the
author clicking "Commit suggestion" moves the line to column 0. Cosmetic in TS, semantic
breakage in Python or YAML.

## Fix

Read-time alignment, so a moved anchor stays correct and no migration is needed:

- `alignSuggestion` re-indents a patch to the anchored line when the patch itself carries no
  indentation. Multi-line patches shift as a block so relative nesting survives. A patch that
  does write its own indentation is left alone.
- `anchorLineIndex` becomes the single source for anchored-line text. The submit screen used
  to build its own copy of that map.
- Submission uses the head diff, not the review snapshot. GitHub applies the patch against
  head, and the snapshot is wrong twice over: the author may have re-indented the line, and
  the reviewer may have re-anchored against a newer diff, in which case the same line number
  points somewhere else entirely. When head cannot be fetched, alignment is skipped rather
  than guessed from the snapshot.
- The head sha travels with the diff and is pinned as `commit_id`. The submitter used to read
  head a second time; a push landing between the two reads would indent against A and submit
  against B.
- Export reuses the diff the submit screen already synced instead of reading the snapshot.
  Other sources have no submit step, so they keep reading the snapshot.
- Prompt contract and both MCP tool schemas now state the requirement, to cut the rate at the
  source.

## Known trade-off

The only signal available is whether the first line carries indentation, so a patch that
deliberately targets column 0 (moving a block out of its nesting) is re-indented. Models
omitting indentation is the common case and deliberate dedent-to-top-level is the rare one,
so the trade is taken knowingly. Recording the intent at ingress was considered and rejected:
the only party who could fill that field is the agent, which is the unreliable side here.

## Verification

`typecheck` and `lint` clean. Seven cases exercised through the public shared entrypoints,
including the real PR #4072 data: unindented patch against an indented anchor, patch with its
own indentation, anchor absent from the diff, multi-line patch, export parity, tab and blank
line edges, and `commit_id` pinning plus its fallback. Preview panel confirms the review card
and the export screen render, no console errors.

Not covered: `submitReview` sits below IPC, so the two `gh` calls were not exercised. That
path needs a real PR submission to confirm.