### PR TITLE
fix(review): stop review hotkeys from eating macOS Ctrl inline-edit keys

### DIFF
--- a/src/renderer/keys.ts
+++ b/src/renderer/keys.ts
@@ -23,7 +23,7 @@ const IS_MAC = /mac/i.test(
     navigator.platform,
 );
 
-function primaryModifier(e: { metaKey: boolean; ctrlKey: boolean }): boolean {
+export function primaryModifier(e: { metaKey: boolean; ctrlKey: boolean }): boolean {
   return IS_MAC ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
 }
 

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -19,7 +19,7 @@ import { Resizer } from './review/Resizer';
 import { ReviewStatusBar } from './review/StatusBar';
 import { describeRoundError, describeSendFailure } from './review/round-error';
 import { RerunPanel } from './review/RerunPanel';
-import { isRerunKey } from '../keys';
+import { isRerunKey, primaryModifier } from '../keys';
 import { LogoMark } from '../components/LogoMark';
 import { Wordmark } from '../components/Wordmark';
 import {
@@ -426,8 +426,10 @@ export function ReviewScreen({
         if (helpOpen) setHelpOpen(false);
         return;
       }
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod && !e.altKey && e.key === '?' && !typing) {
+      // 平台主修饰键(判据与选型见 primaryModifier):macOS 上 Ctrl+F / Ctrl+A 一类归文本控件的
+      // 行内编辑,两边都收会把它们从 composer、finding 编辑框里抢走。
+      const mod = primaryModifier(e);
+      if (!e.metaKey && !e.ctrlKey && !e.altKey && e.key === '?' && !typing) {
         if (!helpOpen && modalOpen) return; // 已有别的模态在前,别再叠一层帮助
         e.preventDefault();
         setHelpOpen((v) => !v);

--- a/src/renderer/screens/review/DiffPane.tsx
+++ b/src/renderer/screens/review/DiffPane.tsx
@@ -16,6 +16,7 @@ import { AnnotateComposer, type NewFindingDraft } from './AnnotateComposer';
 import { PencilIcon } from './PencilIcon';
 import { SelectionPopover } from './SelectionPopover';
 import { DiffFindBar } from './DiffFindBar';
+import { primaryModifier } from '../../keys';
 import {
   clearMatches,
   findMatches,
@@ -497,7 +498,7 @@ export function DiffPane(props: DiffPaneProps) {
   const findSeed = useRef<string | null>(null);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || e.key.toLowerCase() !== 'f') return;
+      if (!primaryModifier(e) || e.altKey || e.shiftKey || e.key.toLowerCase() !== 'f') return;
       findSeed.current = selectionSeed(ref.current);
     };
     window.addEventListener('keydown', onKey, true);
@@ -517,7 +518,7 @@ export function DiffPane(props: DiffPaneProps) {
   useEffect(() => {
     if (!findOpen || props.keysSuspended) return;
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.key.toLowerCase() !== 'g') return;
+      if (!primaryModifier(e) || e.altKey || e.key.toLowerCase() !== 'g') return;
       e.preventDefault();
       step(e.shiftKey ? -1 : 1);
     };


### PR DESCRIPTION
## Problem

The review-screen navigation listener and the diff pane find listeners all
gated on `e.metaKey || e.ctrlKey`. On macOS, Ctrl+F/B/A/E/K are text-control
inline-edit keys, so those global listeners were calling preventDefault and
stealing focus out of the composer and the finding editors.

Measured in the UI preview (`?screen=review`) with focus in `.composer-input`,
before the fix:

| key | defaultPrevented | focus |
| --- | --- | --- |
| Cmd+F (positive control) | true | moved to the find bar |
| Ctrl+F | true | moved to the find bar |
| Ctrl+J (negative control) | false | stayed in the composer |
| bare f (negative control) | false | stayed in the composer |

Ctrl+Shift+F, Ctrl+2, Ctrl+U and Ctrl+G were swallowed the same way.
Ctrl+E was already correct, since the rerun shortcut goes through
`primaryModifier`.

## Fix

Export the existing `primaryModifier` from `keys.ts` and reuse it, rather than
adding a second platform check. Callers updated: the review-screen navigation
block (Cmd+F, Cmd+Shift+F, Cmd+1-3, Cmd+U) and the two diff pane listeners
(Cmd+F selection seed, Cmd+G next match).

The `?` help branch used to lean on `!mod` to reject modifiers. With `mod` now
platform-aware, Ctrl+? would have leaked through on macOS, so that branch got
an explicit bare-key guard.

The Cmd+Enter send handlers are left alone: Ctrl+Enter is not a macOS
inline-edit key, and those are local onKeyDown handlers on the input itself,
so they never steal keys from another control.

## Verification

Same preview, same dispatch channel, after the fix. All Cmd variants still
fire (Cmd+F, Cmd+Shift+F, Cmd+2, Cmd+U, Cmd+G report prevented true). All
Ctrl variants pass through (prevented false, focus stays in the composer, tab
and diff view unchanged), as does Cmd+Ctrl+F. Bare `?` still opens the help
overlay; Ctrl+? and Cmd+? do not.

`npm run typecheck` and `npm run lint` are clean.