### PR TITLE
fix(review): settle rounds left scanning by app exit

### DIFF
--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { isProposalUndoBlocked, REVIEW_RETENTION_MS } from '@shared/domain';
+import { isProposalUndoBlocked, REVIEW_RETENTION_MS, scanDoneStatus } from '@shared/domain';
 import type {
   CodexModelInfo,
   Discussion,
@@ -166,6 +166,13 @@ const SESSION_FORWARDERS: {
     reason: payload.reason,
   }),
 };
+
+/**
+ * 冷启动收尾用的失败原因(见 {@link ReviewManager.failInterruptedRounds})。
+ * 说的是这条 review 自己身上发生过的事实,不借 agent 的口气,也不塞英文错误码。
+ */
+const ROUND_INTERRUPTED_BY_EXIT =
+  '上次退出 Duetlens 时这一轮机审还在跑,进程结束后就中断了 —— 不是 agent 报的错。';
 
 /**
  * 轮次失败的落库形态。turn 失败带得到 agent 归因;编排层自己抛的(source/网络/gh)只有原文,
@@ -756,6 +763,51 @@ export class ReviewManager extends EventEmitter {
     return this.store.pruneReviewsBefore(nowMs - REVIEW_RETENTION_MS);
   }
 
+  /**
+   * 把上次进程留下的「还在扫描中」收掉(轮次判失败、父状态补齐),返回处理的条数。
+   *
+   * 只在启动、尚无活跃会话时调用 —— 会话是进程内的活物,此刻库里任何 scanning 都必然是
+   * 上次退出时留下的,不必去猜它是否还在跑。这条判据同时要求进程唯一,故 main 在开库之前
+   * 先拿单实例锁。收尾后当前轮是 failed,失败卡上的「重试本轮」即可接手
+   * (见 {@link retryRound});已上报的 findings 一条不动。
+   */
+  failInterruptedRounds(): number {
+    let settled = 0;
+    for (const review of this.store.listReviews()) {
+      const current = this.store.getRound(review.id, review.currentRound);
+      const roundLeftScanning = current?.status === 'scanning';
+      /**
+       * 父记录还在说「扫描中」也要收:轮次与父状态是**两张表两次写**,而两条路径的写序还相反
+       * —— 跑完是先写父状态(ReviewSession.runStart)后收轮次,收尾是先收轮次后写父状态。
+       * 崩在任一个缝里都会留下一半,只看其中一边就会漏掉另一种。压根没有轮次记录的那种
+       * (createReview 与紧随的 startRound 之间崩过、或轮次表存在之前的存量行)同样落在这一支。
+       */
+      const reviewLeftScanning = review.status === 'scanning';
+      if (!roundLeftScanning && !reviewLeftScanning) continue;
+      /** 父状态已经翻过去了 = 这一轮其实跑完了,只是 done 还没落库。 */
+      const scanFinished = review.status !== 'scanning' && review.status !== 'failed';
+      // 这一步跑在 IPC 注册与建窗之前,settleRound 外发的轮次事件此刻没有订阅者,落地即丢;
+      // renderer 起来后首次拉取读到的就是收尾后的状态。
+      if (current && roundLeftScanning)
+        this.settleRound(
+          review.id,
+          current.round,
+          // 哪边已经落定就拿哪边去补另一边:拿一句「中断」盖掉真跑完的那一轮,
+          // 用户会看到一条已完成的 review 顶着中断原因和重试入口
+          scanFinished ? 'done' : 'failed',
+          scanFinished ? undefined : new Error(ROUND_INTERRUPTED_BY_EXIT),
+        );
+      if (reviewLeftScanning) {
+        // 反过来:轮次已经跑完(done / stopped)、只差父状态没落的,按正常口径补 ——
+        // 一律判失败等于把一轮真跑出了 findings 的机审说成失败。没有轮次记录的那种才是真失败。
+        const roundFinished = !roundLeftScanning && current != null && current.status !== 'failed';
+        this.store.setReviewStatus(review.id, roundFinished ? scanDoneStatus(review.source) : 'failed');
+      }
+      settled += 1;
+    }
+    return settled;
+  }
+
   /** 显式续接一个非活跃 review 的会话(app 重启后);已活跃则原样返回。 */
   async resumeReview(reviewId: string): Promise<Review> {
     if (!this.sessions.has(reviewId)) await this.resumeSession(reviewId);
@@ -1092,7 +1144,15 @@ export class ReviewManager extends EventEmitter {
         round,
       })
       .then(
-        () => this.settleRound(review.id, round, session.isStopped() ? 'stopped' : 'done'),
+        () => {
+          this.settleRound(review.id, round, session.isStopped() ? 'stopped' : 'done');
+          // 父状态压在收轮之后写:两次写库同一个写序(失败路径亦然),崩在缝里只会留下
+          // 「轮次已终态、父记录仍 scanning」这一种,冷启动据轮次结果反推即可。
+          // 反过来写就分不清这一轮是跑完还是被叫停 —— 两者的父状态是同一个终态。
+          const status = scanDoneStatus(review.source);
+          this.store.setReviewStatus(review.id, status);
+          this.forward({ reviewId: review.id, type: 'status', payload: status });
+        },
         (e: unknown) => {
           this.settleRound(review.id, round, 'failed', e);
           this.forward({ reviewId: review.id, type: 'status', payload: 'failed' });

--- a/src/backend/review/review-session.ts
+++ b/src/backend/review/review-session.ts
@@ -14,7 +14,6 @@ import {
   MACHINE_TURN_KINDS,
   reportFindingSchema,
   resolveFindingSchema,
-  scanDoneStatus,
   updateFindingSchema,
   type Discussion,
   type Finding,
@@ -510,8 +509,9 @@ export class ReviewSession {
       if (pending.length === 0) this.emit('selfcheck-skipped', { reason: 'no-findings' });
       else await this.runTurn('selfcheck', selfCheckPrompt(pending));
     }
-    const source = this.store.getReview(this.reviewId)?.source;
-    this.setStatus(source ? scanDoneStatus(source) : 'reviewing');
+    // 跑完的父状态**不在这里写**:它与「收轮次」是两次写库,而收尾路径是先收轮次后写状态。
+    // 两边写序相反的话,崩在中间会留下「轮次还 scanning、父记录已完成」—— 冷启动就再也分不清
+    // 这一轮是跑完了还是被人叫停。故交给 ReviewManager.launch 在收轮之后统一写。
     return this.store.listFindings(this.reviewId);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { IpcEvents, type CompletionNotice, type ReviewEvent } from '@shared/ipc'
 
 // 开发态与打包版可能同时开着:各自独立 userData,否则两个进程写同一个 sqlite,
 // 且各自的内存态互相看不见对方的写入。DUETLENS_USER_DATA 可显式指向某份数据
-// (如直接开使用版的库排查问题),前提是确保只有一个实例在跑。ready 前必须设好。
+// (如直接开使用版的库排查问题)。ready 前必须设好 —— 单实例锁按这个目录加,见下。
 const userDataOverride = process.env.DUETLENS_USER_DATA;
 if (userDataOverride) {
   app.setPath('userData', path.resolve(userDataOverride));
@@ -25,6 +25,37 @@ const envReady = hydrateEnv();
 
 let manager: ReviewManager;
 let mainWindow: BrowserWindow | null = null;
+/** whenReady 里的初始化是否已走完(IPC 已注册、首个窗口已建)。 */
+let ready = false;
+
+/**
+ * 单实例锁。Electron 按 userData 目录加锁,所以开发态与打包版仍可并存(各自独立目录),
+ * 挡的是**同一份库被两个进程同时开着**。
+ *
+ * 这不只是「窗口别开两个」:冷启动收尾把库里所有 scanning 判成上次退出时的残留
+ * (见 ReviewManager.failInterruptedRounds),而两个进程彼此的会话在内存里互不可见 ——
+ * 后起的那个会把前一个**正在跑的**那一轮判成中断,两边随后还可能各自重试同一轮。
+ * 故必须在开库之前就把这件事定死;userData 已在上面设好,加锁才落在对的目录上。
+ */
+const singleInstance = app.requestSingleInstanceLock();
+if (!singleInstance) {
+  app.quit();
+} else {
+  // 再次点开时把已经在跑的那个窗口亮到前面,而不是让用户以为没反应
+  app.on('second-instance', () => {
+    // 初始化还没走完:窗口本来就要建出来,这会儿抢着建等于赶在 IPC 注册之前,拿到的是个空壳
+    if (!ready) return;
+    // macOS 关掉最后一个窗口后进程还活着(见 window-all-closed),mainWindow 此时是 null ——
+    // 直接返回的话,用户再点一次图标仍然什么都不发生,和没加这个处理器一样
+    if (!mainWindow) {
+      createWindow();
+      return;
+    }
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+  });
+}
 
 /** `ready-to-show` 迟迟不来(dev server 没起、渲染进程崩)也得把窗口放出来,否则只剩一个看不见的进程。 */
 const WINDOW_SHOW_TIMEOUT_MS = 5000;
@@ -106,6 +137,9 @@ function notifyNative(notice: CompletionNotice): void {
 }
 
 app.whenReady().then(async () => {
+  // quit 与 ready 是两条独立的路,拿不到锁时 ready 仍可能先到 —— 这条路上一步都不能往下走,
+  // 尤其不能开库:开了就等于两个进程同时持有同一个 sqlite 连接
+  if (!singleInstance) return;
   await envReady;
 
   const db = openDatabase(path.join(app.getPath('userData'), 'duetlens.db'));
@@ -113,6 +147,9 @@ app.whenReady().then(async () => {
 
   // 过期历史在建窗前清一次:此刻还没有活跃会话,删库不会抽走运行中会话的行。
   manager.pruneExpiredReviews();
+  // 同一个时机收上次退出时中断的机审:codex 会话随进程没了,库里那行还停在 scanning,
+  // 而 review tab 会跨重启恢复 —— 不收尾就是开屏一个永远转的进度条。
+  manager.failInterruptedRounds();
 
   const broadcast = (channel: string, payload: unknown) => {
     for (const w of BrowserWindow.getAllWindows()) w.webContents.send(channel, payload);
@@ -142,6 +179,7 @@ app.whenReady().then(async () => {
   manager.on('review-event', (e: ReviewEvent) => notifier(e));
 
   createWindow();
+  ready = true;
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();


### PR DESCRIPTION
A codex session dies with the process, but the database row does not: the
review stays `scanning` forever. Now that review tabs are restored across
restarts, that turns into a spinner that never stops on the next launch.

- Cold start settles anything the last process left mid-scan. The parent
  status is the trigger, so all three shapes are covered: a genuinely
  interrupted round, a half-written settle, and a review with no round row
  at all (crash between `createReview` and `startRound`, or pre-rounds-table
  legacy rows).
- Whichever side already landed is used to repair the other one. A round
  left `scanning` under a finished parent becomes `done`, not `failed` --
  labelling a completed scan as interrupted would hand the user a bogus
  failure card and retry button.
- Both write paths now settle the round before the parent status, so the
  only half-written shape left is one the sweep can reason about. Telling a
  natural finish apart from a user stop is impossible from the parent status
  alone, since both land on `scanDoneStatus`.
- Single instance lock, taken before the database is opened. The sweep
  assumes this process is the only one holding the file; without the lock a
  second instance would fail rounds the first one is actively running. A
  second launch now focuses the running window, or creates one if the last
  window was closed (macOS keeps the process alive).

Verified on a copy of the dev database driven through a real launch: all
five half-written shapes settle as intended, an already-stopped round is
left untouched, and a second `npm start` exits immediately while the first
instance survives.