### PR TITLE
fix(review): dedupe tab labels and add a hover card

### DIFF
--- a/src/renderer/components/ReviewTabs.css
+++ b/src/renderer/components/ReviewTabs.css
@@ -63,7 +63,8 @@
   flex: none;
   opacity: 0.8;
 }
-/* 本地分支这档的 ref 就是整个标签(标题与它同名,已被去重),长分支名全靠它自己截 */
+/* 身份(PR #号 / 分支名):这枚 tab 认人的那半句,故最后才轮到被截。
+   它是唯一按内容占宽的项,标题只吃它剩下的 —— 见下面 .ttl 的 flex-basis */
 .rev-tab .lbl {
   flex: 0 1 auto;
   min-width: 0;
@@ -73,10 +74,10 @@
   font-size: 11.5px;
 }
 
-/* 两者都能缩,但先缩标题:收缩量按基准宽 × 系数分配,给标题一个大系数,
-   ref(它是这枚 tab 的身份)就只在标题已经缩没了之后才轮到被截 */
+/* 基准宽取 0 再 grow:标题占的永远只是身份用剩的空间,收缩轮不到身份头上。
+   (按 flex-shrink 系数分配是**按比例**的,系数开到 100 也只是让身份少截一点、不是不截) */
 .rev-tab .ttl {
-  flex: 0 100 auto;
+  flex: 1 1 0;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
@@ -183,4 +184,39 @@
 }
 .rev-tabs .tab-notice button:hover {
   text-decoration: underline;
+}
+
+/* tab 悬浮卡:答「这枚 tab 是哪条 review」—— 项目 + 身份一行,完整标题一行。
+   fixed 而非 absolute:tabs-strip 会横向滚动,绝对定位的卡片会被它的 overflow 裁掉。
+   位置由 JS 按实测矩形给。 */
+.rev-tabs .tab-tip {
+  position: fixed;
+  z-index: 65;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 320px;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-3);
+  box-shadow: 0 6px 18px rgb(0 0 0 / 0.28);
+  font-size: 11.5px;
+  line-height: 1.5;
+  pointer-events: none;
+}
+/* 身份不折行:它是认人的那半句,折了反而读不出边界 */
+.rev-tabs .tab-tip .tip-id {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--text-dim);
+}
+/* 标题折行,但封到两行:长 PR 标题原样铺开会变成一堵墙 */
+.rev-tabs .tab-tip .tip-ttl {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  color: var(--text);
 }

--- a/src/renderer/components/ReviewTabs.tsx
+++ b/src/renderer/components/ReviewTabs.tsx
@@ -1,7 +1,8 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { REVIEW_STATUS_LABELS } from '@shared/domain';
 import type { ReviewTab } from '../review/tabs';
 import type { TabMeta } from '../review/useTabMeta';
-import { shortSourceLabel } from '../review/source-ref';
+import { shortSourceLabel, sourceTitleRest, tabTipText } from '../review/source-ref';
 import { SourceIcon } from './SourceIcon';
 import './ReviewTabs.css';
 
@@ -16,6 +17,9 @@ export interface TabNotice {
    */
   sticky?: boolean;
 }
