### PR TITLE
fix(finding): clear the recheck note when a finding body is rewritten

### DIFF
--- a/scripts/spike-export.ts
+++ b/scripts/spike-export.ts
@@ -50,6 +50,7 @@ function mkFinding(p: Partial<Finding> & Pick<Finding, 'id' | 'severity' | 'titl
     submittedUrl: null,
     submittedRound: null,
     round: 1,
+    bodyRound: 1,
     lastSeenRound: 1,
     resolution: null,
     resolutionNote: null,

--- a/scripts/spike-proposals.ts
+++ b/scripts/spike-proposals.ts
@@ -27,7 +27,7 @@ import type {
   ConversationHandle,
   StartConversationOptions,
 } from '../src/backend/agent/conversational-agent';
-import type { FindingProposal } from '../src/shared/domain';
+import { isProposalUndoBlocked, type FindingProposal } from '../src/shared/domain';
 
 const REVIEW_FILE = 'scripts/seed-demo.js';
 const SRC = `const db = require('../src/db');
@@ -92,6 +92,10 @@ async function main() {
     log('──── C3. 扫描在跑 + 追问排队 ────');
     await assertModeIsPerTurn();
 
+    // ── C4. 改写正文作废复核说明,撤销要把它交还(纯本地)────────────────────
+    log('──── C4. 采纳改写正文 → 复核说明作废;撤销 → 还原 ────');
+    assertUndoRestoresRecheckNote();
+
     // ── A. 扫描 ────────────────────────────────────────────────────────────
     log('──── A. 首轮扫描 ────');
     const findings = await session.start({
@@ -142,11 +146,11 @@ async function main() {
     for (const key of Object.keys(update.patch) as (keyof typeof update.patch)[]) {
       assert.deepEqual(updated[key] ?? null, update.patch[key] ?? null, `${key} 应已按提案落库`);
     }
-    // 快照只含动过的字段 —— 拍全量会让撤销顺手回滚应用之后的编辑
-    assert.deepEqual(
-      Object.keys(applied.before ?? {}).sort(),
-      Object.keys(update.patch).sort(),
-      'before 快照只应包含该提案动过的字段',
+    // 快照只含这次真正改动的字段 —— 拍全量会让撤销顺手回滚应用之后的编辑。
+    // 是 patch 字段的子集:提案把某字段写回了同一个值时不进快照(还原它等于没还原)。
+    assert.ok(
+      Object.keys(applied.before ?? {}).every((k) => k in update.patch),
+      'before 快照不应超出该提案动过的字段',
     );
     log(`✓ 已落库,快照字段: ${Object.keys(applied.before ?? {}).join(',')}`);
 
@@ -241,6 +245,95 @@ function assertApplyRollsBack(): void {
   assert.equal(after.severity, before.severity, '★ 回滚后严重度不应变');
   assert.equal(store.getProposal(proposalId)!.status, 'pending', '★ 回滚后提案仍是待确认');
   log('✓ 第二步失败 → finding 与提案一起回滚,没有半状态');
+}
+
+/**
+ * 采纳一条改写正文的提案时,本轮的复核说明与首轮补丁一并作废(它们写在这份正文之前,
+ * 而复核说明会取代正文发出去)。撤销则要把两者一起交还 —— 它们不在 patch 的字段里,
+ * 快照漏拍的话,撤销交回的是一条被剥掉复核说明的旧 finding。
+ */
+function assertUndoRestoresRecheckNote(): void {
+  const store = new ReviewStore(openDatabase(':memory:'));
+  const manager = new ReviewManager(store);
+  const reviewId = store.createReview({ source: 'local-branch', sourceRef: 'x', title: 't' }).id;
+  const finding = store.addFinding(
+    reviewId,
+    { severity: 'high', title: '数据竞争', body: '原正文', file: 'a.ts', line: 1, suggestion: '  const c = 0;' },
+    'agent',
+  );
+  const NOTE = '第 2 轮复核:换成了 RefCell,跨线程仍不安全。';
+  store.startRound(reviewId, 2, {});
+  store.setFindingResolution(finding.id, 2, 'still_present', NOTE);
+
+  const disc = store.addUserDiscussion(reviewId, { file: 'a.ts', line: 1 });
+  const proposalId = store.addProposal({
+    reviewId,
+    discussionId: disc.id,
+    findingId: finding.id,
+    kind: 'update',
+    patch: { body: '跨线程共享仍需 Mutex。' },
+    baseUpdatedAt: store.getFinding(finding.id)!.updatedAt,
+  }).id;
+
+  const applied = manager.applyProposal(reviewId, proposalId);
+  const after = store.getFinding(finding.id)!;
+  assert.equal(after.resolutionNote, null, '★ 采纳改写正文 → 复核说明作废');
+  assert.equal(after.suggestion, null, '★ 首轮补丁同源作废');
+  assert.equal(after.bodyRound, 2, '正文轮次推到本轮');
+  assert.equal(after.resolution, 'still_present', '判定本身不受影响,只是说明被新正文取代');
+  assert.deepEqual(
+    Object.keys(applied.before ?? {}).sort(),
+    ['body', 'bodyRound', 'resolutionNote', 'suggestion'],
+    '★ 快照要连作废的几项一起拍下,否则撤不回来',
+  );
+
+  // 应用之后 agent 又写了一份新的复核说明 → 撤销会拿旧值把它顶掉,必须先拦下
+  store.setFindingResolution(finding.id, 2, 'still_present', '第 2 轮补充:另一条路径也会踩到。');
+  assert.equal(
+    isProposalUndoBlocked(store.getProposal(proposalId)!, store.getFinding(finding.id)),
+    true,
+    '★ 连带清空的字段被重新写过 → 不给撤销',
+  );
+  assert.throws(() => manager.undoProposal(reviewId, proposalId), /又被改过/, '★ 权威层也要拦');
+
+  // 退回应用后的样子(说明仍是空的),撤销才该放行
+  store.restoreFinding(finding.id, { resolutionNote: null });
+  manager.undoProposal(reviewId, proposalId);
+  const restored = store.getFinding(finding.id)!;
+  assert.equal(restored.body, '原正文', '正文应还原');
+  assert.equal(restored.resolutionNote, NOTE, '★ 复核说明应交还');
+  assert.equal(restored.suggestion, '  const c = 0;', '★ 补丁应交还');
+  assert.equal(restored.bodyRound, 1, '★ 正文轮次应交还 —— 否则旧正文冒充本轮新话再追评一次');
+  log('✓ 改写正文作废复核说明与补丁,撤销一并交还;期间被重写过则拦下');
+
+  // 应用时**没有**说明可清(去重兜底命中那种),于是它进不了快照;此后新写的一份不受任何
+  // 守卫保护,只能靠撤销自己不去派生 —— 借 updateFinding 写回旧正文的话,它会顺手清掉这份新的。
+  const g = store.addFinding(
+    reviewId,
+    { severity: 'high', title: '另一条', body: '原正文', file: 'b.ts', line: 1 },
+    'agent',
+  );
+  store.touchFindingSeen(g.id, 2);
+  const gBefore = store.getFinding(g.id)!;
+  const gProposalId = store.addProposal({
+    reviewId,
+    discussionId: disc.id,
+    findingId: g.id,
+    kind: 'update',
+    patch: { body: '改写过的正文。' },
+    baseUpdatedAt: store.getFinding(g.id)!.updatedAt,
+  }).id;
+  const gApplied = manager.applyProposal(reviewId, gProposalId);
+  assert.ok(!('resolutionNote' in (gApplied.before ?? {})), '本来就没有说明 → 不进快照');
+
+  const LATE = '第 2 轮复核:仍然踩得到。';
+  store.setFindingResolution(g.id, 2, 'still_present', LATE);
+  manager.undoProposal(reviewId, gProposalId);
+  const gRestored = store.getFinding(g.id)!;
+  assert.equal(gRestored.body, '原正文', '正文应还原');
+  assert.equal(gRestored.bodyRound, gBefore.bodyRound, '正文轮次应还原');
+  assert.equal(gRestored.resolutionNote, LATE, '★ 撤销之后写下的说明不得被回滚顺手清掉');
+  log('✓ 撤销只碰快照点名的字段,应用之后新写的复核说明原样留着');
 }
 
 /**

--- a/scripts/spike-submit.ts
+++ b/scripts/spike-submit.ts
@@ -158,6 +158,82 @@ async function main() {
     log('复核追评:跨轮追发一次 + 同轮不重复 + 旧说明不复用 ok');
   }
 
+  // ---- 复核之后又改写正文:旧说明与旧补丁一并作废,追评改发新正文 ----
+  {
+    const db = openDatabase(':memory:');
+    const store = new ReviewStore(db);
+    const { review, f1 } = seed(store);
+    const fake = new FakeSubmitter({ status: 'success', url: 'https://gh/x#r1', submittedCount: 2 });
+    const manager = new ReviewManager(store, undefined, { submitter: fake });
+    await manager.submitReview(review.id, { event: 'comment' });
+
+    const NOTE = '第 2 轮复核:换成了 RefCell,跨线程仍不安全。';
+    store.startRound(review.id, 2, {});
+    store.setFindingResolution(f1.id, 2, 'still_present', NOTE);
+
+    // 改元信息不动复核说明:说的还是同一条问题
+    store.updateFinding({ findingId: f1.id, severity: 'medium' });
+    assert.equal(recheckNote(store.getFinding(f1.id)!, 2), NOTE, '只改严重度不作废复核说明');
+
+    // 改写正文:说明被新正文取代,首轮补丁同源作废;判定与追评义务不受影响
+    store.updateFinding({ findingId: f1.id, body: '换 RefCell 没解决:跨线程共享仍需 Mutex。' });
+    const rewritten = store.getFinding(f1.id)!;
+    assert.equal(rewritten.resolutionNote, null, '复核说明随正文改写清空');
+    assert.equal(rewritten.suggestion, null, '首轮补丁没跟着刷新 → 不留给作者一键采纳');
+    assert.equal(rewritten.resolution, 'still_present', '判定本身不因改写而失效');
+    assert.equal(needsRecheckFollowUp(rewritten, 2), true, '★ 追评仍然欠着,不能因说明被清掉就不发');
+    assert.equal(isSubmittable(rewritten, 2), true, '★ 仍在待提交集');
+
+    const res = await manager.submitReview(review.id, { event: 'comment' });
+    assert.equal(res.status, 'success');
+    const body = fake.last!.payload.comments.find((c) => c.line === 20)!.body;
+    assert.match(body, /↻ 第 2 轮复核追评/, '仍是一条复核追评');
+    assert.match(body, /跨线程共享仍需 Mutex/, '正文取最新改写的那份');
+    assert.ok(!body.includes('跨线程仍不安全'), '被取代的复核说明不再发出去');
+    assert.ok(!body.includes('```suggestion'), '作废的首轮补丁不随追评发出');
+
+    // 同一次调用带上新补丁 → 那份是看过复核之后写的,留住
+    store.setFindingResolution(f1.id, 2, 'still_present', '仍然不安全。');
+    store.updateFinding({
+      findingId: f1.id,
+      body: '改用 Mutex。',
+      suggestion: '    const c = new Mutex(0);',
+    });
+    const refreshed = store.getFinding(f1.id)!;
+    assert.equal(refreshed.resolutionNote, null, '复核说明照样作废');
+    assert.equal(refreshed.suggestion, '    const c = new Mutex(0);', '随新正文给出的补丁不作废');
+    log('复核后改写正文:说明与旧补丁作废、追评改发新正文 ok');
+  }
+
+  // ---- 去重兜底命中(仍存在但没附说明)后改写正文:首轮补丁照样作废 ----
+  {
+    const db = openDatabase(':memory:');
+    const store = new ReviewStore(db);
+    const { review, f1 } = seed(store);
+    const fake = new FakeSubmitter({ status: 'success', url: 'https://gh/x#r1', submittedCount: 2 });
+    const manager = new ReviewManager(store, undefined, { submitter: fake });
+    await manager.submitReview(review.id, { event: 'comment' });
+
+    // 第 2 轮被去重兜底命中:本轮仍存在,但一个字都没新写
+    store.startRound(review.id, 2, {});
+    store.touchFindingSeen(f1.id, 2);
+    assert.equal(recheckNote(store.getFinding(f1.id)!, 2), null, '兜底命中不写说明');
+    assert.equal(needsRecheckFollowUp(store.getFinding(f1.id)!, 2), false, '一字未写 → 不追评');
+
+    // agent 随后改写正文:这才是本轮的新话,补丁没跟着刷新就得作废
+    store.updateFinding({ findingId: f1.id, body: '第 2 轮:改动没碰到共享路径,竞态照旧。' });
+    const rewritten = store.getFinding(f1.id)!;
+    assert.equal(rewritten.suggestion, null, '★ 没有复核说明也要作废首轮补丁 —— 它照着旧代码写');
+    assert.equal(needsRecheckFollowUp(rewritten, 2), true, '有了新话 → 欠一条追评');
+
+    const res = await manager.submitReview(review.id, { event: 'comment' });
+    assert.equal(res.status, 'success');
+    const body = fake.last!.payload.comments.find((c) => c.line === 20)!.body;
+    assert.match(body, /改动没碰到共享路径/, '追评发新正文');
+    assert.ok(!body.includes('```suggestion'), '★ 作废的首轮补丁不得随追评发给作者');
+    log('兜底命中后改写正文:补丁作废 + 追评只发新正文 ok');
+  }
+
   // ---- 脱锚 finding 并入摘要:多段正文整体缩进在列表项内 ----
   {
     const db = openDatabase(':memory:');

--- a/src/backend/db/review-store.ts
+++ b/src/backend/db/review-store.ts
@@ -5,6 +5,7 @@ import type { DB } from './database';
 import {
   DEFAULT_UI_SETTINGS,
   isAutoClosedFixed,
+  isStillPresent,
   summaryFileSchema,
   SUMMARY_FILES_LIMIT,
   type Discussion,
@@ -17,6 +18,7 @@ import {
   type ProposalKind,
   type ProposalPatch,
   type ProposalStatus,
+  type ProposalUpdateBefore,
   type ReportFindingInput,
   DEFAULT_REVIEW_UI_STATE,
   type Review,
@@ -93,6 +95,7 @@ interface FindingRow {
   submitted_url: string | null;
   submitted_round: number | null;
   round: number;
+  body_round: number | null;
   last_seen_round: number;
   resolution: string | null;
   resolution_note: string | null;
@@ -220,6 +223,8 @@ function toFinding(r: FindingRow): Finding {
     submittedUrl: r.submitted_url,
     submittedRound: r.submitted_round,
     round: r.round,
+    // 没改写过就是首报时那份;新建路径不必逐个填这一列
+    bodyRound: r.body_round ?? r.round,
     lastSeenRound: r.last_seen_round,
     resolution: r.resolution as FindingResolution | null,
     resolutionNote: r.resolution_note,
@@ -673,7 +678,20 @@ export class ReviewStore {
     return rows.map(toFinding);
   }
 
-  /** 对话打磨后回写可编辑字段(codex update_finding 与用户就地编辑共用此路径)。 */
+  /**
+   * 对话打磨后回写可编辑字段(codex update_finding 与用户就地编辑共用此路径)。
+   *
+   * 本轮判定「仍存在」的条目一旦被改写正文,旧的复核说明与旧 suggestion 一并作废:两者都写在
+   * 这份正文之前,而提交/导出时复核说明取代正文发出去(见 findingNarrative)。留着的话,屏上
+   * 写着新结论、发出去的却是旧那条;那份补丁更是照着作者已经改过的代码写的,一键采纳就覆盖回去。
+   * 例外是这次更新自带的新 suggestion —— 那才是看过复核之后给的。
+   *
+   * 判据取「本轮判定仍存在」而非「有没有复核说明」:去重兜底命中的条目同样是本轮仍存在,只是
+   * 没附说明(见 touchFindingSeen),按说明问会漏掉它,把首轮补丁留到追评里发出去。
+   *
+   * 只认正文:改严重度 / 换分类 / 单调补丁都不动它 —— 说的仍是同一条问题。
+   * 空正文也不算改写:它取代不了任何东西,清掉只会让这条 finding 什么说明都不剩。
+   */
   updateFinding(input: UpdateFindingInput): Finding | null {
     const existing = this.getFinding(input.findingId);
     if (!existing) return null;
@@ -684,14 +702,66 @@ export class ReviewStore {
       body: input.body ?? existing.body,
       suggestion: input.suggestion === undefined ? existing.suggestion : input.suggestion,
     };
+    const round = this.currentRound(existing.reviewId);
+    const rewritten = next.body.trim() !== '' && next.body !== existing.body;
+    const supersedesRecheck = rewritten && isStillPresent(existing, round);
+    const resolutionNote = supersedesRecheck ? null : existing.resolutionNote;
+    const suggestion =
+      supersedesRecheck && input.suggestion === undefined ? null : next.suggestion;
     this.withReviewTouch({ finding: input.findingId }, (ts) => {
       this.db
         .prepare(
-          `UPDATE findings SET severity = ?, category = ?, title = ?, body = ?, suggestion = ?, updated_at = ? WHERE id = ?`,
+          `UPDATE findings
+              SET severity = ?, category = ?, title = ?, body = ?, suggestion = ?,
+                  resolution_note = ?, body_round = ?, updated_at = ?
+            WHERE id = ?`,
         )
-        .run(next.severity, next.category, next.title, next.body, next.suggestion, ts, input.findingId);
+        .run(
+          next.severity,
+          next.category,
+          next.title,
+          next.body,
+          suggestion,
+          resolutionNote,
+          rewritten ? round : existing.bodyRound,
+          ts,
+          input.findingId,
+        );
     });
     return this.getFinding(input.findingId);
+  }
+
+  /**
+   * 提案撤销专用:把旧值快照**逐字**写回,不走 {@link updateFinding} 的派生规则。
+   *
+   * 撤销是回滚,不是一次新表态。借 updateFinding 写回旧正文的话,那条规则会把这次回滚当成
+   * 「改写正文」重算一遍:应用之后新写下的复核说明会被它一并清掉,而快照里没有那份新值,
+   * 补都补不回来。这里只碰快照点名的列 —— 应用没动过的字段,撤销就不该碰。
+   */
+  restoreFinding(findingId: string, before: ProposalUpdateBefore): void {
+    const COLUMNS: Record<keyof ProposalUpdateBefore, string> = {
+      severity: 'severity',
+      category: 'category',
+      title: 'title',
+      body: 'body',
+      suggestion: 'suggestion',
+      resolutionNote: 'resolution_note',
+      bodyRound: 'body_round',
+    };
+    const sets: string[] = [];
+    const args: (string | number | null)[] = [];
+    for (const [key, column] of Object.entries(COLUMNS) as [keyof ProposalUpdateBefore, string][]) {
+      const value = before[key];
+      if (value === undefined) continue;
+      sets.push(`${column} = ?`);
+      args.push(value);
+    }
+    if (!sets.length) return;
+    this.withReviewTouch({ finding: findingId }, (ts) => {
+      this.db
+        .prepare(`UPDATE findings SET ${sets.join(', ')}, updated_at = ? WHERE id = ?`)
+        .run(...args, ts, findingId);
+    });
   }
 
   /**

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -230,8 +230,18 @@ const V16 = `
 ALTER TABLE reviews ADD COLUMN summary_round INTEGER;
 `;
 
+// 正文写于第几轮。复核说明会被后来的正文改写作废(见 ReviewStore.updateFinding),此后
+// 「本轮到底有没有给作者新写一句话」就只剩这一列可问 —— 去重兜底命中的条目同样是
+// 「仍存在 + 没有说明」,但它一个字都没新写,不该据此追发一条与已提交评论重复的追评。
+//
+// 存量行按首报轮次回填:改写轮次无从追溯,宁可少发一条追评,也不要凭空重发已在 PR 上的话。
+const V17 = `
+ALTER TABLE findings ADD COLUMN body_round INTEGER;
+UPDATE findings SET body_round = round;
+`;
+
 const MIGRATIONS: string[] = [
-  V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16,
+  V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17,
 ];
 
 export function migrate(db: Database): void {

--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -152,7 +152,9 @@ const TOOLS = [
       '更正一条已上报 finding 的可编辑字段(改严重度 / 改写正文 / 换标题 / 调整 suggestion)。' +
       '讨论中一旦认定原来写的不准,就调用它,不必等用户开口 —— 讨论期间它不会立即改动 finding,' +
       '只会在对话里生成一张待确认卡片,由 reviewer 一键采纳。只传要改的字段。' +
-      '注意:若结论是「这条根本不成立」,请用 dismiss_finding,不要把剔除理由写进 body。',
+      '注意:若结论是「这条根本不成立」,请用 dismiss_finding,不要把剔除理由写进 body。' +
+      '改写 body 会作废本轮 resolve_finding 写下的复核说明与原有 suggestion —— 新 body 要自足,' +
+      '补丁若仍成立请在同一次调用里一并给出。',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -10,7 +10,6 @@ import type {
   ProposalStatus,
   ProposalTriageBefore,
   ProposalUpdateBefore,
-  ProposalUpdatePatch,
   Review,
   ReviewIntensity,
   ReviewRound,
@@ -68,17 +67,22 @@ function assertContentWritable(f: Finding, action: string): void {
 }
 
 /**
- * 只拍 patch 真正动过的那几个字段的旧值。
+ * 只拍这次应用**真正改动过**的那几个字段的旧值。
  * 拍全量的话,撤销会把应用之后 reviewer 自己的编辑一并回滚 —— 提案只降了个 severity,
  * 撤销却连带把他重写过的正文换回旧版。
+ *
+ * 按前后值比,而不是按 patch 点名的键:改写正文会连带清掉复核说明与过时的 suggestion、
+ * 并把正文轮次推到本轮(见 ReviewStore.updateFinding),这几下没人点名,却同样要能撤回来。
  */
-function snapshotPatched(before: Finding, patch: ProposalUpdatePatch): ProposalUpdateBefore {
+function snapshotPatched(before: Finding, after: Finding): ProposalUpdateBefore {
   const snapshot: ProposalUpdateBefore = {};
-  if (patch.severity !== undefined) snapshot.severity = before.severity;
-  if (patch.category !== undefined) snapshot.category = before.category;
-  if (patch.title !== undefined) snapshot.title = before.title;
-  if (patch.body !== undefined) snapshot.body = before.body;
-  if (patch.suggestion !== undefined) snapshot.suggestion = before.suggestion;
+  if (after.severity !== before.severity) snapshot.severity = before.severity;
+  if (after.category !== before.category) snapshot.category = before.category;
+  if (after.title !== before.title) snapshot.title = before.title;
+  if (after.body !== before.body) snapshot.body = before.body;
+  if (after.suggestion !== before.suggestion) snapshot.suggestion = before.suggestion;
+  if (after.resolutionNote !== before.resolutionNote) snapshot.resolutionNote = before.resolutionNote;
+  if (after.bodyRound !== before.bodyRound) snapshot.bodyRound = before.bodyRound;
   return snapshot;
 }
 
@@ -432,12 +436,13 @@ export class ReviewManager extends EventEmitter {
           p.kind === 'dismiss' ? p.patch.reason : null,
         );
       }
+      const after = this.store.getFinding(p.findingId);
       const before_ =
         p.kind === 'update'
-          ? snapshotPatched(before, p.patch)
+          ? snapshotPatched(before, after ?? before)
           : { triage: before.triage, dismissReason: before.dismissReason, autoClosed: before.autoClosed };
       return {
-        finding: this.store.getFinding(p.findingId),
+        finding: after,
         discussion: null,
         proposal: this.resolveProposal(proposalId, 'applied', { before: before_ }),
       };
@@ -479,7 +484,9 @@ export class ReviewManager extends EventEmitter {
       if (p.kind === 'update') {
         if (current) assertContentWritable(current, '撤销');
         // 快照只含该提案动过的字段,所以这一还原不会碰 reviewer 在应用之后自己改的其他字段
-        this.store.updateFinding({ findingId: p.findingId, ...(p.before as ProposalUpdateBefore) });
+        // 逐字写回,不借 updateFinding —— 那条路会把这次回滚当成一次新的正文改写,
+        // 顺手清掉应用之后新写下的复核说明(见 ReviewStore.restoreFinding)
+        this.store.restoreFinding(p.findingId, p.before as ProposalUpdateBefore);
       } else {
         // 走 restoreTriage 而非 setTriage:后者会把 auto_closed 清零,复核自动结案的条目
         // 撤销后就变成「reviewer 亲手剔的」,下一轮回归不再自动恢复

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -14,9 +14,9 @@ import type {
   ReviewStartStage,
 } from '@shared/ipc';
 import type { PrSummary } from '@shared/source-discovery';
-import { scanDoneStatus } from '@shared/domain';
+import { isStillPresent, scanDoneStatus } from '@shared/domain';
 import { hasAnchor, isSubmittable } from '@shared/github-review';
-import type { Discussion, Finding, FindingProposal, Message, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
+import type { Discussion, Finding, FindingProposal, Message, ProposalUpdateBefore, ProposalUpdatePatch, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
 import { mergeLayers } from '@shared/prompt';
 import { APP_VERSION } from '@shared/version';
 import type { UpdateStatus } from '@shared/update';
@@ -184,6 +184,7 @@ function mkFinding(p: Partial<Finding> & Pick<Finding, 'id' | 'severity' | 'titl
     submittedUrl: null,
     submittedRound: null,
     round: 1,
+    bodyRound: 1,
     lastSeenRound: 1,
     resolution: null,
     resolutionNote: null,
@@ -519,6 +520,39 @@ function buildPromptView(cwd?: string): ReviewPromptView {
   };
 }
 
+/**
+ * 与 ReviewStore.updateFinding 同一口径的改写:本轮判定仍存在的条目一旦被改写正文,
+ * 旧复核说明与没跟着刷新的旧补丁一并作废,正文轮次推到本轮。
+ *
+ * 就地编辑与采纳提案都得走它 —— 提案那条若图省事直接 `{...f, ...patch}`,预览会留着旧说明与
+ * 旧补丁,给出与实机**相反**的结果,而预览正是人工验收看的那一屏。
+ */
+function editFinding(f: Finding, patch: ProposalUpdatePatch, currentRound: number): Finding {
+  const body = patch.body ?? f.body;
+  const rewritten = body.trim() !== '' && body !== f.body;
+  const supersedes = rewritten && isStillPresent(f, currentRound);
+  return {
+    ...f,
+    severity: patch.severity ?? f.severity,
+    category: patch.category === undefined ? f.category : patch.category,
+    title: patch.title ?? f.title,
+    body,
+    suggestion:
+      patch.suggestion === undefined ? (supersedes ? null : f.suggestion) : patch.suggestion,
+    resolutionNote: supersedes ? null : f.resolutionNote,
+    bodyRound: rewritten ? currentRound : f.bodyRound,
+    updatedAt: Date.now(),
+  };
+}
+
+/** 与 review-manager 的 snapshotPatched 同口径:按前后差异拍,连带作废的那几项也要能撤回来。 */
+function snapshotChanged(before: Finding, after: Finding): ProposalUpdateBefore {
+  const keys = ['severity', 'category', 'title', 'body', 'suggestion', 'resolutionNote', 'bodyRound'] as const;
+  const snapshot: Record<string, unknown> = {};
+  for (const k of keys) if (after[k] !== before[k]) snapshot[k] = before[k];
+  return snapshot as ProposalUpdateBefore;
+}
+
 /** 装一个 stub 到 window.duetlens;写路径(triage/编辑/讨论)真的改内存态并经事件回推,便于自查闭环。 */
 export function installPreviewApi(): void {
   const diff = parseUnifiedDiff(RAW_DIFF);
@@ -842,11 +876,10 @@ export function installPreviewApi(): void {
         // 旧值快照与后端同步落下 —— 不记的话预览里永远走不到「↩ 撤销」那条路
         let before: FindingProposal['before'] = null;
         if (p.kind === 'update' && f) {
-          // 与后端同口径:只拍 patch 动过的字段,拍全量会让撤销顺手回滚应用之后的编辑
-          before = Object.fromEntries(
-            Object.keys(p.patch).map((k) => [k, (f as unknown as Record<string, unknown>)[k]]),
-          );
-          emit({ ...f, ...p.patch, updatedAt: Date.now() });
+          // 与后端同口径:走同一套改写规则,快照按前后差异拍(拍全量会让撤销顺手回滚应用之后的编辑)
+          const next = editFinding(f, p.patch as ProposalUpdatePatch, review.currentRound);
+          before = snapshotChanged(f, next);
+          emit(next);
         } else if ((p.kind === 'dismiss' || p.kind === 'restore') && f) {
           before = { triage: f.triage, dismissReason: f.dismissReason, autoClosed: f.autoClosed };
           emit({
@@ -873,6 +906,7 @@ export function installPreviewApi(): void {
         const i = proposals.findIndex((p) => p.id === proposalId);
         const p = proposals[i];
         const f = p.findingId ? findings.find((x) => x.id === p.findingId) : null;
+        // 逐字写回快照,不过 editFinding —— 回滚不是一次新表态(同后端 ReviewStore.restoreFinding)
         if (f && p.before) emit({ ...f, ...p.before, updatedAt: Date.now() });
         const next = { ...p, status: 'skipped' as const, resolvedAt: Date.now() };
         proposals[i] = next;
@@ -924,6 +958,7 @@ export function installPreviewApi(): void {
           submittedUrl: null,
           submittedRound: null,
           round: 2,
+          bodyRound: 2,
           lastSeenRound: 2,
           resolution: null,
           resolutionNote: null,
@@ -970,6 +1005,7 @@ export function installPreviewApi(): void {
           submittedUrl: null,
           submittedRound: null,
           round: 2,
+          bodyRound: 2,
           lastSeenRound: 2,
           resolution: null,
           resolutionNote: null,
@@ -1016,15 +1052,7 @@ export function installPreviewApi(): void {
       },
       updateFinding: async (_r, input) => {
         const f = findings.find((x) => x.id === input.findingId)!;
-        const next: Finding = {
-          ...f,
-          severity: input.severity ?? f.severity,
-          category: input.category === undefined ? f.category : input.category,
-          title: input.title ?? f.title,
-          body: input.body ?? f.body,
-          suggestion: input.suggestion === undefined ? f.suggestion : input.suggestion,
-          updatedAt: Date.now(),
-        };
+        const next = editFinding(f, input, review.currentRound);
         emit(next);
         return next;
       },

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -332,6 +332,8 @@ export interface Finding {
   submittedRound: number | null;
   /** 首次被报出的轮次 */
   round: number;
+  /** 正文最近一次被改写的轮次(没改写过 = 首报轮次);见 {@link hasFreshStatement} */
+  bodyRound: number;
   /** agent 最近一次对它表态或重报的轮次 */
   lastSeenRound: number;
   /** 该次表态的结论;仅当 lastSeenRound === Review.currentRound 时代表本轮判定 */
@@ -353,13 +355,36 @@ export interface Finding {
 export const isAutoClosedFixed = (f: Finding): boolean => f.triage === 'dismiss' && f.autoClosed;
 
 /**
+ * 本轮复核判定「仍存在」。与 UI 同一口径:只有表态轮次 === 当前轮次才代表本轮结论。
+ *
+ * 与 {@link recheckNote} 分开问:说明会被随后的 `update_finding` 作废清掉
+ * (见 ReviewStore.updateFinding),而判定本身不受影响 —— 问题仍然在,追评仍然欠着。
+ */
+export function isStillPresent(f: Finding, currentRound: number): boolean {
+  return f.lastSeenRound === currentRound && f.resolution === 'still_present';
+}
+
+/**
  * 本轮复核判定「仍存在」时 agent 给出的说明。它是看过作者的修改尝试之后写的,
  * 比首次报出的正文更新,故提交/导出时**取代**首轮正文作为评论正文。
- * 与 UI 同一口径:只有表态轮次 === 当前轮次才代表本轮结论。
+ *
+ * 反过来:正文若在这之后又被改写,新正文才是最新的一份,这条说明会在落库时一并清掉,
+ * 此处随即回到正文口径 —— 两份描述同一处的话,不能各说各的。
  */
 export function recheckNote(f: Finding, currentRound: number): string | null {
-  if (f.lastSeenRound !== currentRound || f.resolution !== 'still_present') return null;
+  if (!isStillPresent(f, currentRound)) return null;
   return f.resolutionNote?.trim() || null;
+}
+
+/**
+ * 本轮有没有**新写给作者的话**:一条本轮的复核说明,或一份本轮改写过的正文。
+ *
+ * 两者是同一件事的两种落法,不能只认前者:复核说明会被随后的正文改写清掉,而那次改写
+ * 正是新话本身。也不能只认「本轮仍存在」—— 去重兜底命中的条目同样挂着这个判定却一字未写,
+ * 据它追评就是把已经提交过的原话再发一遍。
+ */
+export function hasFreshStatement(f: Finding, currentRound: number): boolean {
+  return recheckNote(f, currentRound) !== null || f.bodyRound === currentRound;
 }
 
 /**
@@ -393,6 +418,8 @@ export function alignSuggestion(suggestion: string, anchorLine?: string | null):
  * 同上三处共用的一键补丁:复核说明取代首轮正文时,首轮 suggestion 一并作废。
  * 它与首轮正文同源、同样写在作者这次改动之前,而 `resolve_finding` 没有刷新它的入口 ——
  * 挂到当前锚点上就是一键覆盖作者刚改的代码,比一段对不上的描述更伤。
+ * 唯一的刷新入口是 `update_finding`,而它改写正文时会把旧说明与旧补丁一起清掉,
+ * 所以走到这里还留着补丁的,必然是随新正文一起给的那份,不必在此另作区分。
  *
  * `anchorLine` 是锚定行原文(取自 diff 新侧),给了就据它补齐缩进,见 {@link alignSuggestion}。
  */
@@ -457,8 +484,14 @@ export type ProposalPatch = ProposalUpdatePatch | ProposalReasonPatch | ReportFi
  *
  * 只拍**该提案真正改动的那几个字段** —— 拍全量的话,撤销会把应用之后 reviewer 自己的编辑
  * 一并回滚掉:提案只降了个 severity,撤销却连带把他重写过的正文换回旧版。
+ *
+ * 复核说明与正文轮次不在 patch 的字段里,却会随正文改写一并变(见 ReviewStore.updateFinding),
+ * 故也拍进来 —— 否则撤销交回的是一条被剥掉复核说明、正文轮次还停在本轮的旧 finding。
  */
-export type ProposalUpdateBefore = ProposalUpdatePatch;
+export type ProposalUpdateBefore = ProposalUpdatePatch & {
+  resolutionNote?: string | null;
+  bodyRound?: number;
+};
 
 export interface ProposalTriageBefore {
   triage: Triage;
@@ -550,9 +583,20 @@ export function isProposalUndoBlocked(p: FindingProposal, finding: Finding | nul
   if (p.status !== 'applied' || p.kind === 'create' || !p.before) return false;
   if (!finding) return true;
   if (p.kind === 'update') {
-    return (Object.keys(p.patch) as (keyof ProposalUpdatePatch)[]).some(
-      (k) => (finding[k] ?? null) !== (p.patch[k] ?? null),
-    );
+    if (
+      (Object.keys(p.patch) as (keyof ProposalUpdatePatch)[]).some(
+        (k) => (finding[k] ?? null) !== (p.patch[k] ?? null),
+      )
+    )
+      return true;
+    // 快照里 patch 没点名的那几项,是应用改写正文时被**连带清空**的(见 ReviewStore.updateFinding),
+    // 应用之后它们必然是空。此刻不空 = 有人重新写过一份,撤销会拿旧值把那份新的顶掉。
+    // bodyRound 不必单列:它只随正文变,而正文已在上面逐字段比过了。
+    const before = p.before as ProposalUpdateBefore;
+    if (before.resolutionNote !== undefined && finding.resolutionNote !== null) return true;
+    if (before.suggestion !== undefined && p.patch.suggestion === undefined && finding.suggestion !== null)
+      return true;
+    return false;
   }
   if (p.kind === 'dismiss')
     return finding.triage !== 'dismiss' || (finding.dismissReason ?? '') !== p.patch.reason;

--- a/src/shared/github-review.ts
+++ b/src/shared/github-review.ts
@@ -7,7 +7,8 @@ import {
   findingAnchorText,
   findingNarrative,
   findingSuggestion,
-  recheckNote,
+  hasFreshStatement,
+  isStillPresent,
   type Finding,
   type Review,
 } from './domain';
@@ -161,12 +162,16 @@ export function submitBlocker(payload: PrReviewPayload): string | null {
 }
 
 /**
- * 上一轮已提交、本轮复核判定仍存在且给了说明 → 还欠 author 一条追评。
+ * 上一轮已提交、本轮复核判定仍存在且写下了新话 → 还欠 author 一条追评。
  * `submitted` 之所以不再是"发过就完"的终态:作者据首轮评论改过一版、agent 复核后认定没改对,
  * 这条结论只留在本地等于白复核。同轮内不重复(提交时记下轮次),避免一轮里连发两条同样的评论。
+ *
+ * 「新话」两种落法都算(见 {@link hasFreshStatement}):只认复核说明的话,agent 一改写正文
+ * 就把说明清掉,这条追评随即从待提交集里消失 —— 而它欠着的追评并没有还上。
  */
 export function needsRecheckFollowUp(f: Finding, currentRound: number): boolean {
-  if (f.submission !== 'submitted' || recheckNote(f, currentRound) === null) return false;
+  if (f.submission !== 'submitted' || !isStillPresent(f, currentRound)) return false;
+  if (!hasFreshStatement(f, currentRound)) return false;
   return (f.submittedRound ?? currentRound) < currentRound;
 }
 


### PR DESCRIPTION
A `still_present` recheck note is written before the body it ends up sitting next
to. Once `update_finding` rewrites that body, the note describes an older version
of the finding, yet `findingNarrative` still sends it *in place of* the body: the
card shows two descriptions of the same problem and the stale one is what reaches
the author. The note is now cleared on such a rewrite, together with the
suggestion that was never refreshed alongside it.

- Invalidation keys on the verdict of the round rather than on the note, so the
  dedupe fallback path (still present, no note attached) also drops its stale
  patch instead of shipping a one-click overwrite of code the author just
  changed.
- Follow-up submission now asks whether the round produced a fresh statement at
  all: a recheck note, or a body rewritten this round. The latter needs the new
  `body_round` column (migration V17, backfilled from the report round). A
  rewrite therefore no longer drops the finding out of the submit queue, while a
  dedupe-only touch still sends nothing.
- Proposal undo writes its snapshot verbatim instead of going through
  `updateFinding`, which would treat the rollback as a fresh rewrite and clear a
  note written after the apply. Snapshots are taken by before/after diff so the
  fields cleared as a side effect can be rolled back, and undo is refused when
  one of them has been written again.

Verified with the deterministic spikes (submit, proposals section C, db
migration) plus a manual pass over edit / apply / undo in the UI preview.