### PR TITLE
fix(diff): re-locate when the same finding or file is clicked again

### DIFF
--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -120,6 +120,19 @@ export function ReviewScreen({
   const { settings, update } = useSettings();
   const [activePath, setActivePath] = useState<string | null>(null);
   const [focusFindingId, setFocusFindingId] = useState<string | null>(null);
+  // 定位是「请求」不是「状态」:滚走之后再点同一处,值没变则 DiffPane 的定位 effect 不会重跑,
+  // 于是那次点击落空。每发起一次定位就自增,让重复定位也带得动。
+  const [focusFindingNonce, setFocusFindingNonce] = useState(0);
+  const requestFocusFinding = (id: string) => {
+    setFocusFindingId(id);
+    setFocusFindingNonce((n) => n + 1);
+  };
+  const [activePathNonce, setActivePathNonce] = useState(0);
+  // 只给「用户要求跳过去」用;DiffPane 自己滚完回报的选中文件走 setActivePath,否则会再滚一次
+  const requestFocusFile = (path: string) => {
+    setActivePath(path);
+    setActivePathNonce((n) => n + 1);
+  };
   // 左栏文件检索:纯导航态不持久化;由屏持有才能在换 review 时清掉,并让 ⌘⇧F 把焦点甩进输入框
   const [fileQuery, setFileQuery] = useState('');
   const fileQueryRef = useRef<HTMLInputElement>(null);
@@ -167,13 +180,13 @@ export function ReviewScreen({
   // 折叠的文件整段内容都不在 DOM 里,内联卡自然也没有 —— 任何跳到代码的动作都得先把它放出来,
   // 否则滚动落空、中栏停在上一处。展开与两处状态更新同批提交,effect 跑时卡片已经在了。
   const revealFile = (path: string) => {
-    setActivePath(path);
+    requestFocusFile(path);
     expandFile(path);
   };
 
   const focusFinding = (f: Finding) => {
     revealFile(f.file);
-    setFocusFindingId(f.id);
+    requestFocusFinding(f.id);
     // 点 finding 亦选中其讨论线程,切到 Discussion 栏即见对话(不强制换 tab)
     setActiveDiscussionId(f.discussionId);
   };
@@ -182,7 +195,7 @@ export function ReviewScreen({
   // 与 focusFinding 的区别只在强制换 tab —— 后者是定位,这里是明确要开聊。
   const discussFinding = (f: Finding) => {
     expandFile(f.file);
-    setFocusFindingId(f.id);
+    requestFocusFinding(f.id);
     setActiveDiscussionId(f.discussionId);
     setTab('discussion');
   };
@@ -194,7 +207,7 @@ export function ReviewScreen({
     const d = discussions.find((x) => x.id === id);
     if (d?.file) revealFile(d.file);
     const f = findings.find((x) => x.discussionId === id);
-    if (f) setFocusFindingId(f.id);
+    if (f) requestFocusFinding(f.id);
   };
 
   // 向某条 discussion 追问:先乐观上屏 user 气泡再显打字指示(否则 IPC/续接延迟会让「回复中」抢先出现),
@@ -300,9 +313,9 @@ export function ReviewScreen({
         line: anchor.line,
         ...draft,
       });
-      setActivePath(f.file);
+      requestFocusFile(f.file);
       expandFile(f.file);
-      setFocusFindingId(f.id);
+      requestFocusFinding(f.id);
       setTab('findings');
     },
     [reviewId, diffReady, expandFile],
@@ -372,7 +385,7 @@ export function ReviewScreen({
   const jumpToCode = (d: Discussion) => {
     if (d.file) revealFile(d.file);
     const f = findings.find((x) => x.discussionId === d.id);
-    if (f) setFocusFindingId(f.id);
+    if (f) requestFocusFinding(f.id);
   };
 
   // 提升 user discussion 为 finding:落库后经事件回推(finding + discussion),再聚焦新 finding 就地编辑
@@ -380,9 +393,9 @@ export function ReviewScreen({
     async (discussionId: string) => {
       if (!reviewId) return;
       const f = await window.duetlens.review.promoteDiscussion(reviewId, discussionId);
-      setActivePath(f.file);
+      requestFocusFile(f.file);
       expandFile(f.file);
-      setFocusFindingId(f.id);
+      requestFocusFinding(f.id);
     },
     [reviewId, expandFile],
   );
@@ -802,7 +815,7 @@ export function ReviewScreen({
             files={diff}
             findings={findings}
             activePath={activePath}
-            onSelect={setActivePath}
+            onSelect={requestFocusFile}
             viewed={viewed}
             onToggleViewed={onToggleViewed}
             query={fileQuery}
@@ -826,7 +839,9 @@ export function ReviewScreen({
             findings={findings}
             discussions={discussions}
             activePath={activePath}
+            activePathNonce={activePathNonce}
             focusFindingId={focusFindingId}
+            focusFindingNonce={focusFindingNonce}
             currentRound={currentRound}
             onTriage={onTriage}
             onUpdate={onUpdate}

--- a/src/renderer/screens/review/DiffPane.tsx
+++ b/src/renderer/screens/review/DiffPane.tsx
@@ -152,8 +152,12 @@ export interface DiffPaneProps {
   discussions?: Discussion[];
   /** 左栏选中的文件路径;变化时滚动到对应 file-header */
   activePath: string | null;
+  /** 定位请求序号:每次点选自增,让重复点同一个文件也能重新滚回去 */
+  activePathNonce?: number;
   /** 右栏点选的 finding;变化时滚动到内联卡并高亮 */
   focusFindingId: string | null;
+  /** 定位请求序号:每次点选自增,让重复点同一条 finding 也能重新滚回去 */
+  focusFindingNonce?: number;
   /** review 当前轮次;内联卡据此显示「本轮新增 / 已修复」标记 */
   currentRound?: number;
   /** finding 写路径:裁决 / 就地编辑,缺省则内联卡为只读 */
@@ -349,7 +353,7 @@ export function DiffPane(props: DiffPaneProps) {
     () => {
       if (activePath) scrollToFile(activePath);
     },
-    [activePath, activeCollapsed, scrollToFile],
+    [activePath, activeCollapsed, props.activePathNonce, scrollToFile],
   );
 
   // 标记已看会把当前文件折叠掉,滚动位置不变则视口塌进下一个文件的中段;
@@ -388,7 +392,7 @@ export function DiffPane(props: DiffPaneProps) {
       const el = ref.current.querySelector(`#${CSS.escape(`finding-${focusFindingId}`)}`);
       el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
     },
-    [focusFindingId, focusCollapsed],
+    [focusFindingId, focusCollapsed, props.focusFindingNonce],
   );
 
   // 长代码行只让 code 表自己横滚(文件头/hunk 头/内联卡片不跟着滑走);


### PR DESCRIPTION
Clicking a finding card scrolls the diff to its inline card. Scroll away, click the same card again, and nothing happens. Same for the left file tree: after scrolling off a file, clicking its row again does not bring it back.

## Why

Both locate paths were keyed on a value, not on the act of asking. `ReviewScreen` held `focusFindingId` and `activePath`; `DiffPane` scrolled from an effect that depends on them. Clicking the same target writes the same value, so no dependency changes and the effect never re-runs. The click is dropped.

The effect had already grown a `focusCollapsed` / `activeCollapsed` dependency for a neighbouring case (the target file was collapsed, so the card was not in the DOM yet). That patched one instance of the same shape without naming it.

## What changes

A locate request now carries a nonce that increments on every request, and the effects depend on it. The id still drives the highlight; the nonce only says "this is a new request".

Requests are the ones a person makes: clicking a finding card or a gutter dot, selecting a discussion, jumping to code, the file tree row, adding a finding, promoting a discussion.

One caller deliberately stays on the plain setter: after marking a file viewed, `DiffPane` scrolls itself with `behavior: 'auto'` and then reports the new file through `onSelectFile` so the left rail follows. That is a report, not a request; bumping the nonce there would chase the instant scroll with a smooth one.

## Verification

Driven in the preview panel with `scrollIntoView` and the pane's `scrollTo` hooked, each case verified failing before the fix and passing after:

- finding card: before, the second click on an already-focused card logged nothing; after, the second and third clicks each re-issue `scrollIntoView(#finding-f4, {block: 'center'})`.
- file tree: before, the second click on `app.css` logged nothing; after, three consecutive clicks each re-issue `scrollTo({top: 8193})`.

Smooth scrolling barely advances inside the preview panel, so the landing position is not observable there; the same element with `behavior: 'auto'` lands correctly, which places the remaining gap in the panel, not the code.

`npm run typecheck` and `npm run lint` are clean.
