### PR TITLE
fix(source): reject symlinks that resolve outside the repo

### DIFF
--- a/scripts/spike-gitbutler.ts
+++ b/scripts/spike-gitbutler.ts
@@ -2,12 +2,12 @@
  * GitButler source 验证(不烧 token):
  *   (1) 确定性:合成 but 结构化 diff → toUnifiedDiff → 断言重建成标准 unified(改/增/删)。
  *   (2) 实仓 smoke:对本仓某虚拟分支跑 GitButlerSource.getDiff/getFile,断言 diff 标记与文件内容。
- *   (3) 路径穿越:越界读盘被拒。
+ *   (3) 路径穿越:越界读盘被拒,仓内符号链接可读、指向仓外的被拒。
  *   (4) 入口模式探测:inspectRepo 对 workspace 仓 / 普通仓 / 非 git 目录的判定。
  * 运行:npm run spike:gitbutler [虚拟分支名，默认 feat/dev]
  */
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { run } from '../src/backend/source/exec';
@@ -85,6 +85,16 @@ async function testLive(branch: string) {
   }
 }
 
+/** 读不到必须**抛**(见 Source.getFile 契约):回占位文本的话,取证闸会把一次失败的读当成已取证。 */
+async function rejects(fn: () => Promise<unknown>, why: string): Promise<string> {
+  try {
+    await fn();
+  } catch (e) {
+    return (e as Error).message;
+  }
+  throw new Error(`应当被拒却读成功了: ${why}`);
+}
+
 async function testTraversal() {
   const source = new GitButlerSource({
     source: 'gitbutler-vbranch',
@@ -93,13 +103,41 @@ async function testTraversal() {
   });
   // POSIX 下真实穿越向量:相对 ../ 与绝对路径(反斜杠是合法文件名,不算分隔符)
   for (const p of ['../../../../etc/passwd', '/etc/passwd', 'src/../../../etc/hosts']) {
-    const out = await source.getFile(p);
-    assert.ok(out.startsWith('// 拒绝越界读取'), `应拒绝越界路径: ${p}`);
+    const msg = await rejects(() => source.getFile(p), p);
+    assert.ok(msg.includes('拒绝越界读取'), `应拒绝越界路径: ${p}(实际: ${msg})`);
   }
   // 正常仓内路径不被误伤
   const ok = await source.getFile('package.json');
   assert.ok(ok.includes('duetlens'), '仓内路径应正常读取');
   log('✅ (3) 路径穿越:越界 ../、绝对路径被拒,仓内路径放行');
+}
+
+/**
+ * 符号链接:词法检查看到的是 `<root>/leak`,而 readFile 跟到了仓库外。
+ * 被审仓库是**不可信输入** —— 一条指向 ~/.ssh/id_rsa 的链接就能把私钥送进模型上下文。
+ */
+async function testSymlinkEscape() {
+  const outer = await realpath(await mkdtemp(path.join(tmpdir(), 'duetlens-sym-')));
+  try {
+    const repo = path.join(outer, 'repo');
+    await mkdir(repo, { recursive: true });
+    await writeFile(path.join(outer, 'secret.txt'), 'PRIVATE KEY\n');
+    await writeFile(path.join(repo, 'a.txt'), 'in-repo\n');
+    await symlink('../secret.txt', path.join(repo, 'leak'));
+    // 仓内指向仓内的链接是合法的,不能一刀切禁掉 symlink
+    await symlink('a.txt', path.join(repo, 'alias'));
+
+    const source = new GitButlerSource({ source: 'gitbutler-vbranch', ref: 'x', repoPath: repo });
+    const msg = await rejects(() => source.getFile('leak'), 'leak -> ../secret.txt');
+    assert.ok(msg.includes('拒绝越界读取'), `符号链接越界应被拒(实际: ${msg})`);
+    assert.ok(!msg.includes('PRIVATE'), '拒绝信息里也不能带出目标内容');
+
+    assert.equal(await source.getFile('alias'), 'in-repo\n', '仓内符号链接应照常可读');
+    assert.equal(await source.getFile('a.txt'), 'in-repo\n', '普通文件不受影响');
+    log('✅ (3b) 符号链接:指向仓外被拒,仓内链接与普通文件放行');
+  } finally {
+    await rm(outer, { recursive: true, force: true });
+  }
 }
 
 /** 入口模式探测:本仓(workspace 分支)按虚拟分支审,临时普通仓与非 git 目录都落到 local。 */
@@ -136,6 +174,7 @@ async function testInspect() {
 async function main() {
   testReconstruction();
   await testTraversal();
+  await testSymlinkEscape();
   await testInspect();
   await testLive(process.argv[2] ?? 'feat/dev');
   log('✅ PASS — GitButler source 就位');

--- a/src/backend/source/gitbutler-source.ts
+++ b/src/backend/source/gitbutler-source.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import { butJson } from './but-cli';
 import { gitGrep } from './git-grep';
@@ -47,8 +47,24 @@ export class GitButlerSource implements Source {
   async getFile(p: string): Promise<string> {
     const full = this.resolveInRepo(p);
     if (!full) throw new Error(`拒绝越界读取 ${p}`);
+    // **词法判断拦不住符号链接**:readFile 会跟随它,而被审仓库完全可以提交一条
+    // `leak -> ~/.ssh/id_rsa` —— `<root>/leak` 在词法上就在根内,读回来的却是仓库外的私钥,
+    // 再由取证工具原样送进模型上下文。故解析真实路径后再判一次归属。
+    // 根本身也要 realpath:macOS 的 /tmp 就是 /private/tmp 的链接,不解析会把自家路径判成越界。
+    let realRoot: string;
+    let real: string;
     try {
-      return await readFile(full, 'utf8');
+      realRoot = await realpath(this.target.repoPath);
+      real = await realpath(full);
+    } catch {
+      // 不存在 / 断链 —— 是读不到,不是越界,别把两者说成一回事
+      throw new Error(`无法读取 ${p}`);
+    }
+    if (real !== realRoot && !real.startsWith(realRoot + path.sep)) {
+      throw new Error(`拒绝越界读取 ${p}(符号链接指向仓库外)`);
+    }
+    try {
+      return await readFile(real, 'utf8');
     } catch {
       throw new Error(`无法读取 ${p}`);
     }
@@ -62,7 +78,7 @@ export class GitButlerSource implements Source {
     });
   }
 
-  /** 把相对路径限制在 repoPath 内(防 `../` 穿越读盘);越界返回 null。 */
+  /** 词法上把相对路径限制在 repoPath 内(挡 `../` 与绝对路径);符号链接由 getFile 再判一次。 */
   private resolveInRepo(p: string): string | null {
     const root = path.resolve(this.target.repoPath);
     const full = path.resolve(root, p);


### PR DESCRIPTION
`resolveInRepo` only checked the path lexically, and `readFile` follows symlinks. A reviewed repo carrying `leak -> ~/.ssh/id_rsa` passes `startsWith(root + sep)` as `<root>/leak` and then reads the private key, which the evidence tools hand straight to the model.

Reproduced before fixing:

```
git show HEAD:leak     ->  ../secret.txt    (link text)
readFile(<repo>/leak)  ->  TOP SECRET KEY   (target content)
```

The target is now resolved with `realpath` and re-checked against the real repo root. The root is resolved too, since on macOS `/tmp` is itself a link to `/private/tmp` and comparing unresolved paths would reject the tool's own repo. Links that stay inside the repo keep working, so this does not blanket-ban symlinks.

Failure messages stay distinguishable: an unresolvable or dangling path is "cannot read", only a resolved path outside the root is "refused as out of bounds". Collapsing the two is the same defect the evidence gate exists to avoid.

### Blast radius

`GitButlerSource` is the only source that reads the filesystem:

- `LocalGitSource` uses `git show <ref>:<path>`; a symlink is a blob holding the link text, so it returns `../secret.txt`, not the target.
- `GitHubPrSource` goes through `gh api`.
- `search_code` uses `git grep`, which does not read through symlinks (verified against a target file that does contain the search term).

### Also: the traversal spike has been red since #52

It still asserted on the placeholder string `getFile` returned before #52 changed it to throw, so it has not passed since that PR merged and I did not run it there. It now asserts the throw, and a new case (3b) covers the symlink escape, red-verified by removing the ownership check.

`npm run spike:gitbutler <vbranch>` passes all five sections.