### PR TITLE
chore(release): 0.7.2

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -4,6 +4,26 @@ Only **user-visible** changes are recorded here. Internal refactors, docs and CI
 listed — read `git log` for those. Versions follow [Semantic Versioning](https://semver.org/);
 while on `0.x`, the minor position doubles as the breaking-change position.
 
+## [0.7.2] - 2026-08-24
+
+### Fixed
+
+- **Reviews no longer silently report zero findings on codex 0.149 and later.** That release folds
+  MCP tool calls into approvals, which flipped `approvalPolicy: "never"` from "don't ask, allow" to
+  "don't ask, deny". Every `report_finding` and `write_summary` the agent made was rejected, so a
+  review ran to completion with an empty result page and nothing unusual in the logs —
+  indistinguishable, on screen, from a review that genuinely found nothing. The handshake now asks
+  for the `granular` approval policy with all five gates closed (currently the only spelling that
+  means "don't ask and allow") and falls back to `"never"` when codex rejects that policy; older
+  builds ignore fields they do not understand, so no second handshake is needed. On top of that, a
+  round now fails loudly when codex refuses to hand a tool call to the built-in MCP server, instead
+  of degrading into an empty verdict. (#72)
+
+### Upgrade notes
+
+- The database schema is unchanged at v21; 0.7.0, 0.7.1 and 0.7.2 can be installed in any direction.
+- The update arrives through the in-app updater; there is no need to download the dmg again.
+
 ## [0.7.1] - 2026-08-21
 
 ### Fixed
@@ -379,6 +399,7 @@ while on `0.x`, the minor position doubles as the breaking-change position.
 
 First public release.
 
+[0.7.2]: https://github.com/xieziyu/duetlens/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/xieziyu/duetlens/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/xieziyu/duetlens/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/xieziyu/duetlens/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 本文件只记**对使用者可见**的变化。内部重构、文档与 CI 调整不单列,查 `git log`。
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/);`0.x` 阶段 minor 位即破坏性变更位。
 
+## [0.7.2] - 2026-08-24
+
+### 修复
+
+- **codex 0.149 起,评审不再静默地报告「0 个问题」。** 这一版把 MCP 工具调用也纳入了审批,`approvalPolicy: "never"` 的含义从「不问、放行」翻成了「不问、拒绝」,于是 agent 每一次 `report_finding` / `write_summary` 都被挡下,一轮评审跑到底、结论页干干净净、日志里也没有任何异常 —— 与「审完确实没发现问题」在界面上完全一样。现在握手时改为申请 `granular` 审批策略并把五道闸门全部关死(这是当前唯一表达「不问且放行」的写法),codex 若不认这个策略再退回 `"never"`;老版本 codex 会忽略它读不懂的字段,因此不需要第二次握手。另外,codex 若拒绝把工具调用交给内置 MCP 服务器,这一轮会直接判失败并报错,不会再退化成一份空结论。(#72)
+
+### 升级须知
+
+- 数据库结构不变,仍是 v21,与 0.7.1、0.7.0 之间可以来回安装。
+- 更新由应用内 updater 接手,无需重新下载 dmg。
+
 ## [0.7.1] - 2026-08-21
 
 ### 修复
@@ -159,6 +170,7 @@
 
 首个公开版本。
 
+[0.7.2]: https://github.com/xieziyu/duetlens/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/xieziyu/duetlens/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/xieziyu/duetlens/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/xieziyu/duetlens/compare/v0.5.0...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duetlens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
补丁版本,只带 #72 一条修复:codex 0.149 起 MCP 工具调用被纳入审批,`approvalPolicy: "never"`
从「不问、放行」翻成「不问、拒绝」,评审会静默地跑完并报告 0 个问题。

- CHANGELOG 中英双份已补 0.7.2 小节与版本链接引用。
- 数据库结构不变,仍是 v21。
- 本地闸门全绿:typecheck / lint / release-notes 正反两条 / package(0.7.2、adhoc 签名、冒烟启动存活)。