### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -4,6 +4,28 @@ Only **user-visible** changes are recorded here. Internal refactors, docs and CI
 listed — read `git log` for those. Versions follow [Semantic Versioning](https://semver.org/);
 while on `0.x`, the minor position doubles as the breaking-change position.
 
+## [0.7.1] - 2026-08-21
+
+### Fixed
+
+- **Launching from the Dock or Spotlight no longer drops half the environment codex needs.** launchd
+  hands the app an almost empty environment, and only `PATH` was being recovered; everything else was
+  thrown away. A custom codex `model_providers` entry with `env_key`, a plain `OPENAI_API_KEY`, proxy
+  variables — none of them were visible in a GUI launch, so a review died immediately with "missing
+  environment variable X" while the very same config worked fine with the codex CLI in a terminal,
+  which made the failure almost impossible to self-diagnose. The same login-shell probe now brings back
+  the full environment: `PATH` keeps its existing merge and fallback-directory logic, and every other
+  variable is backfilled only when the process does not already have that key, so anything launchd or
+  the command line passed in still wins. Switches that would change how this process runs
+  (`ELECTRON_RUN_AS_NODE`, `NODE_OPTIONS` and friends) and the app's own startup switches
+  (`DUETLENS_USER_DATA`) are never adopted. The probe result stays in memory only: never logged, never
+  stored, never sent over IPC. (#70)
+
+### Upgrade notes
+
+- The database schema is unchanged at v21; 0.7.0 and 0.7.1 can be installed in any direction.
+- The update arrives through the in-app updater; there is no need to download the dmg again.
+
 ## [0.7.0] - 2026-08-20
 
 ### Added
@@ -357,6 +379,7 @@ while on `0.x`, the minor position doubles as the breaking-change position.
 
 First public release.
 
+[0.7.1]: https://github.com/xieziyu/duetlens/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/xieziyu/duetlens/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/xieziyu/duetlens/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/xieziyu/duetlens/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 本文件只记**对使用者可见**的变化。内部重构、文档与 CI 调整不单列,查 `git log`。
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/);`0.x` 阶段 minor 位即破坏性变更位。
 
+## [0.7.1] - 2026-08-21
+
+### 修复
+
+- **从 Dock / Spotlight 启动时,codex 需要的环境变量不再丢一半。** launchd 给的环境近乎是空的,此前只补回了 `PATH`,其余变量一律丢掉:codex 配置里带 `env_key` 的自定义 `model_providers`、裸的 `OPENAI_API_KEY`、代理变量,在图形启动下全都读不到,评审一开跑就死在「missing environment variable X」;而同一份配置在终端里跑 codex CLI 一切正常,这个差异几乎无法自查。现在同一次登录 shell 探测会把整份环境带回来,`PATH` 保持原有的合并与兜底目录逻辑,其余变量只在当前进程没有该键时补上 —— launchd 或命令行传进来的仍然优先。会改变本进程行为的开关(`ELECTRON_RUN_AS_NODE`、`NODE_OPTIONS` 等)与本应用自己的启动开关(`DUETLENS_USER_DATA`)不会被采纳。探测结果只留在内存里:不写日志、不落库、不过 IPC。(#70)
+
+### 升级须知
+
+- 数据库结构不变,仍是 v21,与 0.7.0 之间可以来回安装。
+- 更新由应用内 updater 接手,无需重新下载 dmg。
+
 ## [0.7.0] - 2026-08-20
 
 ### 新增
@@ -148,6 +159,7 @@
 
 首个公开版本。
 
+[0.7.1]: https://github.com/xieziyu/duetlens/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/xieziyu/duetlens/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/xieziyu/duetlens/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/xieziyu/duetlens/compare/v0.4.0...v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duetlens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
发布 0.7.1,一条修复。

- 从 Dock / Spotlight 启动时,登录 shell 探测现在把整份环境带回来,而不是只带 `PATH`;codex 的 `env_key` / `OPENAI_API_KEY` / 代理变量不再在图形启动下消失(#70)。
- 数据库结构不变,仍是 v21,与 0.7.0 可以来回安装。

本地闸门:typecheck、lint、release-notes 抽取(0.7.1 中英两节均通过,9.9.9 非零退出)、`npm run package` 出包,版本号 / `APP_VERSION` / adhoc 签名三项已核,冒烟启动存活。