+
+/** 悬浮卡的出现延迟 */
+const TIP_DELAY_MS = 420;
 
 /**
  * 打开着的 review。**tab 只是视图的把手** —— 关掉一枚不动后端会话,那条审核继续在后台跑
@@ -42,18 +46,19 @@ export function ReviewTabs({
   /** ＋:回入口发起新审核(不直接建 tab —— 没有 review 就没有 tab) */
   onNew: () => void;
 }): React.JSX.Element {
+  const tip = useTabTip();
   return (
     <div className="rev-tabs" role="tablist" aria-label="打开的审核">
-      <div className="tabs-strip">
+      {/* 横向滚动会把卡片留在原处指向已经移开的那枚 tab */}
+      <div className="tabs-strip" onScroll={tip.hide}>
         {tabs.map((t) => {
           const m = meta[t.reviewId];
           const label = m ? shortSourceLabel(m.source, m.sourceRef) : '…';
-          // 本地分支的 title 就是 ref 本身,两个都画等于把同一句话说两遍、还挤掉了别的 tab
-          const title = m && m.title !== label ? m.title : '';
+          const rest = m ? sourceTitleRest(m.source, m.sourceRef, m.title) : '';
+          const tipText = m ? tabTipText(m) : '';
           const on = t.reviewId === activeId;
           const dot = m?.status === 'scanning' ? 'scanning' : m?.status === 'failed' ? 'failed' : null;
-          // 未读数与状态点二选一:210px 的 tab 上两样都画就谁也读不清。
-          // 状态本身不会因此丢失 —— title 里一直带着它。
+          // 未读数与状态点二选一:210px 的 tab 上两样都画就谁也读不清
           const unread = !on && m ? m.unread : 0;
           return (
             <div key={t.reviewId} className={`rev-tab${on ? ' on' : ''}`}>
@@ -61,22 +66,39 @@ export function ReviewTabs({
                 className="tab-main"
                 role="tab"
                 aria-selected={on}
-                title={[
-                  label,
-                  title,
-                  m ? REVIEW_STATUS_LABELS[m.status ?? 'scanning'] : null,
-                  unread > 0 ? `新增 ${unread} 条 finding` : null,
-                ]
-                  .filter(Boolean)
-                  .join(' · ')}
-                onClick={() => onActivate(t.reviewId)}
-                onAuxClick={(e) => e.button === 1 && onClose(t.reviewId)}
+                // 状态与未读也得进这里:显式 aria-label 会盖掉后代,挂在角标 / 状态点上的说明读不到
+                aria-label={
+                  m
+                    ? [
+                        tipText,
+                        rest,
+                        REVIEW_STATUS_LABELS[m.status ?? 'scanning'],
+                        unread > 0 ? `新增 ${unread} 条 finding` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')
+                    : label
+                }
+                onMouseEnter={(e) => m && tip.show(e.currentTarget, tipText, rest)}
+                onMouseLeave={tip.hide}
+                onFocus={(e) => m && tip.show(e.currentTarget, tipText, rest)}
+                onBlur={tip.hide}
+                onClick={() => {
+                  tip.hide();
+                  onActivate(t.reviewId);
+                }}
+                onAuxClick={(e) => {
+                  // 元素被移除不会派发 mouseleave,不先收的话卡片会留在原地指着一枚已经没了的 tab
+                  if (e.button !== 1) return;
+                  tip.hide();
+                  onClose(t.reviewId);
+                }}
               >
                 <SourceIcon source={m?.source} />
                 <span className="mono lbl">{label}</span>
-                {title && <span className="ttl">{title}</span>}
+                {rest && <span className="ttl">{rest}</span>}
                 {unread > 0 ? (
-                  <span className="tab-badge" title={`后台新报出 ${unread} 条 finding`}>
+                  <span className="tab-badge" aria-hidden>
                     {unread > 99 ? '99+' : unread}
                   </span>
                 ) : (
@@ -86,8 +108,7 @@ export function ReviewTabs({
               <button
                 className="tab-close"
                 onClick={() => onClose(t.reviewId)}
-                title="关闭这枚 tab(审核不受影响)"
-                aria-label={`关闭 ${label}`}
+                aria-label={`关闭 ${label}(审核不受影响)`}
               >
                 <CloseIcon />
               </button>
@@ -95,7 +116,7 @@ export function ReviewTabs({
           );
         })}
       </div>
-      <button className="tab-add" onClick={onNew} title="发起新审核">
+      <button className="tab-add" onClick={onNew} aria-label="发起新审核">
         <PlusIcon />
       </button>
       {notice && (
@@ -106,8 +127,72 @@ export function ReviewTabs({
           )}
         </span>
       )}
+      {tip.at && (
+        <div
+          className="tab-tip"
+          role="tooltip"
+          style={{ left: tip.at.left, right: tip.at.right, top: tip.at.y }}
+        >
+          <span className="mono tip-id">{tip.at.id}</span>
+          {tip.at.title && <span className="tip-ttl">{tip.at.title}</span>}
+        </div>
+      )}
     </div>
   );
+}
+
+interface TipAt {
+  /** 项目名 + 完整身份 */
+  id: string;
+  /** 去重后的完整标题;tab 上那份多半被截过 */
+  title: string;
+  y: number;
+  /** 左右二选一:贴左边缘的那枚从左对齐,贴右边缘的从右对齐 */
+  left?: number;
+  right?: number;
+}
+
+/**
+ * tab 的悬浮卡。**不用原生 `title`** —— 它在这条栏上不出现,而且排不了版;
+ * 位置用 fixed + 实测矩形算:tab 条自己会横向滚动,绝对定位会被 strip 的 overflow 裁掉。
+ */
+function useTabTip(): {
+  at: TipAt | null;
+  show: (el: HTMLElement, id: string, title: string) => void;
+  hide: () => void;
+} {
+  const [at, setAt] = useState<TipAt | null>(null);
+  const timer = useRef<number | null>(null);
+
+  const hide = useCallback(() => {
+    if (timer.current !== null) window.clearTimeout(timer.current);
+    timer.current = null;
+    setAt(null);
+  }, []);
+
+  const show = useCallback((el: HTMLElement, id: string, title: string) => {
+    if (timer.current !== null) window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => {
+      // 等待期间这枚 tab 可能已被关掉:脱离文档的元素量出来是 0×0,卡片会飞到左上角
+      if (!el.isConnected) return;
+      const r = el.getBoundingClientRect();
+      // 右半边的 tab 改为右对齐:卡片宽度要等它排完版才知道,靠估宽去夹会把卡片推离它指的那枚 tab
+      const toRight = r.left > window.innerWidth / 2;
+      setAt({
+        id,
+        title,
+        y: r.bottom + 4,
+        left: toRight ? undefined : Math.max(6, r.left),
+        right: toRight ? Math.max(6, window.innerWidth - r.right) : undefined,
+      });
+    }, TIP_DELAY_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (timer.current !== null) window.clearTimeout(timer.current);
+  }, []);
+
+  return { at, show, hide };
 }
 
 const CloseIcon = () => (

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -161,7 +161,7 @@ const REVIEW: Review = {
   model: 'gpt-5.6-sol',
   reasoningEffort: 'high',
   intensity: 'adversarial',
-  title: 'feat: streaming transcode pipeline',
+  title: 'feat/streaming-transcode · feat: streaming transcode pipeline',
   status: 'completed',
   summaryBody: '本次改动引入并发编码管线,整体方向合理,但并发计数存在数据竞争,需修正。',
   summaryFiles: [
@@ -183,14 +183,14 @@ const REVIEW: Review = {
 
 // 入口「最近的审核」/ 历史屏列表 fixture(覆盖三来源 × 状态 × 时间分桶)
 const RECENT_REVIEWS: RecentReview[] = [
-  { ...REVIEW, id: 'r1', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#482', title: 'feat: streaming transcode', status: 'reviewing', findingCount: 3, discussionCount: 2, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 23 * 60_000 },
-  { ...REVIEW, id: 'r2', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#479', title: 'fix: episode duration off-by-one on live cutover', status: 'submitted', findingCount: 5, discussionCount: 0, submittedCount: 4, updatedAt: now - 5 * 3600_000 },
-  { ...REVIEW, id: 'r3', source: 'local-branch', sourceRef: 'fix/feed-encoding-for-legacy-clients', title: 'fix/feed-encoding-for-legacy-clients', repoPath: '/Users/dev/podcast-go', status: 'completed', findingCount: 0, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 26 * 3600_000 },
-  { ...REVIEW, id: 'r4', source: 'gitbutler-vbranch', sourceRef: 'virtual/api-cleanup', title: 'virtual/api-cleanup', repoPath: '/Users/dev/duetlens', status: 'completed', findingCount: 2, discussionCount: 1, submittedCount: 0, updatedAt: now - 4 * 86_400_000 },
-  { ...REVIEW, id: 'r5', source: 'github-pr', sourceRef: 'xieziyu/duetlens#471', title: 'refactor: extract prompt resolver into shared', repoPath: null, status: 'submitted', findingCount: 8, discussionCount: 0, submittedCount: 6, currentRound: 1, summaryRound: 1, updatedAt: now - 10 * 86_400_000 },
-  { ...REVIEW, id: 'r6', source: 'local-branch', sourceRef: 'fix/transcode-timeout', repoPath: '/Users/dev/podcast-go', title: 'fix/transcode-timeout', status: 'failed', findingCount: 1, discussionCount: 0, submittedCount: 0, updatedAt: now - 17 * 86_400_000 },
+  { ...REVIEW, id: 'r1', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#482', title: '#482 · feat: streaming transcode', status: 'reviewing', findingCount: 3, discussionCount: 2, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 23 * 60_000 },
+  { ...REVIEW, id: 'r2', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#479', title: '#479 · fix: episode duration off-by-one on live cutover', status: 'submitted', findingCount: 5, discussionCount: 0, submittedCount: 4, updatedAt: now - 5 * 3600_000 },
+  { ...REVIEW, id: 'r3', source: 'local-branch', sourceRef: 'fix/feed-encoding-for-legacy-clients', title: 'fix/feed-encoding-for-legacy-clients · fix: keep latin-1 feed output for legacy clients', repoPath: '/Users/dev/podcast-go', status: 'completed', findingCount: 0, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 26 * 3600_000 },
+  { ...REVIEW, id: 'r4', source: 'gitbutler-vbranch', sourceRef: 'virtual/api-cleanup', title: 'GitButler · virtual/api-cleanup', repoPath: '/Users/dev/duetlens', status: 'completed', findingCount: 2, discussionCount: 1, submittedCount: 0, updatedAt: now - 4 * 86_400_000 },
+  { ...REVIEW, id: 'r5', source: 'github-pr', sourceRef: 'xieziyu/duetlens#471', title: '#471 · refactor: extract prompt resolver into shared', repoPath: null, status: 'submitted', findingCount: 8, discussionCount: 0, submittedCount: 6, currentRound: 1, summaryRound: 1, updatedAt: now - 10 * 86_400_000 },
+  { ...REVIEW, id: 'r6', source: 'local-branch', sourceRef: 'fix/transcode-timeout', repoPath: '/Users/dev/podcast-go', title: 'fix/transcode-timeout · fix: raise transcode timeout to 5m', status: 'failed', findingCount: 1, discussionCount: 0, submittedCount: 0, updatedAt: now - 17 * 86_400_000 },
   // 距 30 天保留期只剩 3 天:历史屏的临期标记只有这种行才出现,没有它就自查不到
-  { ...REVIEW, id: 'r7', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#440', title: 'chore: bump ffmpeg to 7.1', status: 'completed', findingCount: 2, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 27 * 86_400_000 },
+  { ...REVIEW, id: 'r7', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#440', title: '#440 · chore: bump ffmpeg to 7.1', status: 'completed', findingCount: 2, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 27 * 86_400_000 },
 ];
 
 // 满载提示 fixture:正在跑的会话(?busy=1..4)
@@ -683,7 +683,9 @@ export function installPreviewApi(): void {
   // 可变:重跑 stub 会改 currentRound / status,模拟后端回推后的新值
   let review: Review = {
     ...REVIEW,
-    ...(asGithub ? { source: 'github-pr', sourceRef: 'xieziyu/podcast-go#482', repoPath: null } : {}),
+    ...(asGithub
+      ? { source: 'github-pr' as const, sourceRef: 'xieziyu/podcast-go#482', repoPath: null, title: '#482 · feat: streaming transcode pipeline' }
+      : {}),
     ...(asScanning ? { status: 'scanning' as const } : {}),
     ...(asRoundFailed ? { status: 'failed' as const } : {}),
   };

--- a/src/renderer/review/source-ref.ts
+++ b/src/renderer/review/source-ref.ts
@@ -18,3 +18,80 @@ export function shortSourceLabel(source: Review['source'] | undefined, ref: stri
   const pr = source === 'github-pr' ? parsePrRefLoose(ref) : null;
   return pr ? `#${pr.num}` : ref;
 }
+
+/** 悬浮卡用的完整来源标识:PR 补回仓库,其余给 ref 全文(tab 上那份可能被截过)。 */
+export function fullSourceLabel(source: Review['source'] | undefined, ref: string): string {
+  const pr = source === 'github-pr' ? parsePrRefLoose(ref) : null;
+  if (!pr) return ref;
+  return pr.nwo ? `${pr.nwo}#${pr.num}` : `#${pr.num}`;
+}
+
+/** 图标已经表达过的来源名;它出现在 title 开头时与图标重复。 */
+const SOURCE_NAME: Partial<Record<NonNullable<Review['source']>, string>> = {
+  'gitbutler-vbranch': 'GitButler',
+};
+
+/**
+ * title 里跟在身份之后的那半句。backend 各 source 都按 `<身份> · <正文>` 拼 title,
+ * 而身份(与来源图标)在界面上已经单独画了一遍 —— 逐段剥掉开头这些重复,只留真正的新信息;
+ * 剥空说明这条 title 除了身份什么都没带,那就一个字都不画。
+ * 剥的是**开头连续**的重复段:PR 标题自己带 ` · ` 的部分不受影响。
+ */
+export function sourceTitleRest(
+  source: Review['source'] | undefined,
+  ref: string,
+  title: string | null | undefined,
+): string {
+  if (!title) return '';
+  const dup = new Set(
+    [shortSourceLabel(source, ref), ref, source ? SOURCE_NAME[source] : undefined].filter(
+      (s): s is string => Boolean(s),
+    ),
+  );
+  let rest = title;
+  for (;;) {
+    const i = rest.indexOf(' · ');
+    const head = i === -1 ? rest : rest.slice(0, i);
+    if (!dup.has(head)) return rest;
+    if (i === -1) return '';
+    rest = rest.slice(i + 3);
+  }
+}
+
+/**
+ * 展示用仓库名:本地路径 basename 优先,其次从 github sourceRef 取 repo 段;都拿不到给 null。
+ * 入口最近列表、历史屏与 tab 悬浮卡共用一份 —— 这几处指的是同一个「项目」。
+ */
+export function repoName(r: {
+  source: Review['source'];
+  sourceRef: string;
+  repoPath: string | null;
+}): string | null {
+  if (r.repoPath) {
+    const base = r.repoPath.replace(/[/\\]+$/, '').split(/[/\\]/).pop();
+    if (base) return base;
+  }
+  if (r.source === 'github-pr') {
+    // 走 parsePrRefLoose 而不是就地再写一条:未锚定的通用正则遇到完整 PR 链接会先咬中
+    // `github.com/<owner>`,把 owner 当成项目名
+    const nwo = parsePrRefLoose(r.sourceRef)?.nwo;
+    if (nwo) return nwo.split('/').pop() ?? null;
+  }
+  return null;
+}
+
+/**
+ * tab 悬浮卡那一句:项目名 + 完整身份。**只答「这枚 tab 是哪条 review」** ——
+ * 光有分支名认不出是哪个仓库的分支,而同名分支在两个项目里同时开审是常态。
+ * PR 的 `owner/repo#123` 自己已经带了项目名,不再前缀一遍。
+ */
+export function tabTipText(r: {
+  source: Review['source'];
+  sourceRef: string;
+  repoPath: string | null;
+}): string {
+  const id = fullSourceLabel(r.source, r.sourceRef);
+  const hasNwo = r.source === 'github-pr' && Boolean(parsePrRefLoose(r.sourceRef)?.nwo);
+  const repo = hasNwo ? null : repoName(r);
+  return repo ? `${repo} · ${id}` : id;
+}

--- a/src/renderer/review/useTabMeta.ts
+++ b/src/renderer/review/useTabMeta.ts
@@ -7,6 +7,8 @@ export interface TabMeta {
   title: string;
   sourceRef: string;
   source: Review['source'];
+  /** 悬浮卡要的项目名从它来(见 repoName);github 源可以没有 */
+  repoPath: string | null;
   status: ReviewStatus | null;
   /** 这枚 tab 在后台期间新报出的 finding 数;激活即清零。 */
   unread: number;
@@ -57,7 +59,13 @@ export function useTabMeta(
       if (!alive || !r) return;
       setInfo((prev) => ({
         ...prev,
-        [id]: { title: r.title ?? r.sourceRef, sourceRef: r.sourceRef, source: r.source, status: r.status },
+        [id]: {
+          title: r.title ?? r.sourceRef,
+          sourceRef: r.sourceRef,
+          source: r.source,
+          repoPath: r.repoPath,
+          status: r.status,
+        },
       }));
     };
 

--- a/src/renderer/screens/HistoryScreen.tsx
+++ b/src/renderer/screens/HistoryScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RecentReview } from '@shared/ipc';
 import { REVIEW_RETENTION_DAYS, REVIEW_RETENTION_MS, type ReviewStatus, type SourceKind } from '@shared/domain';
 import { GhIcon, GitButlerIcon, LocalBranchIcon } from './entry/icons';
+import { repoName } from '../review/source-ref';
 import './HistoryScreen.css';
 
 // 全部审核历史屏。数据来自 review:list-recent;
@@ -103,7 +104,7 @@ export function HistoryScreen({ onOpen }: { onOpen: (id: string) => void }): Rea
       if (srcFilter !== 'all' && r.source !== srcFilter) return false;
       if (statFilter !== 'all' && statusGroup(r.status) !== statFilter) return false;
       if (q) {
-        const hay = `${r.title ?? ''} ${repoLabel(r)} ${r.sourceRef}`.toLowerCase();
+        const hay = `${r.title ?? ''} ${repoName(r) ?? r.source} ${r.sourceRef}`.toLowerCase();
         if (!hay.includes(q)) return false;
       }
       return true;
@@ -242,7 +243,7 @@ export function HistoryScreen({ onOpen }: { onOpen: (id: string) => void }): Rea
 function metaParts(r: RecentReview, expiring: number | null): React.JSX.Element {
   return (
     <>
-      <span>{repoLabel(r)}</span>
+      <span>{repoName(r) ?? r.source}</span>
       <span className="dot" />
       <span className={r.findingCount === 0 ? 'find zero' : 'find'}>{r.findingCount} findings</span>
       <span className="dot" />
@@ -330,19 +331,6 @@ function bucketOf(ts: number, now: number): Bucket {
   if (ts >= startOfToday) return 'today';
   if (ts >= now - 7 * DAY_MS) return 'week';
   return 'older';
-}
-
-/** 展示用仓库名:本地路径 basename 优先,其次从 github sourceRef 取 repo 段。 */
-function repoLabel(r: RecentReview): string {
-  if (r.repoPath) {
-    const base = r.repoPath.replace(/[/\\]+$/, '').split(/[/\\]/).pop();
-    if (base) return base;
-  }
-  if (r.source === 'github-pr') {
-    const m = r.sourceRef.match(/([^/]+)\/([^/#]+)/);
-    if (m) return m[2];
-  }
-  return r.source;
 }
 
 function formatWhen(ts: number): string {

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -5,7 +5,7 @@ import type { DiffFile } from '@shared/diff';
 import type { AddFindingInput, DiscussionAnchor, FindingEditInput, LiveCapacity } from '@shared/ipc';
 import { useSettings } from '../settings/SettingsProvider';
 import { SourceIcon } from '../components/SourceIcon';
-import { parsePrRefLoose } from '../review/source-ref';
+import { parsePrRefLoose, sourceTitleRest } from '../review/source-ref';
 import { useIsActiveTab } from '../review/TabVisibility';
 import { useReviewStream, type ReplyStream } from '../review/useReviewStream';
 import { useReviewUiState } from '../review/useReviewUiState';
@@ -681,6 +681,8 @@ export function ReviewScreen({
   // 顶栏源标识:PR 拆成「#号 chip + 仓库 nwo 尾注」,分支 / vbranch 直接显示 ref
   const pr = isGithub ? parsePrRefLoose(review.sourceRef) : null;
   const sourceLabel = pr ? `#${pr.num}` : (review?.sourceRef ?? '…');
+  // 标题去掉与 chip 重复的开头(backend 按 `<身份> · <正文>` 拼);剥空就只剩 chip
+  const titleRest = review ? sourceTitleRest(review.source, review.sourceRef, review.title) : '';
 
   // URL 解析与打开都在 main 侧(ref 可能只有 PR 号,需借 repoPath 推断仓库)
   const openInBrowser = useCallback(() => {
@@ -734,7 +736,7 @@ export function ReviewScreen({
               ← {review.baseRef}
             </span>
           )}
-          <span className="title">{review?.title ?? '加载中…'}</span>
+          <span className="title">{review ? titleRest : '加载中…'}</span>
           {pr?.nwo && <span className="mono nwo">{pr.nwo}</span>}
         </div>
         <span className="spacer" />

--- a/src/renderer/screens/entry/RecentReviews.tsx
+++ b/src/renderer/screens/entry/RecentReviews.tsx
@@ -1,6 +1,7 @@
 import type { RecentReview } from '@shared/ipc';
 import type { ReviewStatus, SourceKind } from '@shared/domain';
 import { GhIcon, GitButlerIcon, LocalBranchIcon } from './icons';
+import { repoName } from '../../review/source-ref';
 
 /** 入口只摆最近这些条,全量翻阅走审核历史屏。 */
 const LIMIT = 20;
@@ -37,7 +38,7 @@ export function RecentReviews({
               <div className="m">
                 <div className="t">{r.title ?? r.sourceRef}</div>
                 <div className="meta mono">
-                  <span>{repoLabel(r)}</span>
+                  <span>{repoName(r) ?? r.source}</span>
                   <span className="dot" />
                   <span className={r.findingCount === 0 ? 'find zero' : 'find'}>{r.findingCount} findings</span>
                   {r.submittedCount > 0 ? (
@@ -105,17 +106,4 @@ function StatusChip({ status }: { status: ReviewStatus }) {
       {m.label}
     </span>
   );
-}
-
-/** 展示用仓库名:优先本地路径 basename,其次从 github sourceRef 取 repo 段。 */
-function repoLabel(r: RecentReview): string {
-  if (r.repoPath) {
-    const base = r.repoPath.replace(/[/\\]+$/, '').split(/[/\\]/).pop();
-    if (base) return base;
-  }
-  if (r.source === 'github-pr') {
-    const m = r.sourceRef.match(/([^/]+)\/([^/#]+)/);
-    if (m) return m[2];
-  }
-  return r.source;
 }


### PR DESCRIPTION
Tab labels said the same thing twice: backend composes review titles as
`<identity> · <subject>`, and the tab already draws that identity next to the
source icon — so a PR read `#4218` + `#4218 · refactor(...)`, and a GitButler
branch read `feat/x` + `GitButler · feat/x`, with both halves truncated.

- strip the leading duplicated segments off the title (`sourceTitleRest`);
  the review topbar had the same duplication and uses the same helper
- let the title shrink to zero before the identity is truncated. The old
  `flex-shrink: 100` on the title only spread the shrink proportionally, so
  the identity still lost characters
- replace the native `title` tooltip (which never showed up on the tab strip)
  with an in-app hover card: project + full identity on one line, the full
  title on the next
- fold the two duplicated `repoLabel` copies (history, recent list) into one
  `repoName`, and fix the pre-existing case where a full PR URL resolved to
  the owner instead of the repo

Preview fixtures now mirror the title format the backend actually produces —
without that, the duplication was not reproducible in `preview:ui`.