### PR TITLE
fix(mcp): stop codex resource probes from failing the round

### DIFF
--- a/scripts/spike-mcp.ts
+++ b/scripts/spike-mcp.ts
@@ -70,6 +70,15 @@ async function main() {
     }),
   );
 
+  // codex 自带 list_mcp_resources 且会主动探;不应答就是一次 -32601,在界面上长成失败的工具调用
+  assert.deepEqual((await client.listResources()).resources, [], 'resources/list 应答空表而非报错');
+  assert.deepEqual(
+    (await client.listResourceTemplates()).resourceTemplates,
+    [],
+    'resources/templates/list 应答空表而非报错',
+  );
+  log('resources:探测返回空表 ✓');
+
   const tools = (await client.listTools()).tools.map((t) => t.name).sort();
   log(`tools: ${tools.join(', ')}`);
   assert.ok(tools.includes('report_finding') && tools.includes('update_finding'), '应含 report/update');

--- a/scripts/spike-sandbox-guard.ts
+++ b/scripts/spike-sandbox-guard.ts
@@ -292,6 +292,29 @@ function silentApprovalTruthTable(): void {
   log('✓ 回显策略真值表:空/缺项/多出的 granular 都不放行');
 }
 
+/**
+ * 9. codex 自带的 MCP 探测工具失败 —— 也挂在 `server: 'duetlens'` 名下,但不是我们的工具。
+ *
+ * 实测:codex 0.149 会自作主张调 list_mcp_resources(它的工具说明还鼓励「优先用 resources」),
+ * 而我们不发布 resources。这类探测失败在事件上与真·未送达同形,拿它判死会毙掉一轮好机审。
+ */
+async function builtinProbeFailureIsHarmless(): Promise<() => Promise<void>> {
+  const f = fixture((agent, turnId) => {
+    agent.emitEvent({
+      kind: 'tool-call',
+      server: MCP_SERVER_NAME,
+      tool: 'list_mcp_resources',
+      status: 'failed',
+      undelivered: 'resources/list failed for `duetlens`: Mcp error: -32601: Method not found',
+    });
+    agent.emitEvent({ kind: 'turn-completed', turnId });
+  });
+  await f.session.start({ cwd: process.cwd(), providers: f.providers, round: 1 });
+  assert.equal(f.agent.disposed, false, 'codex 自带工具探不到东西不是链路故障,本轮得照常跑完');
+  log('✓ codex 自带探测工具失败 → 不判死本轮');
+  return () => f.session.dispose();
+}
+
 async function main(): Promise<void> {
   everyApprovalIsASentinel();
   launchFailuresKeepTheirKind();
@@ -302,6 +325,7 @@ async function main(): Promise<void> {
     declinedMcpElicitationIsNotABreach,
     undeliveredMcpCallKillsRound,
     toolRejectionIsHarmless,
+    builtinProbeFailureIsHarmless,
   ]) {
     const dispose = await t();
     await dispose(); // MCP server 不关,event loop 就一直醒着,进程退不了

--- a/src/backend/mcp/duetlens-mcp-server.ts
+++ b/src/backend/mcp/duetlens-mcp-server.ts
@@ -6,6 +6,8 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
   isInitializeRequest,
   type Tool,
@@ -582,12 +584,18 @@ export class DuetlensMcpServer extends EventEmitter {
   private buildMcpServer(): Server {
     const server = new Server(
       { name: MCP_SERVER_NAME, version: APP_VERSION },
-      { capabilities: { tools: {} } },
+      { capabilities: { tools: {}, resources: {} } },
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: toolsFor(this.providers),
     }));
+
+    // 我们不发布 resources —— 改动面与源码都从工具走。但 codex 会主动探(它自带
+    // list_mcp_resources,提示词还鼓励「优先用 resources」),不应答就是一次 -32601 报错,
+    // 在界面上长成一条失败的工具调用。空列表是这里的诚实答案。
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates: [] }));
 
     server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const { name, arguments: args = {} } = req.params;

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -32,7 +32,7 @@ import {
   MCP_UNDELIVERED_CODE,
   SANDBOX_NOT_APPLIED_CODE,
 } from '@shared/ipc';
