### PR TITLE
fix(review): preview sidebar resize with a dashed ghost line

### DIFF
--- a/src/renderer/screens/ReviewScreen.css
+++ b/src/renderer/screens/ReviewScreen.css
@@ -297,7 +297,17 @@
 .rev-main {
   flex: 1;
   display: grid;
-  grid-template-columns: var(--left-w) 5px minmax(0, 1fr) 5px var(--right-w);
+  /* 侧栏宽 = 持久化值经 cap 封顶。cap 与 resizer 列宽只在窄窗退化那两段媒体查询里改,
+     栏数与顺序在这一行说清就够;Resizer 的拖拽预览也读这两个 cap,数字别写回 grid 行 */
+  --left-cap: 9999px; /* 无上限 */
+  --right-cap: 9999px;
+  --left-rz: 5px;
+  grid-template-columns:
+    min(var(--left-w), var(--left-cap))
+    var(--left-rz)
+    minmax(0, 1fr)
+    5px
+    min(var(--right-w), var(--right-cap));
   min-height: 0;
   /* grid item:不加会被自身宽内容(长代码行)撑破、把右栏顶出视口 */
   min-width: 0;
@@ -327,6 +337,44 @@
   width: 2px;
   background: var(--agent);
   box-shadow: 0 0 0 2px var(--agent-soft);
+}
+/* 拖拽预览的虚线与读数:栏宽要到松手才变,拖拽期只改这两个变量喂 transform(见 Resizer.tsx) */
+.resizer-ghost {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  border-left: 2px dashed var(--agent);
+  transform: translateX(calc(-1px + var(--ghost-dx, 0px)));
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 7;
+}
+.resizer.drag .resizer-ghost {
+  visibility: visible;
+}
+.rz-read {
+  position: absolute;
+  left: 8px;
+  top: 0;
+  transform: translateY(calc(var(--ghost-y, 0px) - 50%));
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--agent);
+  color: var(--on-accent);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+/* 指针捕获只改事件走向:不锁光标,划过 diff 就闪回 text 光标,还会顺手选中代码。
+   两条属性都可继承,但后代自己声明的 cursor / user-select 会赢过 body 上的值,只能连后代一起压;
+   拖拽是瞬时态,!important 的作用面随 .rz-dragging 一起消失 */
+body.rz-dragging,
+body.rz-dragging * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 .pane {
   min-height: 0;
@@ -3999,7 +4047,8 @@
 /* 中窄:侧栏按持久化宽度上限收窄给中间 diff 让位;状态栏减噪。断点已计入 rail 的 52px */
 @media (max-width: 1180px) {
   .rev-main {
-    grid-template-columns: min(var(--left-w), 208px) 5px minmax(0, 1fr) 5px min(var(--right-w), 340px);
+    --left-cap: 208px;
+    --right-cap: 340px;
   }
   .rev-statusbar .sb-tool {
     display: none;
@@ -4008,7 +4057,9 @@
 /* 窄:收起文件树(diff 已按文件全量堆叠,树仅作跳转),留 diff + 右栏两栏 */
 @media (max-width: 940px) {
   .rev-main {
-    grid-template-columns: 0 0 minmax(0, 1fr) 5px min(var(--right-w), 300px);
+    --left-cap: 0px;
+    --right-cap: 300px;
+    --left-rz: 0px; /* 文件树收起后它那条 resizer 也不占位 */
   }
   .rev-main > .tree {
     overflow: hidden;

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -587,6 +587,7 @@ export function ReviewScreen({
           />
           <Resizer
             cssVar="--left-w"
+            capVar="--left-cap"
             width={leftW}
             min={LEFT_MIN}
             max={LEFT_MAX}
@@ -624,6 +625,7 @@ export function ReviewScreen({
           />
           <Resizer
             cssVar="--right-w"
+            capVar="--right-cap"
             width={rightW}
             min={RIGHT_MIN}
             max={RIGHT_MAX}

--- a/src/renderer/screens/review/Resizer.tsx
+++ b/src/renderer/screens/review/Resizer.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 export interface ResizerProps {
-  /** 拖拽实时驱动的栏宽 CSS 变量(挂在 .rev-root) */
+  /** 松手时写入的栏宽 CSS 变量(挂在 .rev-root) */
   cssVar: string;
+  /** 该侧栏宽的响应式上限变量(挂在 .rev-main,窄窗退化时被媒体查询压低) */
+  capVar: string;
   /** 当前已提交栏宽(px);拖拽以此为起点 */
   width: number;
   min: number;
@@ -18,54 +20,96 @@ export interface ResizerProps {
 }
 
 /**
- * 列间可拖拽分隔条。拖拽期间只命令式改 .rev-root 的栏宽 CSS 变量,
- * 不走 React state,避免每次 pointermove 重渲染整棵 DiffPane 导致卡顿;松手才提交一次落库。
+ * 列间可拖拽分隔条。拖拽期只用 transform 移一条虚线预览目标位置,不动 grid 栏宽 ——
+ * 中栏 diff 全量在 DOM 里(无虚拟化),每次 pointermove 改栏宽都要整棵子树重排,
+ * 分隔条就掉在光标后面。松手才写一次真实栏宽,只付一次重排。
  */
-export function Resizer({ cssVar, width, min, max, sign, defaultWidth, onCommit }: ResizerProps) {
+export function Resizer({ cssVar, capVar, width, min, max, sign, defaultWidth, onCommit }: ResizerProps) {
   const elRef = useRef<HTMLDivElement>(null);
-  // 拖拽起点与实时宽度;非 state,避免触发渲染
-  const drag = useRef<{ startX: number; startW: number; latest: number } | null>(null);
+  const ghostRef = useRef<HTMLDivElement>(null);
+  const readRef = useRef<HTMLSpanElement>(null);
+  // 拖拽起点、有效上限与实时宽度;非 state,避免触发渲染。几何量与 cap 都在按下时量一次
+  const drag = useRef<{ startX: number; startW: number; hi: number; top: number; latest: number } | null>(null);
   const [dragging, setDragging] = useState(false);
 
   const host = () => elRef.current?.closest('.rev-root') as HTMLElement | null;
 
+  /** 只写 transform 用的两个变量与读数文本,不触碰任何影响布局的属性 */
+  const paint = useCallback(
+    (next: number, startW: number, clientY: number, top: number) => {
+      const g = ghostRef.current;
+      if (g) {
+        g.style.setProperty('--ghost-dx', `${sign * (next - startW)}px`);
+        g.style.setProperty('--ghost-y', `${clientY - top}px`);
+      }
+      if (readRef.current) readRef.current.textContent = `${next}px`;
+    },
+    [sign],
+  );
+
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
-      drag.current = { startX: e.clientX, startW: width, latest: width };
+      const el = elRef.current;
+      const top = el?.getBoundingClientRect().top ?? 0;
+      // 起点量实际几何宽度,不用持久化值:窄窗下媒体查询会拿 min() 把栏宽压小(见 ReviewScreen.css),
+      // 以持久化值起算的虚线与读数会从一个屏幕上不存在的位置开始
+      const pane = (sign === 1 ? el?.previousElementSibling : el?.nextElementSibling) as HTMLElement | null;
+      // 上限还要压到响应式 cap:超过它的位置布局根本给不出来,预览到那儿就是骗人
+      const cap = parseFloat(getComputedStyle(el?.parentElement ?? document.body).getPropertyValue(capVar));
+      const hi = Number.isFinite(cap) ? Math.min(max, cap) : max;
+      const startW = clamp(Math.round(pane?.getBoundingClientRect().width || width), min, hi);
+      drag.current = { startX: e.clientX, startW, hi, top, latest: startW };
       setDragging(true);
-      elRef.current?.setPointerCapture(e.pointerId);
+      paint(startW, startW, e.clientY, top);
+      document.body.classList.add('rz-dragging');
+      el?.setPointerCapture(e.pointerId);
     },
-    [width],
+    [capVar, width, min, max, sign, paint],
+  );
+
+  /** 收尾:提交 + 撤掉拖拽态。可能被多个事件先后触发,故必须幂等 */
+  const finish = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = drag.current;
+      drag.current = null;
+      setDragging(false);
+      document.body.classList.remove('rz-dragging');
+      const el = elRef.current;
+      if (el?.hasPointerCapture?.(e.pointerId)) el.releasePointerCapture(e.pointerId);
+      // 只按下没拖动(含误点)不写回:窄窗下 startW 是被 min() 压过的值,写回会悄悄改掉用户的栏宽偏好
+      if (!d || d.latest === d.startW) return;
+      // 同帧写 CSS 变量:父层落库前虚线已经收掉,不写就会闪一帧旧宽度
+      host()?.style.setProperty(cssVar, `${d.latest}px`);
+      onCommit(d.latest);
+    },
+    [cssVar, onCommit],
   );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       const d = drag.current;
       if (!d) return;
-      const next = clamp(d.startW + sign * (e.clientX - d.startX), min, max);
+      // 键已松开却没收到 pointerup(指针拖出窗口后在别处松手):回到页面上的第一次移动就收尾
+      if (e.buttons === 0) {
+        finish(e);
+        return;
+      }
+      const next = clamp(d.startW + sign * (e.clientX - d.startX), min, d.hi);
       d.latest = next;
-      host()?.style.setProperty(cssVar, `${next}px`);
+      paint(next, d.startW, e.clientY, d.top);
     },
-    [cssVar, min, max, sign],
+    [sign, min, paint, finish],
   );
 
-  const stop = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const d = drag.current;
-      drag.current = null;
-      setDragging(false);
-      elRef.current?.releasePointerCapture?.(e.pointerId);
-      if (d && d.latest !== width) onCommit(d.latest);
-    },
-    [width, onCommit],
-  );
+  // 拖拽中卸载(切 review / 导航)时 pointerup 永远不会来,不清就把 col-resize 与禁选留给整个 app
+  useEffect(() => () => document.body.classList.remove('rz-dragging'), []);
 
-  // 双击恢复默认:拖歪了没有别的路回来 —— 拖拽期改的是 CSS 变量,这里也一并写回,
-  // 免得父层落库前的一帧还停在旧宽度
+  // 双击恢复默认:拖歪了没有别的路回来
   const reset = useCallback(() => {
+    if (defaultWidth === width) return;
     host()?.style.setProperty(cssVar, `${defaultWidth}px`);
-    if (defaultWidth !== width) onCommit(defaultWidth);
+    onCommit(defaultWidth);
   }, [cssVar, defaultWidth, width, onCommit]);
 
   return (
@@ -76,9 +120,16 @@ export function Resizer({ cssVar, width, min, max, sign, defaultWidth, onCommit 
       title="拖拽调整栏宽 · 双击恢复默认"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
-      onPointerUp={stop}
-      onPointerCancel={stop}
+      onPointerUp={finish}
+      onPointerCancel={finish}
+      // 指针捕获被静默收走(拖出窗口后在别处松手)时唯一还会来的事件 —— 没它虚线就一直挂在页面上
+      onLostPointerCapture={finish}
       onDoubleClick={reset}
-    />
+    >
+      {/* 常驻:按下那一帧 state 还没刷,现挂的话 ref 还是空的,拿不到第一次 paint */}
+      <div ref={ghostRef} className="resizer-ghost" aria-hidden="true">
+        <span ref={readRef} className="rz-read" />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Dragging either sidebar divider lagged behind the cursor. The drag was never debounced —
every `pointermove` wrote `--left-w` / `--right-w`, which lands in
`.rev-main { grid-template-columns }` and relayouts the whole three-column grid. The middle
column is `DiffPane`, which renders every file, hunk and line with no virtualisation and
sticky cells inside, and nothing in the tree is `contain`ed. So each event paid a full
subtree relayout and the divider separated from the pointer, which reads as "delayed".

## Ghost line

Now the drag touches no layout at all: it moves a 1px dashed line by writing `--ghost-dx`
into its own `transform`, a compositor-only path whose cost does not depend on the size of
the diff. The real column width is written once on release, so the layout pays exactly one
relayout per drag.

- A px readout follows the pointer vertically (same transform, `--ghost-y`), so the target
  width is legible while the panes have not moved yet.
- The ghost element is always mounted and hidden with `visibility`. On `pointerdown` the
  state flip has not flushed, so a conditionally rendered ghost would have a null ref for
  the first paint.
- `body.rz-dragging` locks the cursor and selection for the duration. Pointer capture only
  redirects events; without this, crossing the diff flickers back to a text cursor and
  selects code. It has to cover descendants (`body.rz-dragging *`, `!important`) because
  `cursor` and `user-select` are inherited but any descendant declaring its own value wins.

## Drag that never gets a pointerup

Releasing the button outside the window left the ghost on screen forever, since pointer
capture can be taken away silently and no `pointerup` arrives. Three terminators now:

- `onLostPointerCapture` — the one event that still fires when capture is dropped.
- `pointermove` with `e.buttons === 0` — the first move back over the page ends the drag.
- an unmount cleanup for `rz-dragging`, since navigating away mid-drag removes the handlers
  before any of the above can run and would leave `col-resize` and `user-select: none` on
  the whole app.

`finish` is idempotent (it clears `drag.current` first and checks `hasPointerCapture` before
releasing), so several of these firing in sequence commit once.

## Responsive caps are now data, not a duplicated grid line

The two narrow-window breakpoints capped the sidebars with `min(var(--left-w), 208px)` and
friends, each block restating the whole `grid-template-columns`. The drag knew nothing about
those caps, so in a narrow window the ghost previewed 350px, committed 350px, and the layout
stayed at 340px.

`--left-cap` / `--right-cap` / `--left-rz` now hold what the media queries override, the grid
declaration exists once, and `Resizer` reads the cap on `pointerdown` to clamp the preview
and the commit. Hitting a cap now behaves exactly like hitting `max`: the line stops, the
readout stops, nothing is written on release. The default is `9999px` rather than `100vw`
because custom properties are not type-resolved, so JS would read the literal `100vw`.

Two related details fell out of the same area:

- `startW` is measured from the adjacent pane instead of read from the persisted value, so
  the line and the readout start from the divider that is actually on screen.
- The empty-commit test compares against `startW`, not the persisted width. Otherwise a
  plain click on a divider in a narrow window would quietly overwrite a 260px preference
  with the 208px the cap had imposed.

## Verification

`tsc --noEmit` and `eslint` clean. All of the below in `preview:ui`, review screen, no
console errors:

- 1280px: caps read `9999px`; left drag 300 → 345 commits and the column follows; drag to
  `LEFT_MAX` clamps at 460; both dividers reset to their defaults on double-click.
- 1100px (caps 208 / 340): dragging the right divider outward by 55px commits nothing and
  the grid does not move (before this change it wrote 395px against an effective 340px);
  dragging inward commits 300px and the column is 300px; dragging the left divider from the
  capped 208px to 187px moves the pane to 187px.
- 900px: `grid-template-columns` resolves to `0px 0px 543px 5px 300px`, equivalent to the
  hard-coded line it replaces; the tree and its divider are both zero-width.
- Click without moving leaves the width untouched and leaves no residue.
- Release outside the viewport commits the clamped width and clears the ghost and the body
  class.
- Under `rz-dragging`, buttons, code cells, `td` and inputs all compute `col-resize` and
  `user-select: none`, and all revert when the class is removed.
- Unmounting the review screen with the class set clears it.

Not verified: a release that the OS routes to another application window entirely — the
harness delivers its synthetic release to the page, so `onLostPointerCapture` rests on the
event semantics with the `buttons === 0` check as its backstop. Mid-drag frames cannot be
screenshotted either (no hold-button primitive), so the ghost's appearance was checked by
forcing the drag state.

`content-visibility: auto` on `.diff-file` would make the subtree cheap for scrolling and
first paint as well, but it zeroes the geometry of off-screen files and `diff-find.ts`
locates matches with `getBoundingClientRect`. Left alone deliberately; it is its own change.