### PR TITLE
style(review): soften the scan coverage label

### DIFF
--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -999,7 +999,7 @@ function RightPanel({
                       <span className="ff-sp" />
                       {scanCoverage && scanCoverage.total > 0 && (
                         <span>
-                          {scanCoverage.covered}/{scanCoverage.total} 改动文件已取证
+                          {scanCoverage.covered}/{scanCoverage.total} 改动文件已读
                         </span>
                       )}
                     </div>

--- a/src/renderer/screens/review/ScanActivity.tsx
+++ b/src/renderer/screens/review/ScanActivity.tsx
@@ -59,7 +59,7 @@ export interface ScanCoverage {
 }
 
 const COVERAGE_TITLE =
-  '本次改动的文件里,agent 已经取证(读过原文或被检索命中)的比例。' +
+  '本次改动的文件里,agent 已经读过(读到原文或被检索命中)的比例。' +
   '这是覆盖面不是完成度 —— 它跑满也不代表扫描结束,agent 还会读改动之外的上下文。';
 
 function Coverage({ covered, total }: ScanCoverage) {
@@ -72,7 +72,7 @@ function Coverage({ covered, total }: ScanCoverage) {
       <b>
         {covered}/{total}
       </b>
-      {' 改动文件已取证'}
+      {' 改动文件已读'}
     </span>
   );
 }


### PR DESCRIPTION
The scan bar read "N/M 改动文件已取证". 取证 is a forensic word, so the
counter looked like the agent was building a case against the code, while
the number only means the agent actually read those files. UI copy now says
"已读" in the scan bar, the empty-findings feed header, and the tooltip.

The evidence gate itself is untouched: the `evidence` set and evidenceKey()
in the MCP server keep their name, since that half is a precise judgement
(a failed read is not evidence, no evidence means no verdict).

Shipped changelog entries keep the old wording.