-import { MCP_SERVER_NAME } from '@shared/mcp-contract';
+import { isMcpToolName, MCP_SERVER_NAME } from '@shared/mcp-contract';
 import type { AgentErrorKind } from '@shared/agent-events';
 import type { AgentEvent, ConversationalAgent } from '../agent/conversational-agent';
 import type { ReviewStore } from '../db/review-store';
@@ -1109,7 +1109,15 @@ export class ReviewSession {
         // completed,不判死的话这一轮会以「审核完成,0 findings」收场,和「真的没问题」
         // 长得一模一样。判据只认「未送达」这一半:工具自己回的业务拒绝(schema 不合法等)
         // agent 看得到原文、改对了会重来,那是正常来回,不是故障。
-        if (e.kind === 'tool-call' && e.server === MCP_SERVER_NAME && e.undelivered) {
+        // 只认我们自己声明的工具:codex 自带的 MCP 探测工具(list_mcp_resources 等)也挂在
+        // `server: 'duetlens'` 名下,它们探不到东西是常态(我们不提供 resources),
+        // 拿它判死会把一轮好好的机审毙掉。
+        if (
+          e.kind === 'tool-call' &&
+          e.server === MCP_SERVER_NAME &&
+          isMcpToolName(e.tool) &&
+          e.undelivered
+        ) {
           finish({
             kind: 'turn-failed',
             turnId: mine ?? '',

--- a/src/shared/mcp-contract.ts
+++ b/src/shared/mcp-contract.ts
@@ -31,6 +31,14 @@ export const MCP_TOOL = {
 
 export type McpToolName = (typeof MCP_TOOL)[keyof typeof MCP_TOOL];
 
+/**
+ * 这次调用是不是**我们声明的**工具。codex 自带的 MCP 探测工具(list_mcp_resources 等)
+ * 也会以 `server: 'duetlens'` 报事件,不加这道过滤会把它们的失败当成我们自己的工具失联。
+ */
+export function isMcpToolName(name: string): name is McpToolName {
+  return (Object.values(MCP_TOOL) as string[]).includes(name);
+}
+
 /** 跨层被读到的参数名。只收录**两侧都碰**的那些,不做全字段镜像 —— 那会变成第二份 schema。 */
 export const MCP_ARG = {
   findingId: 'finding_id',


### PR DESCRIPTION
A user hit `DUETLENS_MCP_UNDELIVERED codex 没把 list_mcp_resources 交给 Duetlens:
resources/list failed for 'duetlens': Mcp error: -32601: Method not found` on a
matching setup (Duetlens 0.7.2, codex 0.149.1), so the round-failure copy pointing
at a codex version mismatch was misleading.

codex 0.149 ships builtin `list_mcp_resources` / `list_mcp_resource_templates`
tools whenever an MCP server is configured, and their descriptions tell the model
to prefer resources over web search. When the model takes that advice, codex sends
`resources/list` to our server, which declares only the `tools` capability, so the
SDK answers -32601. codex then reports the failure as an mcp tool call under
`server: "duetlens"` (confirmed in a rollout log), and the undelivered-call
safety net matched on the server name alone and killed the whole scan round --
including tearing down the session. It is intermittent because it depends on the
model deciding to probe.

- The MCP server declares the `resources` capability and answers `resources/list`
  and `resources/templates/list` with empty lists. We publish no resources; an
  empty list is the honest answer and keeps the probe from surfacing as a failed
  tool call.
- The undelivered guard now also requires the tool to be one we declare, via a new
  `isMcpToolName` in the shared contract. Failures of codex builtins attributed to
  our server no longer end a good round, and future builtins get the same treatment.

Verification: `spike:mcp` gained assertions that both resource lists answer empty,
and `spike:sandbox-guard` gained a case pinning that a failed builtin probe leaves
the round alive. Both were confirmed to fail with the fix reverted -- the guard case
reproduces the reported error text verbatim. Regression: followup-queue,
reply-stream, session-busy, stop-scan, session-events, adversarial, absorb, plus
typecheck and lint.