### PR TITLE
fix(codex): negotiate a granular read-only approval policy

### DIFF
--- a/docs/design/codex-integration.md
+++ b/docs/design/codex-integration.md
@@ -2,7 +2,7 @@
 
 > 返回 [文档索引](../README.md)
 >
-> 审核 agent 完全建立在 codex-cli 的 `app-server` 之上。下列是**实测结论**(2026-07-18 在 0.144.5 字节级验证,2026-07-20 在 0.144.1 端到端复跑并修正),不是文档臆测。协议随版本演进,升级后重新导出比对。
+> 审核 agent 完全建立在 codex-cli 的 `app-server` 之上。下列是**实测结论**(0.144.x 字节级验证,0.149.1 端到端复跑并修正),不是文档臆测。协议随版本演进,升级后重新导出比对。
 
 ## 关键假设验证
 
@@ -15,6 +15,8 @@
 | token 膨胀有治理原语 | ✅ 内置 auto-compact + `thread/tokenUsage/updated` |
 
 **版本稳定性**:`generate-ts` 全量导出在 **0.144.1 → 0.144.6 逐字节完全一致**(方法名 / 通知名 / 反向请求名全同),即 0.144.x 内 wire 契约无变化。升级到不同 minor 时按此法重导比对。我们只手写最小协议子集,全量重导有专门脚本。
+
+**但 wire 契约没变不等于没坏**:0.149 那次改动一个字段都没动,改的是 `approvalPolicy: "never"` 的**语义**(见下节)。重导比对只能证伪,证实还得端到端跑一轮。
 
 ## 会话 / turn 映射
 
@@ -40,9 +42,39 @@
 
 codex 通过 **server→client 反向请求**要求授权,client 必须应答,否则 turn **卡死**。
 
-**坑(已验证)**:即便 `approvalPolicy: "never"` + `sandbox: "read-only"`,codex 仍会在**每次** MCP 工具调用前发 elicitation。故 client 对**自建受信工具**自动 accept 是架构必需件(另一条路是 `AskForApproval::granular{ mcp_elicitations:false }`)。`exec` / `applyPatch` 类审批在 review-only 下一律拒绝(只读 sandbox 下实测未触发)。
+**坑(已验证)**:即便审批闸门全关 + `sandbox: "read-only"`,codex 仍会在**每次** MCP 工具调用前发 elicitation(granular 里把 `mcp_elicitations` 关掉也照发)。故 client 对**自建受信工具**自动 accept 是架构必需件。`exec` / `applyPatch` 类审批在 review-only 下一律拒绝(只读 sandbox 下实测未触发)。
 
 反向审批统一归一成 `approval` 领域事件:受信 accept 标记为预期内,其余拒绝并上浮供 UI 审批卡呈现。
+
+### 为什么审批策略不是 `never`
+
+0.149 起 codex 把 **MCP 工具调用也纳入审批**,而 `"never"` 的语义是「不问 → 直接拒」,于是 `report_finding` 这类回传工具一律以 isError 收场(原文:`MCP tool call requires approval, but approval policy is never`),机审跑得完却一条 finding 都落不了库 —— 没有任何一处报错。能表达「不问且放行」的只有 `AskForApproval::granular` 五闸全关,而它需要 `initialize` 里声明 `capabilities.experimentalApi`。
+
+更早的 codex 不认 granular,但那些版本上 `"never"` 仍是「不问且放行」—— 两个条件同源于同一次改动,所以**先要 granular、被拒退回 `never`** 这条退路是安全的。协商在 `CodexAppServer.withReadOnlyApproval`(策略随连接不随 thread),只在拒绝形状像「策略不认」时退:放宽成「任何错误都退」等于把真实故障悄悄降级成上面那种最难查的失败。
+
+那条「同源于同一次改动」是**推断,不是实测**(手上只有 0.149.0-alpha.4.1 与 0.149.1,两个都接受 granular,谁也走不进回退分支)。所以不靠它兜底:退回之后若 `never` 恰好连 MCP 调用一并拒了,下面那条判据会把这一轮判死。
+
+连带的两条约束:
+
+- `capabilities` 只能在握手时发对一次 —— 一条连接**只 initialize 一次**(再来是 `-32600 Already initialized`);好在 codex 静默忽略未知字段,旧版收到 `capabilities` 会直接丢掉,不必按版本分叉。
+- `requestAttestation` 恒 false:开了 codex 会发 `attestation/generate` 反向请求,而我们答不了它,一条答不上来的反向请求就是一个卡死的 turn。
+
+### 回传链路断了要判死本轮
+
+codex 在自己那侧拒掉对自建 MCP 的调用时,turn **照常跑完并 completed** —— 用户看到的是「审核完成,0 findings」,与「真的没问题」在界面上一模一样。故 `ReviewSession` 见到未送达的调用即判死本轮(`MCP_UNDELIVERED_CODE`)并拆掉会话。
+
+判据是**结构性**的,不认措辞 —— 两种失败的 `status` 都是 `'failed'`,但形状不同(实测):
+
+| 情形 | `error` | `result` | 该怎么办 |
+| --- | --- | --- | --- |
+| 我们 server 主动回 isError(schema 不合法) | `null` | 有内容,拒绝原文在 `content` 里 | 正常来回,agent 改对了会重来 |
+| codex 侧拒绝(审批策略、传输起不来) | 有值 | `null` | 重试也到不了我们这儿,判死 |
+
+**不要把所有 `failed` 都升级成整轮失败** —— 那会把业务拒绝也判死,而那本是 agent 自我修正的正常路径。回归钉在 `npm run spike:sandbox-guard`,两种形状各一条。
+
+### MCP 工具默认是 deferred 的
+
+0.149 起 MCP 工具不再进模型的初始 tool list(`tool_search_always_defer_mcp_tools` 已是恒开),要经 code mode 检索才拿得到,调用最终仍以 `item.type === "mcpToolCall"` 到货(item id 带 `exec-` 前缀)。**实测不需要为此改提示词**:只要策略允许调用,agent 自己就会去找。
 
 ## 能观测到什么,不能观测到什么
 

