### PR TITLE
chore(theme): drop the unused IBM Plex font stack

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,9 +6,6 @@
 <title>Duetlens — 和 agent 看透每一处改动</title>
 <meta name="description" content="Duetlens 是一个 macOS 桌面应用:把一次 code review 变成你和 codex agent 的双人对话。每条 finding 都是可以继续追问的讨论线程。">
 <link rel="icon" href="./favicon.svg" type="image/svg+xml">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <script type="module" src="./main.js"></script>
 </head>
 <body>

--- a/src/renderer/theme/tokens.css
+++ b/src/renderer/theme/tokens.css
@@ -11,8 +11,9 @@
 
 /* ---- 共享 primitives(与明暗/主题无关)---- */
 :root{
-  --mono:"IBM Plex Mono",ui-monospace,monospace;
-  --sans:"IBM Plex Sans",system-ui,sans-serif;
+  /* 只用系统字体栈:不打包也不外链第三方字体 */
+  --mono:ui-monospace,SFMono-Regular,Menlo,monospace;
+  --sans:system-ui,-apple-system,sans-serif;
   --r:8px;
   /* 实心按钮的 hover 往**深**走,不能用 filter:brightness() 提亮:
      filter 连白字一起作用(白字已到顶,只有底变亮),对比度必然下降 —— 深色 4.92 → 4.32,hover 时重新不达标。


### PR DESCRIPTION
IBM Plex was never loaded in the app: no font link in `index.html` / `preview.html`, no `@font-face`, no font package in `package.json`. `--sans` / `--mono` have always resolved to the system stack, so the declaration was dead text.

The one place it did work was the landing page, which pulls it from Google Fonts while sharing the same `tokens.css`. Dropping it there too keeps one font story across app and site. The UI is mostly Chinese and IBM Plex Sans has no CJK glyphs, so it only ever styled latin, digits and code — not worth a bundle-size or third-party-request cost either way.

- `src/renderer/theme/tokens.css`: `--sans` / `--mono` now name only system fonts
- `site/index.html`: removed the Google Fonts stylesheet and its two preconnects

`mockup/` is frozen and keeps its own copy. The matching note in `docs/design/ui.md` was swept into the `feat/close-tab-shortcut` docs commit and lands with that branch.

Checked with `tsc --noEmit` and `npm run site:build`; verified the review preview and the landing page render correctly with no console errors.