### PR TITLE
feat(review): raise tab limit to 20 and scroll the tab strip

### DIFF
--- a/src/renderer/components/ReviewTabs.css
+++ b/src/renderer/components/ReviewTabs.css
@@ -22,6 +22,18 @@
   display: none;
 }
 
+/* 溢出那侧的渐隐:滚动条藏掉了,不给这个就完全看不出后面还有 tab。
+   用 mask 而不是叠一层伪元素 —— 遮罩按元素自己的盒子算,不会跟着内容滚走。 */
+.rev-tabs .tabs-strip[data-fade='l'] {
+  mask-image: linear-gradient(90deg, transparent, #000 26px);
+}
+.rev-tabs .tabs-strip[data-fade='r'] {
+  mask-image: linear-gradient(90deg, #000 calc(100% - 26px), transparent);
+}
+.rev-tabs .tabs-strip[data-fade='lr'] {
+  mask-image: linear-gradient(90deg, transparent, #000 26px, #000 calc(100% - 26px), transparent);
+}
+
 .rev-tab {
   display: flex;
   align-items: center;
@@ -164,7 +176,10 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  min-width: 0;
+  /* 不参与收缩:tab 条挤满时(上限二十枚,满载提示恰好只在这时出现)按比例分摊会把它压成
+     几个字加省略号 —— 让 tab 条多滚一点,别把话说不完整。max-width 兜住长文案不反过来吃掉整条。 */
+  flex: none;
+  max-width: 340px;
   margin-left: auto;
   padding: 0 12px;
   overflow: hidden;

--- a/src/renderer/components/ReviewTabs.tsx
+++ b/src/renderer/components/ReviewTabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { REVIEW_STATUS_LABELS } from '@shared/domain';
 import type { ReviewTab } from '../review/tabs';
 import type { TabMeta } from '../review/useTabMeta';
@@ -47,10 +47,20 @@ export function ReviewTabs({
   onNew: () => void;
 }): React.JSX.Element {
   const tip = useTabTip();
+  const strip = useStripScroll(activeId, tabs.length);
   return (
     <div className="rev-tabs" role="tablist" aria-label="打开的审核">
       {/* 横向滚动会把卡片留在原处指向已经移开的那枚 tab */}
-      <div className="tabs-strip" onScroll={tip.hide}>
+      <div
+        className="tabs-strip"
+        ref={strip.ref}
+        data-fade={strip.fade}
+        onScroll={() => {
+          tip.hide();
+          strip.sync();
+        }}
+        onWheel={strip.onWheel}
+      >
         {tabs.map((t) => {
           const m = meta[t.reviewId];
           const label = m ? shortSourceLabel(m.source, m.sourceRef) : '…';
@@ -139,6 +149,91 @@ export function ReviewTabs({
       )}
     </div>
   );
+}
+
+/** 两端渐隐的宽度;滚动落位也留这么多,免得刚滚进来的那枚正压在渐隐底下。 */
+const FADE_PX = 26;
+
+/**
+ * tab 条的横向滚动。上限放到二十几枚之后「一屏放不下」是常态(1280 窗口约 9 枚到顶),
+ * 于是两件事必须由代码兜住:
+ *
+ * 1. **活跃那枚要自己滚进视野**。⌃⇥ 切过去、或关掉活跃 tab 后右邻接位时,正文换了而 tab 条
+ *    不动的话,条上一枚活跃的都看不见 —— 人会以为切错了。
+ * 2. **两端要有「后面还有」的迹象**。滚动条是藏掉的(34px 的条上摆一根横滚条太吵),
+ *    没有渐隐就完全看不出溢出。
+ *
+ * 落位自己按实测矩形算,不用 `scrollIntoView`:后者会连带滚祖先,且平滑滚动在预览面板里是 no-op。
+ */
+function useStripScroll(
+  activeId: string | null,
+  count: number,
+): {
+  ref: React.RefObject<HTMLDivElement>;
+  fade: 'l' | 'r' | 'lr' | undefined;
+  sync: () => void;
+  onWheel: (e: React.WheelEvent<HTMLDivElement>) => void;
+} {
+  const ref = useRef<HTMLDivElement>(null);
+  const [fade, setFade] = useState<'l' | 'r' | 'lr' | undefined>(undefined);
+
+  const sync = useCallback(() => {
+    const s = ref.current;
+    if (!s) return;
+    // 1px 容差:缩放下 scrollWidth 带小数,严格比较会让不该出现的那侧渐隐常驻
+    const l = s.scrollLeft > 1;
+    const r = s.scrollLeft < s.scrollWidth - s.clientWidth - 1;
+    setFade(l && r ? 'lr' : l ? 'l' : r ? 'r' : undefined);
+  }, []);
+
+  /** 幂等:已经在视野里就一动不动 —— 点一枚看得见的 tab 不该把整条甩一下。 */
+  const keepVisible = useCallback(() => {
+    const s = ref.current;
+    const el = s?.querySelector<HTMLElement>('.rev-tab.on');
+    if (!s || !el) return;
+    // offsetLeft 不可靠(strip 没定位,offsetParent 是更外面的某个祖先),一律用实测矩形的差
+    const sr = s.getBoundingClientRect();
+    const r = el.getBoundingClientRect();
+    // 首尾那枚会被浏览器自己夹回 0 / 上限,不必单独判
+    if (r.left < sr.left + FADE_PX) s.scrollLeft += r.left - sr.left - FADE_PX;
+    else if (r.right > sr.right - FADE_PX) s.scrollLeft += r.right - sr.right + FADE_PX;
+  }, []);
+
+  /**
+   * 布局期做:留到 effect 才滚的话,活跃那枚会先在屏外绘出一帧。
+   *
+   * **不跟着标题异步补齐重跑**:能滚的时候每枚 tab 都顶在 min-width 上(见 ReviewTabs.css),
+   * 内容宽恒等于 116×N,标题从 '…' 补成全称一个像素都不动。
+   */
+  useLayoutEffect(() => {
+    keepVisible();
+    sync();
+  }, [activeId, count, keepVisible, sync]);
+
+  /**
+   * 可视宽变了同样要重新落位 —— 窗口缩窄、右侧那句轻提示出现都会挤掉宽度,而 scrollLeft 不动,
+   * 活跃那枚就这么被留在屏外。用 ResizeObserver 而非 window.resize:提示进出不发 resize,
+   * 而要量的本来就是这一条 strip。
+   */
+  useEffect(() => {
+    const s = ref.current;
+    if (!s) return;
+    const ro = new ResizeObserver(() => {
+      keepVisible();
+      sync();
+    });
+    ro.observe(s);
+    return () => ro.disconnect();
+  }, [keepVisible, sync]);
+
+  // 竖向滚轮也拿来横滚:鼠标只有这一个轴,不接的话二十几枚 tab 只剩触控板横扫一条路
+  const onWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    const s = ref.current;
+    if (!s || Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+    s.scrollLeft += e.deltaY;
+  }, []);
+
+  return { ref, fade, sync, onWheel };
 }
 
 interface TipAt {

--- a/src/renderer/review/tabs.ts
+++ b/src/renderer/review/tabs.ts
@@ -24,10 +24,11 @@ export interface TabState {
 
 /**
  * 同时开着的 tab 上限。后台 tab 是**挂载但隐藏**的(切回来不丢在途回复残文 / 动作流 / 草稿 /
- * 滚动位置),每一枚都压着一整份 diff DOM,故要有上限。与后端 `maxLiveSessions` 无关 ——
- * 开 tab 只读库、不占会话位。
+ * 滚动位置),每一枚都压着一整份 diff DOM,故要有上限 —— 拦的是内存,不是屏宽:
+ * 一屏放不下由 tab 条自己横滚接住(见 ReviewTabs 的 useStripScroll)。
+ * 与后端 `maxLiveSessions` 无关 —— 开 tab 只读库、不占会话位。
  */
-export const MAX_TABS = 6;
+export const MAX_TABS = 20;
 
 export const EMPTY_TABS: TabState = { tabs: [], activeId: null };
 

--- a/src/renderer/review/useTabMeta.ts
+++ b/src/renderer/review/useTabMeta.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Review, ReviewStatus } from '@shared/domain';
 import { subscribeReviewEvents } from './review-event-bus';
 
@@ -51,59 +51,101 @@ export function useTabMeta(
   /** 已数过的 finding id:同一条新 finding 在后续更新里还会再来,不能数第二次。 */
   const counted = useRef(new Map<string, Set<string>>());
 
+  /**
+   * 已订阅的 review → 退订钩子 + 这一轮订阅的序号。**开关一枚 tab 只动这张表里的一项**:整表重建的话,
+   * 每次开合都要把所有已开 review 重订阅并重拉一遍(上限二十枚就是二十次 IPC),而且重订阅之间那道缝里
+   * 到达的事件谁都收不到。
+   *
+   * 序号是**关掉再重开同一条**时的身份:光看 id 在不在表里,上一轮的在途请求会被当成这一轮的
+   * (「重新打开」就是一颗按钮,这个来回很短),旧快照落地时把重开后已经更新过的标题 / 状态盖回去。
+   */
+  const subs = useRef(new Map<string, { off: () => void; gen: number }>());
+  const nextGen = useRef(0);
+
+  const put = useCallback((id: string, r: Review | null) => {
+    if (!r) return;
+    setInfo((prev) => ({
+      ...prev,
+      [id]: {
+        title: r.title ?? r.sourceRef,
+        sourceRef: r.sourceRef,
+        source: r.source,
+        repoPath: r.repoPath,
+        status: r.status,
+      },
+    }));
+  }, []);
+
+  /**
+   * 拉一条 review 的 tab 元信息;失败退避重试两次。**必须自己重试** —— 未激活的 tab 屏上没有
+   * ReviewScreen,而 `status` 事件只能给已有记录改状态、补不出标题,拉不到就一直停在 '…'。
+   * (旧写法每次开合都重拉全表,顺带把失败的也重试了;改成增量订阅后这条补救没了。)
+   */
+  const load = useCallback(
+    (id: string, gen: number) => {
+      // 认序号而不只认 id:关掉再重开会让同一个 id 重新出现在表里
+      const mine = (): boolean => subs.current.get(id)?.gen === gen;
+      let left = 2;
+      const attempt = (): void => {
+        // 每次触发都问一遍,而不是只在排期时问:退避那几百毫秒里 tab 完全可能已经被关掉
+        if (!mine()) return;
+        void window.duetlens.review
+          .get(id)
+          // 查到不存在(null)不重试:那是 App 的恢复那条路负责剔除的事
+          .then((r) => {
+            if (mine()) put(id, r);
+          })
+          .catch(() => {
+            // 读失败多半是 IPC 抖一下 / 库被锁住;退光了就认了 —— tab 条停在 '…',
+            // 真按不亮时进屏后由 ReviewScreen 自己那套报错接手
+            if (left-- > 0) window.setTimeout(attempt, 600);
+          });
+      };
+      attempt();
+    },
+    [put],
+  );
+
   useEffect(() => {
     const ids = key ? key.split(',') : [];
-    let alive = true;
+    const live = new Set(ids);
 
-    const put = (id: string, r: Review | null) => {
-      if (!alive || !r) return;
-      setInfo((prev) => ({
-        ...prev,
-        [id]: {
-          title: r.title ?? r.sourceRef,
-          sourceRef: r.sourceRef,
-          source: r.source,
-          repoPath: r.repoPath,
-          status: r.status,
-        },
-      }));
-    };
-
-    // 先定起点再订阅:已在表里的保持原值,新加入的从此刻起算
+    // 新加入的才建:先定起点再订阅,已在表里的保持原值
     const now = Date.now();
-    for (const id of ids) if (!watchingSince.current.has(id)) watchingSince.current.set(id, now);
-
-    // 读失败不额外补救:tab 条退回 '…',这枚 tab 后续任何 review / status 事件都会把它补上,
-    // 真按不亮时进屏后由 ReviewScreen 自己那套报错接手 —— 别在这儿架一套重试
-    for (const id of ids)
-      void window.duetlens.review
-        .get(id)
-        .then((r) => put(id, r))
-        .catch(() => {});
-
-    const offs = ids.map((id) =>
-      subscribeReviewEvents(id, (e) => {
-        // review / status 两支都要认:重跑把状态拉回 scanning 走的是 status,标题与轮次变化走 review
-        if (e.type === 'review') put(id, e.payload);
-        else if (e.type === 'status')
-          setInfo((prev) => (prev[id] ? { ...prev, [id]: { ...prev[id], status: e.payload } } : prev));
-        else if (e.type === 'finding') {
-          if (e.payload.createdAt < (watchingSince.current.get(id) ?? now)) return;
-          let seen = counted.current.get(id);
-          if (!seen) counted.current.set(id, (seen = new Set()));
-          if (seen.has(e.payload.id)) return;
-          seen.add(e.payload.id);
-          // 正看着的那枚不记未读:它已经在屏上了
-          if (activeRef.current === id) return;
-          setUnread((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }));
-        }
-      }),
-    );
+    for (const id of ids) {
+      if (subs.current.has(id)) continue;
+      if (!watchingSince.current.has(id)) watchingSince.current.set(id, now);
+      const gen = ++nextGen.current;
+      subs.current.set(id, {
+        gen,
+        off: subscribeReviewEvents(id, (e) => {
+          // review / status 两支都要认:重跑把状态拉回 scanning 走的是 status,标题与轮次变化走 review
+          if (e.type === 'review') put(id, e.payload);
+          else if (e.type === 'status')
+            setInfo((prev) => (prev[id] ? { ...prev, [id]: { ...prev[id], status: e.payload } } : prev));
+          else if (e.type === 'finding') {
+            if (e.payload.createdAt < (watchingSince.current.get(id) ?? now)) return;
+            let seen = counted.current.get(id);
+            if (!seen) counted.current.set(id, (seen = new Set()));
+            if (seen.has(e.payload.id)) return;
+            seen.add(e.payload.id);
+            // 正看着的那枚不记未读:它已经在屏上了
+            if (activeRef.current === id) return;
+            setUnread((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }));
+          }
+        }),
+      });
+      load(id, gen);
+    }
 
     // 关掉的 tab 不留账:重新打开时该是干净的一枚,而不是接着上次的数
-    const live = new Set(ids);
-    for (const id of counted.current.keys()) if (!live.has(id)) counted.current.delete(id);
-    for (const id of watchingSince.current.keys()) if (!live.has(id)) watchingSince.current.delete(id);
+    for (const [id, sub] of subs.current) {
+      if (live.has(id)) continue;
+      sub.off();
+      subs.current.delete(id);
+      counted.current.delete(id);
+      watchingSince.current.delete(id);
+    }
     setUnread((prev) => {
       const stale = Object.keys(prev).filter((id) => !live.has(id));
       if (stale.length === 0) return prev;
@@ -111,12 +153,19 @@ export function useTabMeta(
       for (const id of stale) delete next[id];
       return next;
     });
+  }, [key, load]);
 
-    return () => {
-      alive = false;
-      for (const off of offs) off();
-    };
-  }, [key]);
+  /**
+   * 整表退订只发生在卸载。**必须是单独一条 effect** —— 挂到上面那条(跟着 key 走)的 cleanup 上,
+   * 就又变回每次开合全退全订了。
+   */
+  useEffect(
+    () => () => {
+      for (const sub of subs.current.values()) sub.off();
+      subs.current.clear();
+    },
+    [],
+  );
 
   // 激活即清零。放 effect 而不是在事件里判:未读是"没看过"的意思,看没看以最终停在哪枚为准。
   useEffect(() => {


### PR DESCRIPTION
## Why

The limit was 6, and nothing in the tab bar actually needed that number. The strip
already scrolls, tabs are lazily mounted, and backend session slots are unrelated
(`maxLiveSessions`; opening a tab only reads the DB). What did depend on 6 was the
tab bar never having to scroll in practice: at 1280px about 9 tabs fit, so 6 always did.

Raising the cap to 20 makes overflow the normal case, and the strip had no affordance
for it.

## What changed

- `MAX_TABS` 6 -> 20.
- Keep the active tab in view. `ctrl-tab`, or closing a tab so its neighbour takes
  over, used to switch the content while the tab bar stayed put, leaving no visible
  active tab. The landing position is computed from measured rects rather than
  `scrollIntoView`, which would also scroll ancestors.
- Re-run that correction whenever the strip's own width changes, via a `ResizeObserver`.
  Two real cases: narrowing the window, and the at-limit notice appearing, which takes
  232px off the strip.
- Fade the overflowing edges. The scrollbar is hidden, so without this there is no sign
  that more tabs exist.
- Translate a vertical wheel into horizontal scroll; a mouse has only that one axis.
- The at-limit notice no longer shrinks. With 19 tabs it was squeezed to 104px and
  ellipsized, which is exactly when it shows.

### Tab meta subscriptions

Opening or closing one tab used to rebuild the whole subscription table and refetch every
open review: 20 IPC reads per open/close, plus a gap in which events reached nobody.
Subscriptions are now per review, added and removed individually.

That rebuild was also the only thing retrying a failed read, so a failed first fetch would
leave a tab stuck at `...` forever (a `status` event can only update an existing entry, it
cannot fill in a missing one). Added a bounded retry, plus a generation token per
subscription so an in-flight read from a closed tab cannot land on the same review reopened.

## Verification

Measured in `npm run preview:ui`:

- 20 tabs at 1280px: `scrollWidth` 2320 = 116 x 20, client 1198. Stepping with `ctrl-tab`
  keeps the active tab visible at both ends and across wrap-around; clicking an
  already-visible tab does not move the strip.
- Narrowing 1280 -> 820 with the last tab active: before, `scrollLeft` stayed at 1122 while
  the tab sat at 1134, past a strip ending at 790; after, it moves to 1582 and the tab stays
  visible.
- At-limit notice: client 738 -> 506, `scrollLeft` 1582 -> 1814, active tab still visible,
  notice unclipped at 232px.
- Subscriptions: closing tabs issues 0 `review.get`; opening one issues reads only for that id.
- Retry: an injected IPC failure heals within 1.2s once it clears, a sustained failure
  converges at 5 calls, and closing during backoff issues 0 further calls.
- Staleness: a 7s-delayed read issued before a close/reopen still lands, and is now rejected
  instead of overwriting the reopened tab's title.
- Unread badges: two findings plus a duplicate upsert count 2, and activation clears them.

Label widths do not need watching: once the strip overflows every tab is pinned at its
116px `min-width`, so content width is 116 x N no matter what the labels say. Measured with
20 tabs where 7 had full titles and 13 were still `...` - all 20 were exactly 116px.