### PR TITLE
fix(entry): make in-flight states visible and settle the base picker layout

### DIFF
--- a/src/backend/source/source-discovery.ts
+++ b/src/backend/source/source-discovery.ts
@@ -79,19 +79,17 @@ const PR_CHAIN_DEPTH = 8;
  * 而不必自己记住 pr1 的分支叫什么。
  *
  * 每层一次 `gh` 调用,故封了深度;`seen` 兼防分支互为 base 时成环。
- * 中途出错就把已经摸到的那几层返回:链短一点仍然可用,报错反而把默认那档也一起没收了。
+ *
+ * **第一层与后续层对失败的处理刻意不同**:摸到一半失败就把已有的几层返回(链短一点仍然可用,
+ * 报错反而把默认那档也一起没收);但**第一层失败必须抛** —— 有效 PR 一定有 base,空链只可能是
+ * 探测本身没成,咽下去会让一次限流/断网伪装成「这个 PR 不是 stacked」,界面连重试的口子都不给。
  */
 export async function prBaseChain(ref: string, repoPath?: string): Promise<PrAncestor[]> {
   const parsed = parsePrRef(ref);
   const nwo = parsed.nwo || (await deriveNwo(repoPath));
   const chain: PrAncestor[] = [];
   const seen = new Set<string>();
-  let cursor: string;
-  try {
-    cursor = await prBaseRef(nwo, parsed.num);
-  } catch {
-    return [];
-  }
+  let cursor = await prBaseRef(nwo, parsed.num);
   const defaultBranch = await repoDefaultBranch(nwo);
 
   for (let i = 0; i < PR_CHAIN_DEPTH && cursor && !seen.has(cursor); i++) {

--- a/src/renderer/screens/EntryScreen.css
+++ b/src/renderer/screens/EntryScreen.css
@@ -141,7 +141,6 @@
   outline: none;
 }
 .ghfield input::placeholder { color: var(--text-faint); font-family: var(--sans); }
-.fld-spin { font-size: 10.5px; color: var(--text-faint); }
 
 .pr-resolved {
   margin-top: 12px;
@@ -236,7 +235,6 @@
   flex: none;
 }
 .pf-tag.warn { color: var(--human); border-color: var(--human-line); background: var(--human-soft); }
-.pf-tag.muted { color: var(--text-faint); border-color: var(--border); background: transparent; }
 .path-warn {
   margin-top: 8px; /* = --derived-gap */
   --derived-gap: 8px;
@@ -402,7 +400,9 @@
 }
 
 /* 审核分支下拉:触发器 + 浮层列表 + 选中摘要 */
-.picker-row { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+/* 选择器那一格的行高。占位行要与真选择器等高才能原地替换、不推屏,
+   故两处共用这一个值,别各写各的 40px。 */
+.picker-row { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; --pick-h: 40px; }
 .picker-row .lbl { font-size: 11.5px; color: var(--text-faint); }
 
 /* 「对比 base」与「审核分支」同构,故并排两行:标签定宽,两个下拉左沿才对得齐 */
@@ -413,6 +413,93 @@
 .basemetric .a { color: var(--add); }
 .basemetric .d { color: var(--del); }
 
+/* 入口屏统一的在途状态位(见 entry/Busy.tsx)。原先六处各画各的灰色小字,
+   共同的毛病是不动、不亮、字号比正文小一档 —— 三样凑齐就等于没画。 */
+.busy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* 作为 flex 子项时不许被压:压扁的那半句话比不显示更像故障 */
+  flex: none;
+  font-size: 11.5px;
+  color: var(--agent-2);
+  white-space: nowrap;
+}
+.busy .busy-ring {
+  width: 10px;
+  height: 10px;
+  flex: none;
+  border-radius: 50%;
+  border: 1.5px solid var(--agent-line);
+  border-top-color: var(--agent-2);
+  animation: busy-spin 0.75s linear infinite;
+}
+@keyframes busy-spin { to { transform: rotate(360deg); } }
+/* 放慢而不是停掉:转圈是这里唯一的在途信号,停了就与「卡住了」不可分 */
+@media (prefers-reduced-motion: reduce) {
+  .busy .busy-ring { animation-duration: 2.4s; }
+}
+
+/* base 候选还没到手时占住选择器那一格:边框/高度与 .bp-trig 对齐,
+   候选一到就原地换成真选择器,不推屏 */
+.baseprobe {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: 1;
+  min-width: 260px;
+  min-height: var(--pick-h);
+  padding: 8px 11px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: var(--surface-2);
+  font-size: 13px;
+}
+.baseprobe.err { border-style: solid; border-color: var(--del-gutter); background: var(--del-bg); }
+.baseprobe .bpr-ic { color: var(--sev-high); flex: none; font-weight: 600; }
+.baseprobe .bpr-txt { font-size: 11.5px; color: var(--sev-high); }
+.baseprobe .bpr-retry {
+  margin-left: auto;
+  flex: none;
+  border: 1px solid var(--border);
+  background: var(--surface-3);
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.baseprobe .bpr-retry:hover { color: var(--agent-2); border-color: var(--agent-line); }
+
+/* base 设置区:选择器 + stack 链路条 + 口径提示合成一个块。
+   `.tucked` = github 侧,整区缩到 PR 卡片那一层(base 是那个 PR 的属性),
+   只由容器挂一次 .derived 的连接线,区内子块不再各画各的。 */
+.base-block { margin-top: 10px; }
+/* 本地侧两个子块都不满足条件时容器为空:留着它就是 10px 的死白 */
+.base-block:empty { display: none; }
+.base-block.tucked { --derived-gap: 10px; }
+.base-block.tucked > .derived { margin-left: 0; }
+.base-block.tucked > .derived::before { display: none; }
+/* 区内首块紧贴容器上沿:间距由容器统一给,免得两处各加一次 */
+.base-block > :first-child { margin-top: 0; }
+
+/* 探测占位专用的收起过渡:非 stacked PR 是最常见的一支,结论一到就硬撤这一行,
+   下面的东西会凭空上跳 50px,读起来像故障而不像「查完了」。
+   `overflow: hidden` 只敢挂在这里 —— 真选择器那一区挂上会把浮层裁没。 */
+.base-block.probe {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 200ms ease, opacity 180ms ease, margin-top 200ms ease;
+}
+.base-block.probe > * { min-height: 0; overflow: hidden; }
+.base-block.probe.gone { grid-template-rows: 0fr; opacity: 0; margin-top: 0; }
+/* 收起后别让看不见的转圈继续跑 */
+.base-block.probe.gone .busy-ring { animation: none; }
+@media (prefers-reduced-motion: reduce) {
+  .base-block.probe { transition: none; }
+}
+
 /* base 选项行右侧的范围标签:说的是「选它会把谁算进来」,故按 agent 档着色区别于中性的 ← base */
 .bp-row .cmp.scope { color: var(--agent-2); background: var(--agent-soft); border-color: var(--agent-line); }
 
@@ -422,8 +509,6 @@
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
-  overflow-x: auto;
-  scrollbar-width: thin;
   margin-top: 9px;
   --derived-gap: 9px;
   padding: 8px 11px;
@@ -432,6 +517,26 @@
   border-radius: 9px;
 }
 .stackbar .sb-lbl { font-size: 10.5px; color: var(--text-faint); margin-right: 9px; flex: none; }
+/* 只有链路滚动:`sb-tail` 留在滚动区外,深 stack 下「审核范围 N 层」才不会被推出可视区
+   —— 它是这条链的结论,不该要横向拖动才看得见 */
+.stackbar .sb-scroll {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  /* 撑满剩余宽度而不是收到内容宽:右缘的渐隐才只在真溢出时落在节点上 ——
+     收到内容宽的话,链路没超长时最后一层也会被这层渐隐吃掉一角。 */
+  flex: 1 1 auto;
+  min-width: 0;
+  /* 溢出时把切口渐隐成「还有,可横向滚」,而不是齐根截断的渲染事故相。
+     尾部留同宽的 padding:滚到底时它正好垫在渐隐区下面,最后那个节点(= 被审的那条)
+     才不会在「已经没得滚了」的时候还被遮掉半截 —— 渐隐说的是「右边还有」,滚到头就不该再说。
+     两个值必须同宽,故共用 --sb-fade。 */
+  --sb-fade: 18px;
+  padding-right: var(--sb-fade);
+  mask-image: linear-gradient(to right, #000 calc(100% - var(--sb-fade)), transparent);
+}
 .stackbar .sb-part { display: flex; align-items: center; flex: none; }
 .stackbar .sb-node {
   font-size: 11.5px;
@@ -450,7 +555,7 @@
 .stackbar .sb-node.basenode { color: var(--text); border-style: dashed; border-color: var(--text-deco); }
 .stackbar .sb-seg { width: 18px; height: 1px; background: var(--border); flex: none; }
 .stackbar .sb-seg.in { background: var(--agent-line); height: 2px; }
-.stackbar .sb-tail { margin-left: auto; padding-left: 10px; font-size: 11px; color: var(--text-faint); white-space: nowrap; }
+.stackbar .sb-tail { padding-left: 10px; font-size: 11px; color: var(--text-faint); white-space: nowrap; flex: none; }
 .stackbar .sb-tail b { color: var(--text-dim); font-weight: 600; }
 
 /* 宽 base 的提交口径提示:说的是「这次审的比这个 PR 大」,属于人这一侧要做的取舍,故走 human 档 */
@@ -477,6 +582,7 @@
   align-items: center;
   gap: 9px;
   width: 100%;
+  min-height: var(--pick-h);
   padding: 8px 11px;
   border-radius: 10px;
   border: 1px solid var(--border);

--- a/src/renderer/screens/EntryScreen.tsx
+++ b/src/renderer/screens/EntryScreen.tsx
@@ -21,8 +21,16 @@ import type {
   VbranchSummary,
 } from '@shared/source-discovery';
 import { useSettings } from '../settings/SettingsProvider';
-import { BaseRow, StackLadder, useDiffStat, type BaseOption } from './entry/BasePicker';
+import {
+  BaseProbeRow,
+  BaseRow,
+  BaseSection,
+  StackLadder,
+  useDiffStat,
+  type BaseOption,
+} from './entry/BasePicker';
 import { BranchPicker, BranchSummary, type BranchOption } from './entry/BranchPicker';
+import { Busy } from './entry/Busy';
 import { GhIcon, LocalBranchIcon } from './entry/icons';
 import { baseName, parentDir } from './entry/paths';
 import { RepoSwitch } from './entry/RepoSwitch';
@@ -566,7 +574,9 @@ function GitHubPanel({
   // open PR 列表默认折叠:已贴 PR 链接时目标已确定,展开会把开始按钮挤出视野
   const [browseOpen, setBrowseOpen] = useState(false);
   // 祖先 PR 链(stacked PR 的形状);连同它是为哪个 PR 拉的一起存,换 PR 后旧链立即作废
-  const [chain, setChain] = useState<{ key: string; value: PrAncestor[] } | null>(null);
+  const [chain, setChain] = useState<{ key: string; value: ChainState } | null>(null);
+  // 摸链失败后重来一次的闸;链是纯读取,重试无副作用
+  const [chainTry, setChainTry] = useState(0);
 
   const recheckAuth = () => {
     setGhAuth(null);
@@ -621,23 +631,37 @@ function GitHubPanel({
   // 当前已解析出的目标 PR;祖先链、base、改动面计量都以它为准
   const prKey = preview ? `${preview.nwo}#${preview.number}` : '';
 
-  // 解析出 PR 后摸一次祖先链:stacked 时它就是 base 候选,非 stacked 时只有一环(= PR 自己的 base)
+  // 解析出 PR 后摸一次祖先链:stacked 时它就是 base 候选,非 stacked 时只有一环(= PR 自己的 base)。
+  // **每层一次 gh 调用,现实里要几秒** —— 这段的可见反馈见 BaseProbeRow。
+  //
+  // **只认 prKey,不吃 preview 与 repoPath**:链只取决于是哪个 PR。prKey 自带 owner/repo,
+  // 所以 prBaseChain 那个 repoPath 兜底参数在这条路径上永远用不上;而改本地路径会重跑
+  // previewPr、换出一个新的 preview 对象,把这两样留在依赖里就会为同一个 PR 反复重摸 ——
+  // 白烧几次 gh 是小事,要命的是重摸期间候选表是空的:选择器与宽范围警告双双消失,
+  // 用户手上那条 base 却还在生效,于是可以发起一次自己看不见的宽审核。
   useEffect(() => {
-    if (!preview) {
+    if (!prKey) {
       setChain(null);
       return;
     }
     let alive = true;
+    setChain(null);
     window.duetlens.source
-      .prBaseChain(prKey, repoPath.trim() || undefined)
-      .then((v) => alive && setChain({ key: prKey, value: v }))
-      .catch(() => alive && setChain(null));
+      .prBaseChain(prKey)
+      .then((v) => alive && setChain({ key: prKey, value: { state: 'value', value: v } }))
+      .catch(
+        (e: Error) =>
+          alive && setChain({ key: prKey, value: { state: 'error', message: e.message ?? String(e) } }),
+      );
     return () => {
       alive = false;
     };
-  }, [preview, prKey, repoPath]);
+  }, [prKey, chainTry]);
 
-  const ancestors = chain?.key === prKey ? chain.value : [];
+  // 探测中与探测失败必须可分:都落回「没有候选」的话,一次拉不动的链会静悄悄地
+  // 表现成「这个 PR 不是 stacked」,而用户本可以重贴一次或去查 gh。
+  const chainState: ChainState = chain?.key === prKey ? chain.value : PROBING;
+  const ancestors = chainState.state === 'value' ? chainState.value : [];
   const baseOptions = useMemo<BaseOption[]>(
     () => prBaseOptions(ancestors, preview?.number ?? 0),
     [ancestors, preview],
@@ -645,21 +669,45 @@ function GitHubPanel({
   // **base 属于某一个具体的 PR,目标一变就清** —— 不能改判成「不在候选里才清」:
   // 祖先链是异步的,在它到手前(或它压根拉失败时)候选是空的,那种判法一条都清不掉,
   // 旧 base 会跟着新 PR 一路发起。清空即回到「跟随该 PR 自己的 base」,是安全的那一侧。
+  // 手上这条 baseRef 是为哪个 prKey 选的。只在选择事件里写(不在 render 期写),故 render 期读安全。
+  const baseOwner = useRef('');
   const lastPrKey = useRef(prKey);
   useEffect(() => {
     if (lastPrKey.current === prKey) return;
     lastPrKey.current = prKey;
+    baseOwner.current = '';
     setBaseRef('');
   }, [prKey, setBaseRef]);
 
+  // 链一落定就用它校验手上这条 base:候选里没有它(探测失败 / 链变短了)就清掉。
+  // **不能连 probing 一起判** —— 那会让每次改本地路径都白白吞掉用户选好的 base;
+  // 而落定后候选是空的,界面上已经既不显示这条 base、也不出宽范围警告了,
+  // 再拿它发起就是「说的和做的不一样」(错误行写的是「先按该 PR 自己的 base 审」)。
+  useEffect(() => {
+    if (chainState.state === 'probing' || !baseRef) return;
+    if (baseOptions.some((o) => o.ref === baseRef)) return;
+    baseOwner.current = '';
+    setBaseRef('');
+  }, [chainState.state, baseOptions, baseRef, setBaseRef]);
+
   const prLadder = prLadderNodes(ancestors, preview?.number ?? 0);
   const prBaseIndex = Math.max(0, prLadder.indexOf(ladderLabel(ancestors, baseRef || ancestors[0]?.ref)));
+  // **不等祖先链**:默认档的计量与链无关(PR 自己的 base 就是默认档),而链要串几次 gh。
+  // 串着发会让「链回来」和「数回来」排成两段等待;并行发出后,链一到手数往往已经在了。
+  // 代价是非 stacked PR 也会白算一次 —— github source 不落地(prepare + getDiff 两次 gh、无 clone),
+  // 换掉一整段可见的空白等待值这个价。
+  // 目标刚换、旧 base 还没清掉的那一帧,别拿上一个 PR 的 base 去问新 PR 的 compare:
+  // 清理走 effect(commit 后才生效),而计量的 effect 就在同一轮 flush 里、闭包里捏的还是旧值,
+  // 请求发出去就撤不回来了。**只能在 render 期派生**。
+  // 判据是「这条 base 是为哪个 PR 选的」,不是「它在不在新 PR 的候选表里」——
+  // 两个 PR 的候选里撞上同名 ref 是常事(stack 换条线重开就会),按候选表判会把旧 base 放过去。
+  const statBase = baseOwner.current === prKey ? baseRef : '';
   const stat = useDiffStat({
     source: 'github-pr',
     ref: prKey,
     repoPath: repoPath.trim(),
-    baseRef,
-    enabled: !!preview && baseOptions.length > 1,
+    baseRef: statBase,
+    enabled: !!preview,
   });
 
   // 指定本地仓库后:取 remote 归属(用于匹配校验 + 作为 open PR 列表的来源)
@@ -758,7 +806,7 @@ function GitHubPanel({
           onChange={(e) => setPrRef(e.target.value)}
           placeholder="粘贴 PR 链接 · 或 owner/repo#123"
         />
-        {previewing && <span className="fld-spin mono">解析…</span>}
+        {previewing && <Busy>解析 PR…</Busy>}
       </div>
 
       {preview && (
@@ -793,9 +841,28 @@ function GitHubPanel({
         </div>
       )}
 
+      {/* 摸链期间就把这一区摆出来:摸出多个候选就原地换成选择器(两者等高,不推屏);
+          非 stacked 则收起 —— 那时 PR 卡片的「← base」已经把话说全了。
+          **收起要过渡,不能直接撤**:多数 PR 走的正是这一支,硬撤会让下面凭空上跳一行。 */}
+      {preview && !(chainState.state === 'value' && baseOptions.length > 1) && (
+        <BaseSection tucked collapsed={chainState.state === 'value'}>
+          <BaseProbeRow
+            error={chainState.state === 'error' ? chainState.message : undefined}
+            onRetry={() => setChainTry((n) => n + 1)}
+          />
+        </BaseSection>
+      )}
       {baseOptions.length > 1 && (
-        <>
-          <BaseRow options={baseOptions} value={baseRef} onChange={setBaseRef} stat={stat} />
+        <BaseSection tucked>
+          <BaseRow
+            options={baseOptions}
+            value={baseRef}
+            onChange={(ref) => {
+              baseOwner.current = prKey;
+              setBaseRef(ref);
+            }}
+            stat={stat}
+          />
           <StackLadder nodes={prLadder} baseIndex={prBaseIndex} />
           {baseRef && (
             <div className="scopewarn derived">
@@ -807,7 +874,7 @@ function GitHubPanel({
               </div>
             </div>
           )}
-        </>
+        </BaseSection>
       )}
 
       <label className={mismatch ? 'pathfield warn' : 'pathfield'}>
@@ -821,7 +888,7 @@ function GitHubPanel({
         <button type="button" className="pf-pick" onClick={pickDir} disabled={busy}>
           选择…
         </button>
-        {inferring && !repoPath.trim() && <span className="pf-tag muted mono">查找本地…</span>}
+        {inferring && !repoPath.trim() && <Busy>查找本地 clone…</Busy>}
         {repoPath.trim() && remoteNwo && (
           <span className={mismatch ? 'pf-tag warn' : 'pf-tag'}>
             {mismatch ? 'remote 不匹配 ⚠' : inferred ? '自动匹配 ✓' : '已匹配 ✓'}
@@ -853,7 +920,11 @@ function GitHubPanel({
           </button>
           {browseOpen && (
             <div className="prbox">
-              {openPrs === null && <div className="list-loading mono">列举 open PR…</div>}
+              {openPrs === null && (
+                <div className="list-loading">
+                  <Busy>列举 open PR…</Busy>
+                </div>
+              )}
               {openPrs?.length === 0 && <div className="list-empty">该仓库没有 open PR。</div>}
               {openPrs && openPrs.length > 0 && (
                 <div className="prlist">
@@ -1069,7 +1140,11 @@ function RepoPanel({
         )}
       </div>
 
-      {!insp && <div className="list-loading mono derived">探测仓库…</div>}
+      {!insp && (
+        <div className="list-loading derived">
+          <Busy>探测仓库形态…</Busy>
+        </div>
+      )}
 
       {insp && !insp.isGit && (
         <div className="gb-hint warn derived">
@@ -1119,20 +1194,22 @@ function RepoPanel({
               }
             />
           </div>
-          {!pending && !!selected && baseOptions.length > 0 && (
-            <BaseRow options={baseOptions} value={baseRef} onChange={setBaseRef} stat={stat} />
-          )}
-          {mode === 'gitbutler' && (
-            <StackLadder
-              nodes={stackNodes(gbBranches ?? [], insp?.gitbutler?.targetRef ?? null, selected)}
-              baseIndex={stackBaseIndex(
-                gbBranches ?? [],
-                insp?.gitbutler?.targetRef ?? null,
-                selected,
-                baseRef || baseOptions.find((o) => o.isDefault)?.ref || '',
-              )}
-            />
-          )}
+          <BaseSection>
+            {!pending && !!selected && baseOptions.length > 0 && (
+              <BaseRow options={baseOptions} value={baseRef} onChange={setBaseRef} stat={stat} />
+            )}
+            {mode === 'gitbutler' && (
+              <StackLadder
+                nodes={stackNodes(gbBranches ?? [], insp?.gitbutler?.targetRef ?? null, selected)}
+                baseIndex={stackBaseIndex(
+                  gbBranches ?? [],
+                  insp?.gitbutler?.targetRef ?? null,
+                  selected,
+                  baseRef || baseOptions.find((o) => o.isDefault)?.ref || '',
+                )}
+              />
+            )}
+          </BaseSection>
           {current && <BranchSummary option={current} base={listing ? effectiveBase : undefined} />}
           {err && <div className="start-error derived">{err}</div>}
         </>
@@ -1140,6 +1217,14 @@ function RepoPanel({
     </div>
   );
 }
+
+/** 祖先链的三态。**探测中与探测失败不能并成一档** —— 见 chainState 处的说明。 */
+type ChainState =
+  | { state: 'probing' }
+  | { state: 'value'; value: PrAncestor[] }
+  | { state: 'error'; message: string };
+
+const PROBING: ChainState = { state: 'probing' };
 
 /**
  * stacked PR 的 base 候选:祖先链的每一环。`[0]` 是 PR 自己的 base,即默认基线。

--- a/src/renderer/screens/entry/BasePicker.tsx
+++ b/src/renderer/screens/entry/BasePicker.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { SourceKind } from '@shared/domain';
 import type { DiffStat } from '@shared/source-discovery';
 import { BranchPicker, type BranchOption } from './BranchPicker';
+import { Busy } from './Busy';
 
 /**
  * 一个可选的 diff 基线。`ref` 是落库与传给 git 的原值,`scope` 说的是「选它会把谁算进来」——
@@ -72,13 +73,74 @@ function DiffMetric({ stat }: { stat: DiffStatState }) {
       </span>
     );
   }
-  if (stat.state === 'loading') return <span className="basemetric mono">计量中…</span>;
+  if (stat.state === 'loading') return <Busy>计量中…</Busy>;
   return (
     <span className="basemetric mono">
       {stat.value.files} files · <span className="a">+{stat.value.additions}</span>{' '}
       <span className="d">−{stat.value.deletions}</span>
     </span>
   );
+}
+
+/**
+ * base 候选还没摸出来(或摸失败)时,占住选择器自己那一格。
+ *
+ * **状态必须落在选择器将要出现的位置**,而不是上游结果块里的一枚小字 —— 这段等待要好几秒,
+ * 而人的眼睛在「答案会出现的地方」;放到别处,再动的点也等于没有。
+ * 高度与真实那行一致,摸出多个候选后原地换成选择器,不推屏。
+ */
+export function BaseProbeRow({ error, onRetry }: { error?: string; onRetry?: () => void }) {
+  return (
+    <div className="picker-row base-row">
+      <span className="lbl w">对比 base</span>
+      <div className={error ? 'baseprobe err' : 'baseprobe'}>
+        {error ? (
+          <>
+            <span className="bpr-ic">!</span>
+            <span className="bpr-txt" title={error}>
+              base 候选探测失败 · 先按该 PR 自己的 base 审
+            </span>
+            {onRetry && (
+              <button type="button" className="bpr-retry" onClick={onRetry}>
+                重试
+              </button>
+            )}
+          </>
+        ) : (
+          <Busy>正在探测 Stacked PR…</Busy>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * base 设置区:选择器 + stack 链路条 + 调用方追加的后果提示。
+ *
+ * 三块是同一件事的三层展开(选谁 / 选出来是什么形状 / 选宽了要付什么代价),故合成一个块归组 ——
+ * 各自挂 `.derived` 会画出三条平行虚线,读起来像三条不相干的信息。
+ *
+ * `tucked` 说的是这一区挂在谁下面:github 侧 base 是**某一个具体 PR 的属性**(换 PR 就得清),
+ * 于是整区缩进到 PR 卡片那一层、只在容器上画一次连接线;本地侧 base 与「审核分支」是定宽标签
+ * 对齐的并排两行,回到主层级,线仍由区内的 stack 条自己挂。
+ */
+export function BaseSection({
+  tucked,
+  collapsed,
+  children,
+}: {
+  tucked?: boolean;
+  /**
+   * 收起(高度过渡到 0)。**只给探测占位用** —— 收起靠 `overflow: hidden`,
+   * 真选择器那一区挂上就会把 BranchPicker 的浮层裁没。
+   */
+  collapsed?: boolean;
+  children: ReactNode;
+}) {
+  const cls = ['base-block', tucked && 'tucked derived', collapsed !== undefined && 'probe', collapsed && 'gone']
+    .filter(Boolean)
+    .join(' ');
+  return <div className={cls}>{children}</div>;
 }
 
 /**
@@ -92,12 +154,15 @@ export function StackLadder({ nodes, baseIndex }: { nodes: string[]; baseIndex: 
   return (
     <div className="stackbar derived">
       <span className="sb-lbl mono">stack</span>
-      {nodes.map((n, i) => (
-        <span key={n} className="sb-part">
-          {i > 0 && <span className={i > baseIndex ? 'sb-seg in' : 'sb-seg'} />}
-          <span className={`sb-node mono${nodeClass(i, baseIndex, nodes.length)}`}>{n}</span>
-        </span>
-      ))}
+      {/* 只有链路本身滚动:层数是这条链的结论,跟着节点滚出可视区就得靠横向拖动才看得见 */}
+      <div className="sb-scroll">
+        {nodes.map((n, i) => (
+          <span key={n} className="sb-part">
+            {i > 0 && <span className={i > baseIndex ? 'sb-seg in' : 'sb-seg'} />}
+            <span className={`sb-node mono${nodeClass(i, baseIndex, nodes.length)}`}>{n}</span>
+          </span>
+        ))}
+      </div>
       <span className="sb-tail">
         审核范围 <b>{nodes.length - 1 - baseIndex}</b> 层
       </span>

--- a/src/renderer/screens/entry/BranchPicker.tsx
+++ b/src/renderer/screens/entry/BranchPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { imeComposing } from '../../keys';
+import { Busy } from './Busy';
 import { GitButlerIcon, LocalBranchIcon } from './icons';
 
 /** 一个可审核目标(普通 git 分支或 GitButler 虚拟分支)在选择器里的展示形态。 */
@@ -165,7 +166,9 @@ export function BranchPicker({
             {selected.badge && <span className="headtag mono">{selected.badge}</span>}
           </>
         ) : (
-          <span className="bp-placeholder">{loading ? '列举分支…' : emptyHint}</span>
+          <span className="bp-placeholder">
+            {loading ? <Busy>列举分支…</Busy> : emptyHint}
+          </span>
         )}
         <span className="chev" />
       </button>

--- a/src/renderer/screens/entry/Busy.tsx
+++ b/src/renderer/screens/entry/Busy.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+/**
+ * 入口屏统一的「在途」状态位:转圈 + 一句话。
+ *
+ * 入口屏一次交互里能同时有好几段等待(解析 PR、探测仓库、列举分支、摸 base 候选、算改动面),
+ * 各自画一份的结果是各自都画成了灰色小字 —— **不动、不亮、不占地方的东西等于没画**。
+ * 收成一处:走 agent 档配色(这几段都是「系统在替你查」)、带转圈、字号跟得上正文。
+ *
+ * 降低动效偏好下**放慢而不是停掉** —— 转圈是这里唯一的在途信号,停了就只剩一句静止的话,
+ * 与「卡住了」不可分。
+ */
+export function Busy({ children }: { children: ReactNode }) {
+  return (
+    <span className="busy">
+      <i className="busy-ring" />
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
The entry screen had six in-flight states, each drawn its own way, all of
them faint grey text with no motion. Fold them into one Busy indicator
(agent-coloured ring plus a line of text) used by every one of them.

- move the ancestor-chain probe out of the PR card and into the base picker
  slot itself: a caption inside a dense metadata line is where a multi-second
  wait goes unnoticed. The placeholder matches the real row height, so the
  swap to the picker does not push the page
- collapse the placeholder with a transition when the PR turns out not to be
  stacked, instead of dropping the row and jumping the page 50px
- key the chain probe on the PR identity alone. It carries owner/repo, so the
  repoPath fallback never applied, and re-probing on every path edit blanked
  the candidate list for seconds: picker and scope warning both vanished while
  the chosen base stayed in effect, letting a review start on a wide base the
  screen was no longer showing
- raise a first-layer chain failure instead of returning an empty chain: a
  valid PR always has a base, so an empty chain only ever meant the probe
  itself failed, and swallowing it disguised rate limits as not stacked
- clear the chosen base once the chain settles without it among the
  candidates, so a failed probe cannot start a review on a wider base than
  the screen is showing
- keep the previous PR's base out of the diff stat on the frame the target
  changes, keyed on which PR the base was chosen for
- group the base row, stack ladder and scope warning into one block tucked
  under the PR card: the base area sat flush against the card and its left
  edge zig-zagged between two indent levels
- start the diff stat without waiting for the chain, so the metric is usually
  ready by the time the base row appears
- keep the review-scope count out of the stack ladder scroller, and pad the
  scroll tail so the fade never covers the last node once scrolled to the end