### PR TITLE
feat(update): flag a downloaded update on the rail settings button

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { Wordmark } from './components/Wordmark';
 import { LogoMark } from './components/LogoMark';
 import { AppRail, type RailScreen } from './components/AppRail';
 import { CompletionToast } from './components/CompletionToast';
+import { useUpdateStatus } from './update/useUpdateStatus';
 import './App.css';
 
 // 屏路由。除 onboarding(全屏引导)外都套同一外壳:整幅顶栏 + 左侧 rail;
@@ -52,6 +53,11 @@ export function App({
   // 与 focusDiscussion 同理带上 reviewId —— ReviewScreen 要等 status 到了才兑现,这段空窗里
   // 若换了 review(rail 走开再从历史/通知开另一条),裸布尔会在别人的 review 上弹出面板。
   const [rerunRequest, setRerunRequest] = useState<{ reviewId: string } | null>(null);
+  // 设置屏的定位请求(目前只有 rail 上那颗更新未读点会发)。与 focusDiscussion 同理兑现一次即消费:
+  // 留着的话,之后每次从别处回设置屏都会被再滚一遍。
+  const [settingsFocus, setSettingsFocus] = useState<{ section: 'about' } | null>(null);
+  const updateStatus = useUpdateStatus();
+  const updateReady = updateStatus.phase === 'ready';
 
   const openReview = (id: string, discussionId?: string) => {
     setActiveReviewId(id);
@@ -99,6 +105,8 @@ export function App({
 
   const onRail = (s: RailScreen) => {
     if (s === 'review' && !activeReviewId) return;
+    // 未读点指向的是「关于」那行的重启按钮,进屏就把它滚到眼前 —— 否则用户只知道有事,不知道在哪
+    if (s === 'settings' && updateReady) setSettingsFocus({ section: 'about' });
     setScreen(s);
   };
 
@@ -116,7 +124,12 @@ export function App({
         </header>
       )}
 
-      <AppRail active={RAIL_OF[screen]} reviewAvailable={activeReviewId !== null} onNavigate={onRail} />
+      <AppRail
+        active={RAIL_OF[screen]}
+        reviewAvailable={activeReviewId !== null}
+        updateReady={updateReady}
+        onNavigate={onRail}
+      />
 
       {screen === 'review' ? (
         /* key = 换 review 即重挂:屏内一切 per-review 本地态(草稿、活跃线程、待恢复原文…)
@@ -149,7 +162,13 @@ export function App({
             <PromptRulesScreen reviewId={activeReviewId} onBack={() => setScreen('entry')} />
           )}
           {screen === 'history' && <HistoryScreen onOpen={openReview} />}
-          {screen === 'settings' && <SettingsScreen onOpenPrompt={() => setScreen('prompt')} />}
+          {screen === 'settings' && (
+            <SettingsScreen
+              onOpenPrompt={() => setScreen('prompt')}
+              focusSection={settingsFocus?.section ?? null}
+              onFocusHandled={() => setSettingsFocus(null)}
+            />
+          )}
         </main>
       )}
 

--- a/src/renderer/components/AppRail.css
+++ b/src/renderer/components/AppRail.css
@@ -58,3 +58,16 @@
 .rail-gap {
   flex: 1;
 }
+
+/* 未读点:图标钮上唯一的状态提示,当前只有「新版已下好待重启」用它。
+   描边取 rail 底色,压在图标角上也不糊。 */
+.rail-dot {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--human);
+  box-shadow: 0 0 0 2px var(--surface);
+}

--- a/src/renderer/components/AppRail.tsx
+++ b/src/renderer/components/AppRail.tsx
@@ -9,18 +9,27 @@ export type RailScreen = 'entry' | 'review' | 'history' | 'prompt' | 'settings';
 export function AppRail({
   active,
   reviewAvailable,
+  updateReady = false,
   onNavigate,
 }: {
   active: RailScreen;
   /** 无活跃 review 时「当前审核」不可达 */
   reviewAvailable: boolean;
+  /** 新版已下好、只差重启 —— 设置钮挂未读点,点进去直接落到「关于」那行 */
+  updateReady?: boolean;
   onNavigate: (s: RailScreen) => void;
 }): React.JSX.Element {
   const { settings, update } = useSettings();
   const mode = settings.dataMode;
   const next = nextDataMode(mode);
 
-  const item = (id: RailScreen, label: string, icon: React.JSX.Element, disabled = false) => (
+  const item = (
+    id: RailScreen,
+    label: string,
+    icon: React.JSX.Element,
+    disabled = false,
+    dot = false,
+  ) => (
     <button
       className={`rail-btn${active === id ? ' on' : ''}`}
       onClick={() => onNavigate(id)}
@@ -30,6 +39,7 @@ export function AppRail({
       aria-current={active === id ? 'page' : undefined}
     >
       {icon}
+      {dot && <span className="rail-dot" aria-hidden="true" />}
     </button>
   );
 
@@ -48,7 +58,13 @@ export function AppRail({
       >
         {mode === 'system' ? <SystemIcon /> : mode === 'dark' ? <MoonIcon /> : <SunIcon />}
       </button>
-      {item('settings', '设置', <GearIcon />)}
+      {item(
+        'settings',
+        updateReady ? '设置 · 新版本已就绪,重启即生效' : '设置',
+        <GearIcon />,
+        false,
+        updateReady,
+      )}
     </nav>
   );
 }

--- a/src/renderer/screens/SettingsScreen.css
+++ b/src/renderer/screens/SettingsScreen.css
@@ -63,6 +63,16 @@
   color: var(--agent-2);
 }
 
+/* 左导航的未读点(目前只有「关于」那节的待重启更新会点亮) */
+.set-link-dot {
+  margin-left: auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--human);
+  flex: none;
+}
+
 /* 右内容 */
 .set-content {
   min-width: 0;

--- a/src/renderer/screens/SettingsScreen.tsx
+++ b/src/renderer/screens/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import { DATA_MODE_LABELS, DEFAULT_UI_SETTINGS, REASONING_EFFORTS, REVIEW_INTENS
 import type { EnvironmentReport } from '@shared/environment';
 import { AUTHOR, PROJECT_LINKS, newIssueUrl } from '@shared/links';
 import { useSettings } from '../settings/SettingsProvider';
+import { useUpdateStatus } from '../update/useUpdateStatus';
 import { KbdHelp } from '../components/KbdHelp';
 import './SettingsScreen.css';
 
@@ -45,7 +46,16 @@ const SOURCE_CHOICES: { v: SourceKind; label: string }[] = [
   { v: 'local-branch', label: '本地仓库' },
 ];
 
-export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): React.JSX.Element {
+export function SettingsScreen({
+  onOpenPrompt,
+  focusSection = null,
+  onFocusHandled,
+}: {
+  onOpenPrompt: () => void;
+  /** 外部(rail 未读点)要求进屏即定位到某节;兑现一次由 onFocusHandled 消费掉。 */
+  focusSection?: SectionId | null;
+  onFocusHandled?: () => void;
+}): React.JSX.Element {
   const { settings, update } = useSettings();
   const [active, setActive] = useState<SectionId>('appearance');
   const [env, setEnv] = useState<EnvironmentReport | null>(null);
@@ -54,6 +64,8 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const updateStatus = useUpdateStatus();
+  const updateReady = updateStatus.phase === 'ready';
 
   const runEnvCheck = useCallback(async () => {
     setCheckingCodex(true);
@@ -98,6 +110,16 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
     setActive(cur);
   };
 
+  // 外部定位请求:不复用 goTo(它随每次 render 重建,进不了依赖表),直接现取 DOM。
+  useEffect(() => {
+    if (!focusSection) return;
+    contentRef.current
+      ?.querySelector<HTMLElement>(`[data-sec="${focusSection}"]`)
+      ?.scrollIntoView({ block: 'start' });
+    setActive(focusSection);
+    onFocusHandled?.();
+  }, [focusSection, onFocusHandled]);
+
   // codex 路径 / gh 路径先落库(即时应用到 exec 解析),再自检,使「检测」反映刚填的路径。
   const detectCodex = async (): Promise<void> => {
     await window.duetlens.ui.saveSettings(settings);
@@ -137,6 +159,7 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
               >
                 <span className="ic">{it.icon}</span>
                 {it.label}
+                {it.id === 'about' && updateReady && <span className="set-link-dot" aria-hidden="true" />}
               </button>
             ))}
           </div>
@@ -349,7 +372,7 @@ export function SettingsScreen({ onOpenPrompt }: { onOpenPrompt: () => void }): 
               </div>
               <span className="lic mono">GPL-3.0</span>
             </div>
-            <UpdateRow />
+            <UpdateRow status={updateStatus} />
             <div className="about-links">
               <LinkOut href={PROJECT_LINKS.repo}>源码仓库</LinkOut>
               <i />
@@ -427,14 +450,7 @@ function LinkOut({ href, children }: { href: string; children: React.ReactNode }
  * 更新状态一行。更新本身是后台下载、退出时静默安装的,所以这里不是升级的必经之路 ——
  * 只让用户看得见进度、并能提前重启。dev / 不支持的渠道整行不渲染。
  */
-function UpdateRow(): React.JSX.Element | null {
-  const [status, setStatus] = useState<UpdateStatus>({ phase: 'idle' });
-
-  useEffect(() => {
-    window.duetlens.update.getStatus().then(setStatus).catch(() => undefined);
-    return window.duetlens.update.onStatus(setStatus);
-  }, []);
-
+function UpdateRow({ status }: { status: UpdateStatus }): React.JSX.Element | null {
   if (status.phase === 'unsupported') return null;
 
   const busy = status.phase === 'checking' || status.phase === 'downloading';

--- a/src/renderer/update/useUpdateStatus.ts
+++ b/src/renderer/update/useUpdateStatus.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import type { UpdateStatus } from '@shared/update';
+
+/**
+ * 订阅自动更新状态。preload 的 onStatus 支持多监听,所以各处各订各的,
+ * 不为此再加一层 context —— 状态本身是 main 单向推的,拿到的快照必然一致。
+ */
+export function useUpdateStatus(): UpdateStatus {
+  const [status, setStatus] = useState<UpdateStatus>({ phase: 'idle' });
+
+  useEffect(() => {
+    let alive = true;
+    window.duetlens.update
+      .getStatus()
+      .then((s) => {
+        // 订阅先于 getStatus 返回:推来的新档不该被这次快照回退
+        if (alive) setStatus(s);
+      })
+      .catch(() => undefined);
+    const off = window.duetlens.update.onStatus((s) => {
+      alive = false;
+      setStatus(s);
+    });
+    return () => {
+      alive = false;
+      off();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -1,8 +1,9 @@
 /**
  * 自动更新的状态机。main 侧 electron-updater 的事件收敛成这几档,renderer 只认这里。
  *
- * 更新默认后台下好、退出时静默装上(autoInstallOnAppQuit),所以 UI 只有一处:
- * 设置屏「关于」的一行 —— 用户不去看也照样能升级,去看则能提前手动重启。
+ * 更新默认后台下好、退出时静默装上(autoInstallOnAppQuit),所以 UI 不拦路:
+ * 只在 ready 档给 rail 设置钮点一颗未读点(点进去直落设置屏「关于」那行),
+ * 用户不理它也照样能升级,理它则能提前手动重启。
  */
 export type UpdateStatus =
   /** 打包外(dev)或渠道不可用 —— 不做检查,UI 隐藏整行 */


### PR DESCRIPTION
An update downloaded in the background was only visible on the settings screen, so there was nothing telling the user a restart would upgrade them.

- The rail settings button now carries an unread dot while the update status is `ready`, and its tooltip says the new version is waiting for a restart.
- Navigating to settings from that button scrolls straight to the About section and marks the matching nav item, so the restart button is in view.
- Only the `ready` phase lights up. Nothing is actionable while downloading or on error.

Checked in preview:ui in both light and dark: dot present with `?upd=ready`, absent with `?upd=current`, and the deep link lands on the update row (also when already on the settings screen). typecheck and lint pass.