### PR TITLE
fix(settings): show the neutral status dot in the update pill

### DIFF
--- a/src/renderer/screens/SettingsScreen.css
+++ b/src/renderer/screens/SettingsScreen.css
@@ -262,6 +262,8 @@
   height: 7px;
   border-radius: 50%;
   flex: none;
+  /* 无 tone 的中性态也得有点,否则占位却看不见,读起来像文字左边缺了图标 */
+  background: var(--text-deco);
 }
 .settings .stat.ok {
   color: var(--add);


### PR DESCRIPTION
The status chips in Settings render a 7px dot before the label, but the
dot only got a background from its tone class (ok / warn / err / checking).
The update row's `current` and `idle` phases resolve to no tone, so the dot
stayed transparent while still taking 7px + 6px gap - reading as a missing
icon and a blank gap left of the text.

Give the base `.settings .stat .d` the neutral `--text-deco` background;
tone rules keep overriding it. Verified in the UI preview, light and dark.