--- a/scripts/spike-codex.ts
+++ b/scripts/spike-codex.ts
@@ -126,15 +126,17 @@ async function main() {
     await codex.initialize({ name: 'duetlens', version: APP_VERSION });
     log('codex', 'initialized');
 
-    const thread = await codex.threadStart({
-      cwd: workdir,
-      approvalPolicy: 'never',
-      sandbox: 'read-only',
-      baseInstructions: BASE_INSTRUCTIONS,
-      config: {
-        mcp_servers: { duetlens: { url: mcpUrl, bearer_token_env_var: 'DUETLENS_MCP_TOKEN' } },
-      },
-    });
+    const thread = await codex.withReadOnlyApproval((approvalPolicy) =>
+      codex.threadStart({
+        cwd: workdir,
+        approvalPolicy,
+        sandbox: 'read-only',
+        baseInstructions: BASE_INSTRUCTIONS,
+        config: {
+          mcp_servers: { duetlens: { url: mcpUrl, bearer_token_env_var: 'DUETLENS_MCP_TOKEN' } },
+        },
+      }),
+    );
     log('codex', `thread/start → ${thread.thread.id}`);
 
     const turn = await codex.turnStart({

--- a/scripts/spike-reasoning-summary.ts
+++ b/scripts/spike-reasoning-summary.ts
@@ -139,13 +139,15 @@ async function runTurn(label: string, reasoningSummary: string | null): Promise<
     };
     if (reasoningSummary) config.model_reasoning_summary = reasoningSummary;
 
-    const thread = await codex.threadStart({
-      cwd: workdir,
-      approvalPolicy: 'never',
-      sandbox: 'read-only',
-      baseInstructions: BASE_INSTRUCTIONS,
-      config,
-    });
+    const thread = await codex.withReadOnlyApproval((approvalPolicy) =>
+      codex.threadStart({
+        cwd: workdir,
+        approvalPolicy,
+        sandbox: 'read-only',
+        baseInstructions: BASE_INSTRUCTIONS,
+        config,
+      }),
+    );
     log(label, `thread/start → ${thread.thread.id}(codex ${thread.thread.cliVersion ?? '?'})`);
 
     await codex.turnStart({

--- a/scripts/spike-sandbox-guard.ts
+++ b/scripts/spike-sandbox-guard.ts
@@ -2,7 +2,7 @@
  * 确定性验证「只读沙箱注入失效」的判据(不走 codex/不烧 token)。
  *
  * 背景:codex 对请求里的未知字段是**静默忽略**的,所以 thread/start 把 sandbox 送出去
- * 不等于它生效;又因为注入的 approvalPolicy 是 never,策略没落地时 codex 通常**不会来问**,
+ * 不等于它生效;又因为注入的 approvalPolicy 把审批闸门全关了,策略没落地时 codex 通常**不会来问**,
  * 没有天然哨兵。握手侧的读回校验在 CodexAgent(需真 codex,见 assertReadOnly),
  * 这里验的是 turn 内那条兜底:
  *
@@ -21,9 +21,14 @@ import { openDatabase } from '../src/backend/db/database';
 import { ReviewStore } from '../src/backend/db/review-store';
 import { AgentTurnError, ReviewSession } from '../src/backend/review/review-session';
 import { describeRoundFailure } from '../src/backend/review/review-manager';
-import { CodexServerRequest, DECLINE_BY_METHOD } from '../src/backend/agent/codex/protocol';
-import { POLICY_APPROVALS } from '../src/backend/agent/codex/codex-agent';
-import { SANDBOX_NOT_APPLIED_CODE } from '../src/shared/ipc';
+import {
+  CodexServerRequest,
+  DECLINE_BY_METHOD,
+  READ_ONLY_GATES,
+} from '../src/backend/agent/codex/protocol';
+import { POLICY_APPROVALS, isSilentApproval } from '../src/backend/agent/codex/codex-agent';
+import { MCP_UNDELIVERED_CODE, SANDBOX_NOT_APPLIED_CODE } from '../src/shared/ipc';
+import { MCP_SERVER_NAME, MCP_TOOL } from '../src/shared/mcp-contract';
 import type {
   AgentEvent,
   ConversationalAgent,
@@ -207,13 +212,96 @@ function everyApprovalIsASentinel(): void {
   log('✓ 审批方法表与哨兵集合同步,拒绝说法齐备');
 }
 
+/**
+ * 6. codex 没把调用交给自建 MCP —— findings 回不来,本轮必须判死。
+ *
+ * 这条兜底最容易被写过头:工具自己回的业务拒绝(schema 不合法)也是 `status: 'failed'`,
+ * 而那种 agent 看得到原文、改对了会重来,是正常来回。分界不在措辞上,在 `undelivered`
+ * 有没有值 —— 未送达才有,业务拒绝没有。两种形状都在这里钉住。
+ */
+async function undeliveredMcpCallKillsRound(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'tool-call',
+      server: MCP_SERVER_NAME,
+      tool: MCP_TOOL.reportFinding,
+      status: 'failed',
+      undelivered: 'MCP tool call requires approval, but approval policy is never',
+    });
+    // 未送达之后 turn 照样会 completed —— 正是这一点让它伪装成「审核完成,0 findings」
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await assert.rejects(
+    () => f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 }),
+    (e: Error) =>
+      e instanceof AgentTurnError &&
+      e.errorKind === 'mcp-undelivered' &&
+      e.message.includes(MCP_UNDELIVERED_CODE),
+    'codex 侧拒掉的 MCP 调用 = 回传链路断了,本轮要以 mcp-undelivered 失败',
+  );
+  assert.equal(f.agent.disposed, true, '同沙箱那条:会话得真拆掉,留着下一条追问也白跑');
+  log('✓ 未送达的 MCP 调用 → 本轮判死并拆会话');
+  return () => f.session.dispose();
+}
+
+/** 7. 工具自己回的业务拒绝走同一个事件 —— 不许被上面那条误杀。 */
+async function toolRejectionIsHarmless(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'tool-call',
+      server: MCP_SERVER_NAME,
+      tool: MCP_TOOL.writeSummary,
+      // 实测形状:server 答过话了,拒绝原文在 result 里,故 undelivered 无值
+      status: 'failed',
+    });
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  assert.equal(f.agent.disposed, false, 'server 已答话的业务拒绝不该拆会话 —— agent 还要改对了重来');
+  log('✓ 工具回的业务拒绝 → 不误判为链路断开');
+  return () => f.session.dispose();
+}
+
+/**
+ * 8. 回显策略的真值表。这里是**失败关闭**的那一侧:判错成「静默」就等于放一份没证实的
+ * 策略过关,而 assertReadOnly 之后不会再问第二遍。
+ *
+ * 最容易漏的是空 granular —— 只查「现有值是否都为 false」的写法会因空集恒真而放行。
+ */
+function silentApprovalTruthTable(): void {
+  const gates = { ...READ_ONLY_GATES };
+  const cases: [unknown, boolean, string][] = [
+    ['never', true, '旧版说法'],
+    [{ granular: gates }, true, '我们请求的那份,原样回显'],
+    [{ granular: {} }, false, '空 granular:什么都没证实,不能因空集恒真而放行'],
+    [{ granular: { ...gates, mcp_elicitations: true } }, false, '有闸门开着'],
+    [
+      { granular: Object.fromEntries(Object.entries(gates).slice(1)) },
+      false,
+      '少回显一个闸门:那一个的状态是未知,不是关',
+    ],
+    [{ granular: { ...gates, future_gate: true } }, false, '多出一个我们没请求过的闸门且开着'],
+    [{ granular: { ...gates, future_gate: false } }, true, '多出的闸门关着 —— 仍算静默'],
+    ['on-request', false, '会来问'],
+    [undefined, false, '没回显 = 没证实'],
+  ];
+  for (const [policy, expected, why] of cases) {
+    const got = isSilentApproval(policy as Parameters<typeof isSilentApproval>[0]);
+    assert.equal(got, expected, `${why}:应判 ${expected},实得 ${got}`);
+  }
+  log('✓ 回显策略真值表:空/缺项/多出的 granular 都不放行');
+}
+
 async function main(): Promise<void> {
   everyApprovalIsASentinel();
   launchFailuresKeepTheirKind();
+  silentApprovalTruthTable();
   for (const t of [
     unexpectedApprovalKillsRound,
     expectedApprovalIsHarmless,
     declinedMcpElicitationIsNotABreach,
+    undeliveredMcpCallKillsRound,
+    toolRejectionIsHarmless,
   ]) {
     const dispose = await t();
     await dispose(); // MCP server 不关,event loop 就一直醒着,进程退不了

--- a/src/backend/agent/codex/codex-agent.ts
+++ b/src/backend/agent/codex/codex-agent.ts
@@ -5,7 +5,9 @@ import {
   CodexItemType,
   CodexNotification,
   CodexServerRequest,
+  READ_ONLY_GATES,
   codexErrorKind,
+  type AskForApproval,
   type CodexErrorNotification,
   type CodexModel,
   type CodexTurnError,
@@ -21,6 +23,7 @@ import {
 } from './protocol';
 import { CODEX_TARGET_VERSION } from '@shared/codex';
 import { SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
+import { MCP_SERVER_NAME } from '@shared/mcp-contract';
 import type { CommandAction } from '@shared/agent-events';
 import type {
   AgentEvent,
@@ -34,7 +37,7 @@ import type {
 const MCP_TOKEN_ENV = 'DUETLENS_MCP_TOKEN';
 
 /**
- * 把关执行/写入/权限的反向审批 —— 只读 + approvalPolicy=never 的会话里一条都不该出现,
+ * 把关执行/写入/权限的反向审批 —— 只读 + 闸门全关的会话里一条都不该出现,
  * 故可当沙箱注入是否失效的哨兵。`mcpElicitation` **不在此列**:那是工具调用的确认,
  * 用户自己在 config.toml 里配的第三方 MCP server 也会发,被拒不能说明我们的注入没生效。
  */
@@ -50,6 +53,26 @@ export const POLICY_APPROVALS: ReadonlySet<string> = new Set([
 const norm = (v: string | undefined): string => (v ?? '').toLowerCase().replace(/[^a-z]/g, '');
 
 /**
+ * 回显的审批策略是否等于「不来问」。两版 codex 的说法都认:`'never'` 与闸门全关的 granular。
+ *
+ * 两侧都要判,少一侧就有一种漂移能蒙混过去:
+ * - **请求过的闸门逐个回显且严格为 `false`** —— 只查「现有值是否都为 false」的话,
+ *   `{ granular: {} }` 会因空集恒真而通过,于是一份根本没证实的策略被当成已生效。
+ *   闸门清单从 {@link READ_ONLY_GATES} 派生,不另抄一份。
+ * - **回显里多出来的闸门也必须关着** —— 多一个我们没请求过的开关意味着 codex 可能来问,
+ *   而「不该被问到」正是 {@link POLICY_APPROVALS} 那条兜底的前提。
+ *
+ * 导出仅供 spike:sandbox-guard 钉住上面这张真值表(assertReadOnly 本身要真 codex 才跑得起来)。
+ */
+export function isSilentApproval(policy: AskForApproval | undefined): boolean {
+  if (typeof policy === 'string') return norm(policy) === 'never';
+  const gates: Record<string, unknown> | undefined = policy?.granular;
+  if (!gates) return false;
+  if (!Object.keys(READ_ONLY_GATES).every((gate) => gates[gate] === false)) return false;
+  return Object.values(gates).every((open) => open === false);
+}
+
+/**
  * 证实只读注入**真的落地**,否则拒绝开工。见 {@link SANDBOX_NOT_APPLIED_CODE} ——
  * 请求发出去不算数,codex 会静默吞掉它不认识的字段。
  *
@@ -59,8 +82,9 @@ const norm = (v: string | undefined): string => (v ?? '').toLowerCase().replace(
 function assertReadOnly(res: ThreadStartResponse | ThreadResumeResponse): void {
   const sandbox = (res as EffectiveThreadPolicy).sandbox?.type;
   const approval = (res as EffectiveThreadPolicy).approvalPolicy;
-  if (norm(sandbox) === 'readonly' && norm(approval) === 'never') return;
-  const seen = `sandbox=${sandbox ?? '(未回显)'}, approvalPolicy=${approval ?? '(未回显)'}`;
+  if (norm(sandbox) === 'readonly' && isSilentApproval(approval)) return;
+  const shown = approval === undefined ? '(未回显)' : JSON.stringify(approval);
+  const seen = `sandbox=${sandbox ?? '(未回显)'}, approvalPolicy=${shown}`;
   throw new Error(
     `${SANDBOX_NOT_APPLIED_CODE} codex 没有按只读沙箱起会话(${seen})。` +
       `本机 codex ${res.thread.cliVersion ?? '版本未知'},这版 Duetlens 对齐的是 ${CODEX_TARGET_VERSION}。`,
@@ -85,7 +109,7 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
     this.server = new CodexAppServer({
       codexBin: opts.codexBin,
       codexHome: opts.codexHome,
-      trustedMcpServers: ['duetlens'],
+      trustedMcpServers: [MCP_SERVER_NAME],
       onLog: opts.onLog,
     });
     this.server.on('notification', (m, p) => this.mapNotification(m, p));
@@ -142,29 +166,33 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
 
   async startConversation(opts: StartConversationOptions): Promise<ConversationHandle> {
     await this.launchServer(opts.mcpToken);
-    const res = await this.server.threadStart({
-      cwd: opts.cwd,
-      sandbox: 'read-only',
-      approvalPolicy: 'never',
-      baseInstructions: opts.baseInstructions,
-      model: opts.model || undefined,
-      config: this.threadConfig(opts),
-    });
+    const res = await this.server.withReadOnlyApproval((approvalPolicy) =>
+      this.server.threadStart({
+        cwd: opts.cwd,
+        sandbox: 'read-only',
+        approvalPolicy,
+        baseInstructions: opts.baseInstructions,
+        model: opts.model || undefined,
+        config: this.threadConfig(opts),
+      }),
+    );
     this.acceptOrStop(res);
     return { conversationId: res.thread.id, model: res.model || undefined };
   }
 
   async resumeConversation(opts: ResumeConversationOptions): Promise<ConversationHandle> {
     await this.launchServer(opts.mcpToken);
-    const res = await this.server.threadResume({
-      threadId: opts.conversationId,
-      cwd: opts.cwd,
-      sandbox: 'read-only',
-      approvalPolicy: 'never',
-      baseInstructions: opts.baseInstructions,
-      model: opts.model || undefined,
-      config: this.threadConfig(opts),
-    });
+    const res = await this.server.withReadOnlyApproval((approvalPolicy) =>
+      this.server.threadResume({
+        threadId: opts.conversationId,
+        cwd: opts.cwd,
+        sandbox: 'read-only',
+        approvalPolicy,
+        baseInstructions: opts.baseInstructions,
+        model: opts.model || undefined,
+        config: this.threadConfig(opts),
+      }),
+    );
     this.acceptOrStop(res);
     return { conversationId: res.thread.id, model: res.model || undefined };
   }
@@ -192,9 +220,9 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
   private threadConfig(opts: StartConversationOptions): Record<string, unknown> | undefined {
     const config: Record<string, unknown> = {};
     if (opts.mcpUrl) {
-      const duetlens: Record<string, unknown> = { url: opts.mcpUrl };
-      if (opts.mcpToken) duetlens.bearer_token_env_var = MCP_TOKEN_ENV;
-      config.mcp_servers = { duetlens };
+      const server: Record<string, unknown> = { url: opts.mcpUrl };
+      if (opts.mcpToken) server.bearer_token_env_var = MCP_TOKEN_ENV;
+      config.mcp_servers = { [MCP_SERVER_NAME]: server };
     }
     if (opts.reasoningEffort) config.model_reasoning_effort = opts.reasoningEffort;
     return Object.keys(config).length ? config : undefined;
@@ -253,6 +281,7 @@ export class CodexAgent extends EventEmitter implements ConversationalAgent {
             tool: call.tool,
             status: call.status,
             args: call.arguments,
+            undelivered: call.error?.message,
             durationMs: call.durationMs ?? undefined,
           });
         } else if (item?.type === CodexItemType.commandExecution) {

--- a/src/backend/agent/codex/codex-app-server.ts
+++ b/src/backend/agent/codex/codex-app-server.ts
@@ -2,10 +2,15 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { resolveTool } from '../../config/tool-paths';
 import { JsonRpcConnection } from './jsonrpc';
+import { isApprovalPolicyUnsupported } from '@shared/codex';
 import {
+  CLIENT_CAPABILITIES,
   CodexMethod,
   CodexServerRequest,
   DECLINE_BY_METHOD,
+  LEGACY_READ_ONLY_APPROVAL,
+  READ_ONLY_APPROVAL,
+  type AskForApproval,
   type InitializeParams,
   type McpServerElicitationRequestParams,
   type McpServerElicitationRequestResponse,
@@ -43,6 +48,8 @@ export class CodexAppServer extends EventEmitter {
   private child?: ChildProcessWithoutNullStreams;
   private rpc?: JsonRpcConnection;
   private readonly trusted: Set<string>;
+  /** 协商下来的审批策略;认过一次就不再重试(策略随连接,不随 thread) */
+  private approvalPolicy?: AskForApproval;
 
   constructor(private readonly opts: CodexAppServerOptions = {}) {
     super();
@@ -72,12 +79,54 @@ export class CodexAppServer extends EventEmitter {
     });
   }
 
+  /**
+   * 握手。**一条连接只握一次**(再来一次是 `-32600 Already initialized`),所以这里没有
+   * 「先试后退」的余地 —— 能力声明只能一次发对。发的是 {@link CLIENT_CAPABILITIES},
+   * 不认识它的旧版 codex 会把整个字段当未知字段丢掉,不必按版本分叉。
+   */
   async initialize(clientInfo: InitializeParams['clientInfo']): Promise<unknown> {
-    return this.rpcOrThrow().request(CodexMethod.initialize, { clientInfo });
+    return this.rpcOrThrow().request(CodexMethod.initialize, {
+      clientInfo,
+      capabilities: CLIENT_CAPABILITIES,
+    });
   }
 
   async listModels(params: ModelListParams = {}): Promise<ModelListResponse> {
     return this.rpcOrThrow().request<ModelListResponse>(CodexMethod.modelList, params);
+  }
+
+  /**
+   * 把「只读且静默」翻成本机 codex 认的那种说法:先要 {@link READ_ONLY_APPROVAL}(granular),
+   * 被拒再退 {@link LEGACY_READ_ONLY_APPROVAL}。`start` 会被调一次或两次,收到策略后自己发
+   * thread/start 或 thread/resume。
+   *
+   * 为什么退得起:握手不能重来(一条连接只 initialize 一次),但 thread/start 被拒时并没有
+   * 建出 thread,原地换个说法重发既安全也不烧 token。
+   *
+   * **退的条件是拒绝的形状像「策略不认」**(判据与其宽窄的取舍见 `isApprovalPolicyUnsupported`
+   * —— 它有意认下所有 serde 形状拒绝,不止点名 granular 的那句)。不放宽成「任何错误都退」:
+   * 真退错了,拿到的会是最难查的那种失败 —— 会话建得起来、turn 跑得完、一条 finding 都回不来。
+   * 退不动时抛第二次的错 —— 那次用的是最保守的说法,更接近真因。
+   *
+   * 退回后**并非无人看管**:若那个版本上 `'never'` 恰好连 MCP 调用一并拒了,ReviewSession
+   * 对未送达调用的兜底会把这一轮判死(见 `MCP_UNDELIVERED_CODE`),不会静默变成 0 findings。
+   */
+  async withReadOnlyApproval<T>(start: (approvalPolicy: AskForApproval) => Promise<T>): Promise<T> {
+    if (this.approvalPolicy) return start(this.approvalPolicy);
+    try {
+      const res = await start(READ_ONLY_APPROVAL);
+      this.approvalPolicy = READ_ONLY_APPROVAL;
+      return res;
+    } catch (e) {
+      const message = (e as Error).message;
+      if (!isApprovalPolicyUnsupported(message)) throw e;
+      this.opts.onLog?.(
+        `codex 不认 granular 审批策略(${message}),退回 ${LEGACY_READ_ONLY_APPROVAL}`,
+      );
+      const res = await start(LEGACY_READ_ONLY_APPROVAL);
+      this.approvalPolicy = LEGACY_READ_ONLY_APPROVAL;
+      return res;
+    }
   }
 
   async threadStart(params: ThreadStartParams): Promise<ThreadStartResponse> {

--- a/src/backend/agent/codex/protocol.ts
+++ b/src/backend/agent/codex/protocol.ts
@@ -25,9 +25,56 @@ export type AskForApproval =
     };
 
 // ---- initialize ----
+
+/**
+ * 客户端单向声明的能力(0.149 起有;更早的 codex 把整个字段当未知字段静默丢弃,
+ * 故无条件发,不必按版本分叉)。
+ *
+ * - `experimentalApi`:granular 审批策略的前提,见 {@link READ_ONLY_APPROVAL}。
+ * - `requestAttestation`:恒 false —— 开了 codex 会发 `attestation/generate` 反向请求,
+ *   而我们答不了它,一条答不上来的反向请求就是一个卡死的 turn。
+ */
+export interface InitializeCapabilities {
+  experimentalApi: boolean;
+  requestAttestation: boolean;
+}
+
+export const CLIENT_CAPABILITIES: InitializeCapabilities = {
+  experimentalApi: true,
+  requestAttestation: false,
+};
+
 export interface InitializeParams {
   clientInfo: { name: string; version: string; title?: string };
+  capabilities?: InitializeCapabilities;
 }
+
+/**
+ * 只读审核会话的审批策略:**五个闸门全关** —— 既不来问,也不因为没问就拒。
+ *
+ * 为什么不是 `'never'`:0.149 起 codex 把 MCP 工具调用也纳入审批,而 `'never'` 的语义是
+ * 「不问 → 直接拒」,于是 `report_finding` 这类回传工具一律以 isError 收场
+ * (原文:MCP tool call requires approval, but approval policy is never),
+ * 机审跑完一条 finding 都落不了库。只有 granular 能表达「不问且放行」。
+ *
+ * 全关也是 {@link CodexServerRequest} 那套兜底的前提:这几个闸门开着才会有政策类反向审批,
+ * 关着还被问到,就说明只读注入没生效。
+ */
+export const READ_ONLY_GATES = {
+  sandbox_approval: false,
+  rules: false,
+  skill_approval: false,
+  request_permissions: false,
+  mcp_elicitations: false,
+} as const;
+
+export const READ_ONLY_APPROVAL: AskForApproval = { granular: { ...READ_ONLY_GATES } };
+
+/**
+ * 认不出 granular 的 codex 上的同义说法。**退回它是安全的**:不认 granular 的版本,
+ * 恰好就是 `'never'` 仍表示「不问且放行」的那些版本 —— 两个条件同源于 0.149 那次改动。
+ */
+export const LEGACY_READ_ONLY_APPROVAL: AskForApproval = 'never';
 
 // ---- thread/start ----
 export interface ThreadStartParams {
@@ -47,7 +94,8 @@ export interface ThreadStartParams {
  * 这几个字段是只读注入能否被证实的唯一途径,见 {@link SANDBOX_NOT_APPLIED_CODE}。
  */
 export interface EffectiveThreadPolicy {
-  approvalPolicy?: string;
+  /** 回显与请求同形:`'never'` 是字符串,granular 回来的是对象 */
+  approvalPolicy?: AskForApproval;
   sandbox?: { type?: string; [k: string]: unknown } | null;
 }
 
@@ -287,5 +335,16 @@ export interface McpToolCallItem {
   tool: string;
   status: string;
   arguments?: unknown;
+  /** server 答过话就有值(**包括**它主动回的 isError,拒绝原文在 content 里) */
+  result?: { content?: unknown } | null;
+  /**
+   * **codex 自己**没能把这次调用交给 server 时的原因(审批拒绝、传输失败)。
+   *
+   * 这是「未送达」与「server 已处理后拒绝」唯一可靠的分界:两者 `status` 都是 `'failed'`,
+   * 但业务拒绝是 `error: null` + `result` 有内容(agent 看得到原文,能改对了重来),
+   * 未送达是 `error` 有值 + `result: null`(agent 怎么重试都到不了我们这儿)。
+   * 实测两种形状见 review-session 里对未送达的兜底。
+   */
+  error?: { message: string } | null;
   durationMs?: number | null;
 }

--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -28,7 +28,7 @@ import {
 } from '@shared/domain';
 import type { CodeSearchInput, CodeSearchResult } from '../source/source';
 import { APP_VERSION } from '@shared/version';
-import { MCP_ARG, MCP_TOOL } from '@shared/mcp-contract';
+import { MCP_ARG, MCP_SERVER_NAME, MCP_TOOL } from '@shared/mcp-contract';
 
 const CATEGORY_HINT = `建议取值:${FINDING_CATEGORIES.join(' / ')}`;
 
@@ -581,7 +581,7 @@ export class DuetlensMcpServer extends EventEmitter {
 
   private buildMcpServer(): Server {
     const server = new Server(
-      { name: 'duetlens', version: APP_VERSION },
+      { name: MCP_SERVER_NAME, version: APP_VERSION },
       { capabilities: { tools: {} } },
     );
 

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -27,7 +27,12 @@ import {
   type WriteSummaryInput,
 } from '@shared/domain';
 import { findDuplicate, isRestatedFinding } from '@shared/finding-dedupe';
-import { FOLLOWUP_REPLY_FAILED_CODE, SANDBOX_NOT_APPLIED_CODE } from '@shared/ipc';
+import {
+  FOLLOWUP_REPLY_FAILED_CODE,
+  MCP_UNDELIVERED_CODE,
+  SANDBOX_NOT_APPLIED_CODE,
+} from '@shared/ipc';
+import { MCP_SERVER_NAME } from '@shared/mcp-contract';
 import type { AgentErrorKind } from '@shared/agent-events';
 import type { AgentEvent, ConversationalAgent } from '../agent/conversational-agent';
 import type { ReviewStore } from '../db/review-store';
@@ -928,7 +933,7 @@ export class ReviewSession {
 
     cleanup.push(
       this.agent.streamEvents((e) => {
-        // 注入的 approvalPolicy 是 never,codex 本不该来问这类审批;问了就说明只读策略没生效。
+        // 注入的 approvalPolicy 把审批闸门全关了,codex 本不该来问这类审批;问了就说明只读策略没生效。
         // 与握手时的读回校验同一个判据,这里是它的兜底。
         if (e.kind === 'approval' && !e.expected && e.gate === 'policy') {
           finish({
@@ -941,6 +946,21 @@ export class ReviewSession {
           // 「不知道它在什么策略下跑」。拆掉会话让它真的停手:打断需要对方配合,
           // 这里已经不能假定对方守规矩;何况会话留着,下一条追问又会喂进同一个坏策略里。
           // 拆的过程再出错也别变成进程级 unhandled rejection —— 判死已经落下了
+          void this.dispose().catch(() => undefined);
+          return;
+        }
+        // codex 没把对自建 MCP 的调用交给我们 —— findings 回不来了。turn 会照常跑完并
+        // completed,不判死的话这一轮会以「审核完成,0 findings」收场,和「真的没问题」
+        // 长得一模一样。判据只认「未送达」这一半:工具自己回的业务拒绝(schema 不合法等)
+        // agent 看得到原文、改对了会重来,那是正常来回,不是故障。
+        if (e.kind === 'tool-call' && e.server === MCP_SERVER_NAME && e.undelivered) {
+          finish({
+            kind: 'turn-failed',
+            turnId: mine ?? '',
+            error: `${MCP_UNDELIVERED_CODE} codex 没把 ${e.tool} 交给 Duetlens:${e.undelivered}`,
+            errorKind: 'mcp-undelivered',
+          });
+          // 同上:拆会话。回传链路断在 codex 那侧,留着会话只会让下一条追问也白跑。
           void this.dispose().catch(() => undefined);
           return;
         }

--- a/src/renderer/screens/review/round-error.ts
+++ b/src/renderer/screens/review/round-error.ts
@@ -61,6 +61,14 @@ const COPY: Record<AgentErrorKind, RoundErrorCopy> = {
   },
   'sandbox-not-applied': { ...SANDBOX_BREACH, retryable: false },
   'codex-version-mismatch': { ...VERSION_MISMATCH, retryable: false },
+  'mcp-undelivered': {
+    title: 'codex 没把工具调用交给 Duetlens,已中止',
+    advice:
+      'agent 上报 findings 的通道断在 codex 那一侧 —— 它自己就把调用拒了,一条都没到货。' +
+      '再跑也是空手,而且「0 findings」和「真的没问题」在界面上长得一样,所以直接停了。' +
+      `多为本机 codex 与这版 Duetlens 的审批策略对不上;这版对齐的是 codex ${CODEX_TARGET_VERSION}。`,
+    retryable: false,
+  },
   other: {
     title: '这一轮机审没能跑完',
     advice: '',

--- a/src/shared/agent-events.ts
+++ b/src/shared/agent-events.ts
@@ -29,6 +29,8 @@ export const AGENT_ERROR_KINDS = [
   'sandbox-not-applied',
   /** 本机 codex 与这版对齐的协议对不上(见 CODEX_PROTOCOL_ERROR)—— 重试必然复现 */
   'codex-version-mismatch',
+  /** codex 没把工具调用交给自建 MCP —— findings 回不来,再跑也是空手,见 MCP_UNDELIVERED_CODE */
+  'mcp-undelivered',
   'other',
 ] as const;
 export type AgentErrorKind = (typeof AGENT_ERROR_KINDS)[number];
@@ -54,7 +56,19 @@ export type AgentEvent =
   | { kind: 'turn-started'; turnId: string }
   // turnId 是 agent 可选给的:有就据此把残余 delta 挡在别的 turn 之外(被打断那轮常有补发)
   | { kind: 'message-delta'; text: string; turnId?: string }
-  | { kind: 'tool-call'; server: string; tool: string; status: string; args?: unknown; durationMs?: number }
+  | {
+      kind: 'tool-call';
+      server: string;
+      tool: string;
+      status: string;
+      args?: unknown;
+      /**
+       * **codex 没把这次调用交给 server** 时的原因。工具自己回的业务拒绝不在此列 ——
+       * 那种 agent 看得到原文、改对了会重来,不是故障;这里只装它重试也到不了的那半。
+       */
+      undelivered?: string;
+      durationMs?: number;
+    }
   /**
    * agent 跑的 shell 命令(只读沙箱下就是 rg / sed / cat 这一类取证动作)。
    * 与 `tool-call` 分开是因为二者的可读单位不同:工具调用问的是「哪个工具、什么参数」,

--- a/src/shared/codex.ts
+++ b/src/shared/codex.ts
@@ -1,13 +1,13 @@
 /**
  * 与本机 codex 的版本契约。放 shared:backend 起会话时据此校验,renderer 出错时据此给结论。
  *
- * app-server **没有版本协商**:initialize 只在 userAgent 串里带版本,没有 capabilities 列表,
- * 而 thread/start 的应答里有 `thread.cliVersion`。所以「对不对得上」只能事后从失败里认,
- * 认不出就会以裸 JSON-RPC 错误码糊到用户脸上。
+ * app-server **没有版本协商**:initialize 里的 capabilities 是客户端单向声明能力,
+ * 不回告服务端支持什么;版本只在 userAgent 串与 thread/start 应答的 `thread.cliVersion` 里。
+ * 所以「对不对得上」只能事后从失败里认,认不出就会以裸 JSON-RPC 错误码糊到用户脸上。
  */
 
 /** 手写协议子集(backend/agent/codex/protocol.ts)对齐的 codex 版本。 */
-export const CODEX_TARGET_VERSION = '0.145.0';
+export const CODEX_TARGET_VERSION = '0.149.1';
 
 /**
  * JSON-RPC 错误码的尾巴。只由 jsonrpc.ts 拼接 codex 的错误应答时产生,来源唯一 ——
@@ -30,4 +30,20 @@ const SERDE_SHAPE = /Invalid request|missing field|unknown variant|unknown field
  */
 export function isCodexProtocolError(message: string): boolean {
   return RPC_REJECTED.test(message) && SERDE_SHAPE.test(message);
+}
+
+/**
+ * 本机 codex 不认我们请求的审批策略。用来决定「换个说法重试」还是「照抛」——
+ * 这两版 codex 表达只读且静默的说法不同,见 backend 侧 `READ_ONLY_APPROVAL`。
+ *
+ * 认两类:0.149 起点名 granular / experimentalApi 的能力门,以及**任何** serde 形状拒绝。
+ * 后半段是有意放宽的 —— 更早的 codex 可能只回一句通用的 `invalid type`,收窄到点名那两个
+ * 词就会漏掉它们。代价是形状错若出在别的字段(如 baseInstructions 改名)也会白退一次;
+ * 但那次退回用的是更保守的说法,同一个原因会再失败一次并显式抛出,**不会伪装成成功**。
+ *
+ * 不认的是「任何错误都退」:真退错了,拿到的会是最难查的那种失败 —— 会话建得起来、
+ * turn 跑得完、一条 finding 都回不来。
+ */
+export function isApprovalPolicyUnsupported(message: string): boolean {
+  return /granular|experimentalApi/i.test(message) || isCodexProtocolError(message);
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -209,12 +209,24 @@ export const FOLLOWUP_REPLY_FAILED_CODE = 'DUETLENS_FOLLOWUP_REPLY_FAILED';
  * codex 对请求里的未知字段是**静默忽略**的(实测多送一个字段照常走到业务逻辑),
  * 所以 thread/start 把 `sandbox` 送出去不等于它生效:字段哪天改名或换枚举,我们会
  * 「发送成功」而 codex 按自己的默认策略跑,审核 agent 就不再是只读的,且全程无一句报错。
- * 又因为注入的 `approvalPolicy` 是 never,这种情况下 codex **不会来问**,没有天然的哨兵。
+ * 又因为注入的 `approvalPolicy` 把审批闸门全关了,这种情况下 codex **不会来问**,没有天然的哨兵。
  *
  * 故一律失败关闭:握手读回策略、turn 里收到本不该出现的审批请求,两处都判死本轮。
  * 嵌进 message 的理由同 {@link FOLLOWUP_REPLY_FAILED_CODE}:IPC 只把 message 串过去。
  */
 export const SANDBOX_NOT_APPLIED_CODE = 'DUETLENS_SANDBOX_NOT_APPLIED';
+
+/**
+ * codex 没把对自建 MCP 的调用交给我们 —— **findings 的回传链路断了**。
+ *
+ * 与沙箱那条同属「跑得下去但结果不可信」:codex 在自己那侧就把调用拒了(审批策略不合、
+ * 传输起不来),turn 照常跑完、照常 completed,而 report_finding / write_summary 一条都没到货。
+ * 不判死的话,用户看到的是「审核完成,0 findings」—— 与「真的没问题」长得一模一样。
+ *
+ * 判据是**结构性**的,不认措辞:未送达是 `error` 有值,而工具自己回的业务拒绝是
+ * `error: null` + result 带原文。后者是 agent 能改对了重来的,不在此列。
+ */
+export const MCP_UNDELIVERED_CODE = 'DUETLENS_MCP_UNDELIVERED';
 
 /** 正在跑的一条审核;满载提示逐条列出,可跳过去看或叫停。 */
 export interface BusyReview {

--- a/src/shared/mcp-contract.ts
+++ b/src/shared/mcp-contract.ts
@@ -10,6 +10,12 @@
  * 有意不做成模板 —— 那段是写给模型读的说明,拼接会毁掉可读性,且它已是锁定段。
  */
 
+/**
+ * codex 那侧看到的 server 名。注入 config、判「这次调用是不是我们自己的 server」都取它 ——
+ * 后者是安全判据(见 ReviewSession 对未送达调用的兜底),拼错不会报错,只会让兜底静默失效。
+ */
+export const MCP_SERVER_NAME = 'duetlens';
+
 export const MCP_TOOL = {
   reportFinding: 'report_finding',
   updateFinding: 'update_finding',


### PR DESCRIPTION
## What broke

codex 0.149 folds MCP tool calls into approvals. `approvalPolicy: "never"` used to mean
"don't ask, allow"; it now means "don't ask, deny". Every `report_finding` / `write_summary`
came back as `isError`:

```
MCP tool call requires approval, but approval policy is never
```

A scan ran to completion, reported 0 findings, and logged nothing anywhere — indistinguishable
from a clean review.

The wire contract itself did not change. A `generate-ts` re-export against 0.149.1 matches our
hand-written subset field for field: methods, notifications, reverse-request names, item shapes,
token usage, error payloads. Only the semantics moved, so re-export diffing can falsify a break
but cannot confirm one.

## The fix

Ask for `AskForApproval::granular` with all five gates closed — the only spelling that means
"don't ask and allow" — declaring the `capabilities.experimentalApi` it requires, and fall back
to `"never"` when codex rejects that policy. Negotiation lives in
`CodexAppServer.withReadOnlyApproval`, since which spelling this codex accepts is a protocol
detail that layer exists to absorb; the agent and both codex-driving spikes share it.

Compatibility rests on two measured facts rather than a version comparison:

- codex ignores unknown fields in params, so `capabilities` goes out unconditionally and older
  builds drop it. This matters because a connection can only `initialize` once
  (`-32600 Already initialized`), leaving no room to retry the handshake.
- Versions that reject granular are the ones where `"never"` still means allow, so the fallback
  is safe. That part is inference: both builds on hand accept granular, so neither can prove it.

## Not relying on that inference

If some build did reject granular while denying MCP calls, the fallback would land us right back
in the silent-zero-findings state. So `ReviewSession` now fails the round when codex refuses to
hand a call to the built-in MCP server (`MCP_UNDELIVERED_CODE`).

The two failures are told apart by shape, not by wording — both report `status: "failed"`:

| case | `error` | `result` |
| --- | --- | --- |
| our server rejected it (schema validation) | `null` | present, reason in `content` |
| codex never delivered it (approval, transport) | set | `null` |

Only the second is fatal. The first is the agent fixing its arguments and retrying, and treating
every `failed` as fatal would kill rounds on that normal exchange.

## Verification

- End-to-end on real codex: granular path starts a thread, passes the read-back check, auto-accepts
  the elicitation, and lands a finding. Legacy path (handshake without `capabilities`, so granular
  is genuinely rejected) falls back, is accepted by the read-back check, and caches the policy.
- Real echoes from codex 0.149.1 and 0.149.0-alpha.4.1, both policies, all pass the read-back check.
- `spike:sandbox-guard` covers the new ground and both spikes pass; each new assertion was confirmed
  to fail with its guard removed.

`spike:codex` and `spike:reasoning-summary` were changed mechanically and not executed — each costs
a real review turn.