### PR TITLE
ci(pages): move the deploy actions to their node 24 releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,11 +43,11 @@ jobs:
 
       - run: npm run site:build
 
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/dist
 
       - id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
The pages deploy logs a Node 20 deprecation warning: `configure-pages`, `deploy-pages` and `upload-artifact` still target Node 20 and are being forced onto Node 24 by the runner.

- `configure-pages` v5.0.0 -> v6.0.0
- `upload-pages-artifact` v4.0.0 -> v5.0.0
- `deploy-pages` v4.0.5 -> v5.0.0

`upload-artifact` is not called directly here; v4 of `upload-pages-artifact` pulls it in as a composite step, and v5 moves that to `upload-artifact@v7`, which clears the third entry in the warning.

All three new versions declare `using: node24` in their `action.yml` at the pinned commit. The majors only carry the runtime bump and dependency updates, so the inputs are unchanged. SHA pins with a version comment are kept. `release.yml` already pins node24 releases and needs no change.

Verify by running the `pages` workflow manually after merge; the warning should be gone.