### PR TITLE
fix(spike): inject duetlens MCP bearer token in codex spike

### DIFF
--- a/scripts/spike-codex.ts
+++ b/scripts/spike-codex.ts
@@ -119,7 +119,8 @@ async function main() {
     log('codex', `⚠ 意外反向审批: ${method} → denied`),
   );
 
-  codex.start();
+  // MCP server 一律校验 bearer(见 DuetlensMcpServer),令牌不给就是每次工具调用 401
+  codex.start({ DUETLENS_MCP_TOKEN: mcp.token });
 
   try {
     await codex.initialize({ name: 'duetlens', version: APP_VERSION });
@@ -130,7 +131,9 @@ async function main() {
       approvalPolicy: 'never',
       sandbox: 'read-only',
       baseInstructions: BASE_INSTRUCTIONS,
-      config: { mcp_servers: { duetlens: { url: mcpUrl } } },
+      config: {
+        mcp_servers: { duetlens: { url: mcpUrl, bearer_token_env_var: 'DUETLENS_MCP_TOKEN' } },
+      },
     });
     log('codex', `thread/start → ${thread.thread.id}`);
 


### PR DESCRIPTION
The spike started a codex thread without the MCP bearer token, so every
tool call was rejected with 401 and report_finding never arrived - the
assertion could only ever fail.

Mirror the real path in codex-agent.ts: pass DUETLENS_MCP_TOKEN in the
server env and point the duetlens MCP config at it via
bearer_token_env_var.

Verified with npm run spike:codex - the turn now reaches report_finding
and the spike passes.