### PR TITLE
feat(entry): cap recent reviews at 20 on home

### DIFF
--- a/src/renderer/screens/entry/RecentReviews.tsx
+++ b/src/renderer/screens/entry/RecentReviews.tsx
@@ -2,6 +2,9 @@ import type { RecentReview } from '@shared/ipc';
 import type { ReviewStatus, SourceKind } from '@shared/domain';
 import { GhIcon, GitButlerIcon, LocalBranchIcon } from './icons';
 
+/** 入口只摆最近这些条,全量翻阅走审核历史屏。 */
+const LIMIT = 20;
+
 /** 最近审核列表:源徽标 + 标题 + 计数/状态元信息;空态给首次引导。 */
 export function RecentReviews({
   reviews,
@@ -10,14 +13,15 @@ export function RecentReviews({
   reviews: RecentReview[];
   onOpen: (id: string) => void;
 }) {
+  const shown = reviews.slice(0, LIMIT);
   return (
     <div className="recent-section">
       <div className="section-head">
         <h3 className="mono">最近的审核</h3>
-        {reviews.length > 0 && <span className="count mono">{reviews.length}</span>}
+        {shown.length > 0 && <span className="count mono">{shown.length}</span>}
       </div>
 
-      {reviews.length === 0 ? (
+      {shown.length === 0 ? (
         <div className="empty-history">
           <div className="eh-ic">◇</div>
           <div className="eh-t">还没有审核记录</div>
@@ -27,7 +31,7 @@ export function RecentReviews({
         </div>
       ) : (
         <div className="recent-list">
-          {reviews.map((r) => (
+          {shown.map((r) => (
             <div key={r.id} className="recent-rev" onClick={() => onOpen(r.id)}>
               <SourceBadge source={r.source} sourceRef={r.sourceRef} />
               <div className="m">


### PR DESCRIPTION
入口页「最近的审核」只渲染最近 20 条,全量翻阅走左侧 rail 的审核历史屏。

- 只在 `RecentReviews` 里切片,不动 `review:list-recent`:历史屏复用同一条 IPC,要全量做搜索/筛选/分组,在 store 加 LIMIT 会把它一起截断。
- 标题旁计数改读切片后的条数,避免出现「写着 35 却只列 20 行」。