### PR TITLE
feat(entry): list recent repos in the local-repo switch dropdown

### DIFF
--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -1218,7 +1218,12 @@ export function installPreviewApi(): void {
           return { ...base, head: 'gitbutler/workspace', mode: 'local', degraded: 'but-missing' };
         return { ...base, head: 'gitbutler/workspace', mode: 'gitbutler', gitbutler };
       },
-      listRepoPaths: async () => ['/Users/dev/GitHub/backend-podcast-node', '/Users/dev/duetlens'],
+      listRepoPaths: async () => [
+        '/Users/dev/podcast-go',
+        '/Users/dev/GitHub/backend-podcast-node',
+        '/Users/dev/duetlens',
+        '/Users/dev/GitHub/xiaoyuzhou/xyz-web',
+      ],
     },
     prompt: {
       get: async (cwd) => buildPromptView(cwd),

--- a/src/renderer/screens/EntryScreen.css
+++ b/src/renderer/screens/EntryScreen.css
@@ -635,6 +635,75 @@
 .pick-cta:hover { filter: brightness(1.06); }
 .pick-hint { font-size: 11.5px; color: var(--text-faint); }
 
+/* 换仓库下拉:最近审核过的目录 + 末位的目录对话框 */
+.rswitch { position: relative; flex: none; }
+.rs-trig { display: inline-flex; align-items: center; gap: 6px; }
+.rs-trig .chev {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-right: 1.5px solid var(--text-deco);
+  border-bottom: 1.5px solid var(--text-deco);
+  transform: translateY(-2px) rotate(45deg);
+}
+.rswitch.open .rs-trig { border-color: var(--agent-line); color: var(--text); }
+.rswitch.open .rs-trig .chev { border-color: var(--agent-2); transform: translateY(1px) rotate(-135deg); }
+.rs-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  min-width: 300px;
+  max-width: 380px;
+  background: var(--surface-2);
+  border: 1px solid var(--agent-line);
+  border-radius: 11px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.rs-menu.up { top: auto; bottom: calc(100% + 6px); }
+/* 高度由组件按可用空间算(卡片 overflow:hidden 会裁掉溢出的部分) */
+.rs-rows { max-height: var(--rs-rows-max, 180px); overflow: auto; padding: 5px 5px 0; }
+/* 菜单项是真按钮(焦点要落进菜单),故先抹掉按钮自带的边框/底/字体/居中 */
+.rs-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 7px;
+  background: none;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.rs-row.active { background: var(--surface-3); }
+.rs-row.sel { background: color-mix(in oklab, var(--agent) 12%, var(--surface-2)); }
+/* 名字是识别这一行的唯一凭据,只有它自己撑满时才让位,目录段先截 */
+.rs-row .rn { font-size: 12px; color: var(--text); font-weight: 600; flex: none; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rs-row.sel .rn { color: var(--agent-2); }
+.rs-row .rd { font-size: 10.5px; color: var(--text-faint); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rs-row .tick { margin-left: auto; width: 12px; color: var(--agent-2); font-size: 12px; flex: none; }
+.rs-browse {
+  display: block;
+  width: 100%;
+  padding: 8px 13px;
+  margin-top: 5px;
+  border: 0;
+  border-top: 1px solid var(--border-soft);
+  background: none;
+  font-family: inherit;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  text-align: left;
+  cursor: pointer;
+}
+.rs-browse.active { background: var(--surface-3); color: var(--text); }
+/* 高亮项恒等于焦点所在项,再补一圈内描边,让键盘位置在 hover 底色之外也读得出来 */
+.rs-row:focus-visible,
+.rs-browse:focus-visible { outline: 1.5px solid var(--agent-2); outline-offset: -2px; }
+
 /* 最近用过的仓库(空态快选) */
 .recent-repos {
   display: flex;

--- a/src/renderer/screens/EntryScreen.tsx
+++ b/src/renderer/screens/EntryScreen.tsx
@@ -21,6 +21,8 @@ import type {
 import { useSettings } from '../settings/SettingsProvider';
 import { BranchPicker, BranchSummary, type BranchOption } from './entry/BranchPicker';
 import { GhIcon, LocalBranchIcon } from './entry/icons';
+import { baseName, parentDir } from './entry/paths';
+import { RepoSwitch } from './entry/RepoSwitch';
 import { RecentReviews } from './entry/RecentReviews';
 import { StartOverlay } from './entry/StartOverlay';
 import { LogoMark } from '../components/LogoMark';
@@ -935,9 +937,7 @@ function RepoPanel({
         <span className="repo-path mono" title={repoPath}>
           {repoPath}
         </span>
-        <button type="button" className="pf-pick" onClick={pickDir}>
-          切换…
-        </button>
+        <RepoSwitch current={repoPath} recents={recentRepos} onPick={pickRepo} onBrowse={pickDir} />
         {/* 模式是自动判定的,普通分支这档也要说出来,否则「为什么不是虚拟分支」无处可查 */}
         {listing && insp && !insp.degraded && (
           <span className="mode-chip mono" title={insp.head ? `HEAD: ${insp.head}` : undefined}>
@@ -1026,9 +1026,6 @@ function PickRepoEmpty({ pickDir, hint }: { pickDir: () => void; hint: string })
     </div>
   );
 }
-
-const baseName = (p: string) => p.replace(/\/+$/, '').split('/').pop() || p;
-const parentDir = (p: string) => p.replace(/\/+$/, '').split('/').slice(0, -1).join('/');
 
 /** 底部 CTA 的目标标签(来源 + 已选 ref)。 */
 function useTargetLabel(source: SourceKind, ref: string): string {

--- a/src/renderer/screens/entry/BranchPicker.tsx
+++ b/src/renderer/screens/entry/BranchPicker.tsx
@@ -224,8 +224,8 @@ const ROWS_COMFORT = 108;
 const ROWS_FLOOR = 72;
 const ROWS_MAX = 232;
 
-/** 会裁切内容的各层祖先与视口的交集;取不到边界时不设限(交给 ROWS_MAX 收口)。 */
-function clipBounds(el: HTMLElement): { top: number; bottom: number } {
+/** 会裁切内容的各层祖先与视口的交集;取不到边界时不设限(由调用方的上限收口)。 */
+export function clipBounds(el: HTMLElement): { top: number; bottom: number } {
   let top = 0;
   let bottom = window.innerHeight || document.documentElement.clientHeight || Number.POSITIVE_INFINITY;
   for (let p = el.parentElement; p; p = p.parentElement) {

--- a/src/renderer/screens/entry/RepoSwitch.tsx
+++ b/src/renderer/screens/entry/RepoSwitch.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { clipBounds } from './BranchPicker';
+import { baseName, parentDir } from './paths';
+
+/** 菜单里最多列几个仓库(含当前这个)。 */
+const LIMIT = 6;
+/** 单行高度、浮层与触发器的间距 + 列表内边距、离裁切边留白、列表高度下限(不够就让它自己滚)。 */
+const ROW_H = 30;
+const CHROME = 16;
+const EDGE_INSET = 10;
+const ROWS_FLOOR = 60;
+
+/**
+ * 换仓库:最近审核过的目录直接摆进菜单,系统目录对话框退居末位一项 ——
+ * 常用仓库就那么几个,不该每次都走一遍文件选择器。
+ * 没有别的候选时(首次使用)退回单纯的按钮,不给一个只列着自己的菜单。
+ */
+export function RepoSwitch({
+  current,
+  recents,
+  onPick,
+  onBrowse,
+}: {
+  current: string;
+  recents: string[];
+  onPick: (dir: string) => void;
+  onBrowse: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const [place, setPlace] = useState<{ up: boolean; rowsMax: number } | null>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const trigRef = useRef<HTMLButtonElement>(null);
+  const itemsRef = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const rows = [current, ...recents.filter((p) => p !== current)].slice(0, LIMIT);
+  const hasChoice = rows.length > 1;
+  // 末位的「浏览其他目录…」也是一项:方向键会走到它上面
+  const count = rows.length + 1;
+
+  // 浮层落在会裁切的祖先(入口卡片 overflow:hidden)里,按可用空间定高、必要时上翻
+  useLayoutEffect(() => {
+    if (!open || !boxRef.current) {
+      setPlace(null);
+      return;
+    }
+    const trig = boxRef.current.getBoundingClientRect();
+    const clip = clipBounds(boxRef.current);
+    const want = rows.length * ROW_H;
+    const room = (edge: number) => Math.floor(edge - CHROME - EDGE_INSET - ROW_H);
+    const below = room(clip.bottom - trig.bottom);
+    const above = room(trig.top - clip.top);
+    const up = below < want && above > below;
+    setPlace({ up, rowsMax: Math.min(want, Math.max(ROWS_FLOOR, up ? above : below)) });
+  }, [open, rows.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!boxRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', onDown);
+    return () => document.removeEventListener('pointerdown', onDown);
+  }, [open]);
+
+  // 展开即把焦点交给菜单本身:菜单项是真按钮,高亮项就是焦点所在,
+  // 于是读屏能报出方向键停在哪个仓库,Tab 出去也会经 onBlur 收起浮层(否则它会一直遮着下面的控件)。
+  useEffect(() => {
+    if (open) itemsRef.current[0]?.focus();
+  }, [open]);
+
+  if (!hasChoice) {
+    return (
+      <button type="button" className="pf-pick" onClick={onBrowse}>
+        切换…
+      </button>
+    );
+  }
+
+  // 收起时把焦点还给触发器,除非焦点已经被用户挪走(点了别处 / Tab 出去)
+  const close = (restore = true) => {
+    setOpen(false);
+    if (restore) trigRef.current?.focus();
+  };
+
+  const toggle = () => {
+    if (open) close();
+    else {
+      setActive(0);
+      setOpen(true);
+    }
+  };
+
+  // 焦点即高亮,active 由菜单项的 onFocus 回填 —— 下一项也从当前焦点推,
+  // 从 active 推的话,同一批里连按两下方向键读到的是上一帧的值,第二下会原地不动。
+  const focusItem = (i: number) => itemsRef.current[i]?.focus();
+  const step = (delta: number) => {
+    const at = itemsRef.current.findIndex((el) => el === document.activeElement);
+    focusItem((Math.max(at, 0) + delta + count) % count);
+  };
+
+  const browse = () => {
+    close();
+    onBrowse();
+  };
+
+  const pick = (dir: string) => {
+    close();
+    if (dir !== current) onPick(dir);
+  };
+
+  // Enter / Space 由菜单项自己(button 的原生行为)负责,这里只管开合与方向键
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      if (open) close();
+      return;
+    }
+    if (!open) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        toggle();
+      }
+      return;
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      step(e.key === 'ArrowDown' ? 1 : -1);
+    }
+  };
+
+  // 焦点整个离开组件(Tab / 点走)就收起,不把浮层留在屏上
+  const onBlur = (e: React.FocusEvent) => {
+    if (!boxRef.current?.contains(e.relatedTarget)) setOpen(false);
+  };
+
+  return (
+    <div className={open ? 'rswitch open' : 'rswitch'} ref={boxRef} onKeyDown={onKeyDown} onBlur={onBlur}>
+      <button
+        type="button"
+        className="pf-pick rs-trig"
+        ref={trigRef}
+        onClick={toggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        切换<span className="chev" />
+      </button>
+
+      {open && (
+        <div
+          className={place?.up ? 'rs-menu up' : 'rs-menu'}
+          role="menu"
+          style={place ? ({ '--rs-rows-max': `${place.rowsMax}px` } as React.CSSProperties) : undefined}
+        >
+          <div className="rs-rows">
+            {rows.map((p, i) => (
+              <button
+                key={p}
+                type="button"
+                role="menuitem"
+                ref={(el) => {
+                  itemsRef.current[i] = el;
+                }}
+                tabIndex={i === active ? 0 : -1}
+                className={`rs-row${p === current ? ' sel' : ''}${i === active ? ' active' : ''}`}
+                title={p}
+                onFocus={() => setActive(i)}
+                onMouseEnter={() => focusItem(i)}
+                onClick={() => pick(p)}
+              >
+                <span className="rn mono">{baseName(p)}</span>
+                <span className="rd mono">{parentDir(p)}</span>
+                <span className="tick">{p === current ? '✓' : ''}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            role="menuitem"
+            ref={(el) => {
+              itemsRef.current[rows.length] = el;
+            }}
+            tabIndex={active === rows.length ? 0 : -1}
+            className={active === rows.length ? 'rs-browse active' : 'rs-browse'}
+            onFocus={() => setActive(rows.length)}
+            onMouseEnter={() => focusItem(rows.length)}
+            onClick={browse}
+          >
+            浏览其他目录…
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/screens/entry/paths.ts
+++ b/src/renderer/screens/entry/paths.ts
@@ -1,0 +1,3 @@
+/** 仓库路径在 UI 上一律拆成「名字 + 上级目录」两段:名字是识别凭据,目录只做消歧。 */
+export const baseName = (p: string) => p.replace(/\/+$/, '').split('/').pop() || p;
+export const parentDir = (p: string) => p.replace(/\/+$/, '').split('/').slice(0, -1).join('/');


### PR DESCRIPTION
The head-row switch button now opens a menu listing recently reviewed repos
(current one on top, ticked), with the directory dialog kept as the last item.
Picking a repo no longer requires walking the system file dialog every time.

- Falls back to the plain button when there is no other candidate.
- Recent paths come from the existing review history, so no schema or backend change.
- Menu items are real buttons with roving tabIndex; the menu closes on Escape or
  when focus leaves, and hands focus back to the trigger.
- Preview fixture returns four repo paths so the menu is representative.

Verified in preview:ui in both light and dark. typecheck and lint pass.