### PR TITLE
fix(theme): use --on-accent on agent/severity solid fills

### DIFF
--- a/src/renderer/screens/ReviewScreen.css
+++ b/src/renderer/screens/ReviewScreen.css
@@ -1831,7 +1831,7 @@ body.rz-dragging * {
   align-items: center;
   justify-content: center;
   font-size: 7px;
-  color: var(--on-solid);
+  color: var(--on-accent);
 }
 .scanbar .sb-step.active .sb-dot {
   border-color: var(--agent);
@@ -1928,7 +1928,7 @@ body.rz-dragging * {
 }
 .scanbar .ss-yes {
   font-weight: 600;
-  color: var(--on-solid);
+  color: var(--on-accent);
   background: var(--sev-high);
   border: 1px solid transparent;
 }
@@ -2022,7 +2022,7 @@ body.rz-dragging * {
   align-items: center;
   justify-content: center;
   font-size: 7px;
-  color: var(--on-solid);
+  color: var(--on-accent);
 }
 .tl.failed .tl-l {
   color: var(--sev-high);
@@ -2421,13 +2421,15 @@ body.rz-dragging * {
 .scanbar .se-act button.primary {
   border-color: transparent;
   background: var(--sev-high);
-  /* --sev-high 深色下是浅红(本是给文字用的),白字压上去只有 2.7:1;
-     --on-accent 随模式翻转(深色近黑 / 浅色纯白),两边都过 */
+  /* --sev-high / --agent 深色下都是浅色调(本是给文字用的),白字压上去只有 1.7~3:1;
+     --on-accent 随模式翻转(深色近黑 / 浅色纯白),两边都过。
+     扫描条与时间线上的实心 ✓ / ✕ 同此,包括它们的 hover 变体。 */
   color: var(--on-accent);
 }
 .scanbar .se-act button.primary:hover:not(:disabled) {
   background: color-mix(in oklab, var(--sev-high) 85%, black);
-  color: var(--on-solid);
+  /* hover 只压深 15%,深色下仍是浅红:跟着基态走 --on-accent,别在这里切回白字 */
+  color: var(--on-accent);
 }
 .scanbar .se-act button:disabled {
   opacity: 0.55;
@@ -2526,7 +2528,7 @@ body.rz-dragging * {
   align-items: center;
   justify-content: center;
   font-size: 8px;
-  color: var(--on-solid);
+  color: var(--on-accent);
 }
 .tl.done::before {
   background: var(--agent-line);


### PR DESCRIPTION
`--sev-high` and `--agent` are tuned as text colors, which means they are light-toned in dark mode. Five places still painted `--on-solid` (white) on top of them, so in every dark theme the scanbar check marks, the failure crosses and the stop-scan confirm button were close to invisible.

Measured on the running preview, white on those fills: duetlens 2.46 / 2.66, github 2.99 / 2.52, cyberpunk 1.74 / 2.87.

The base rule of `.se-act button.primary` had already been fixed to `--on-accent`, carrying a comment that explains exactly this - but its `:hover` variant switched back to `--on-solid`. That is how the pattern kept spreading.

After the fix, dark mode measures 7.13 to 11.72. Light mode is unaffected: `--on-accent` resolves to white there, so the same five places stay at 6.04 / 7.89. All numbers read off live DOM, including the confirm button, which only exists after clicking stop during a scan.

This is not introduced by the cyberpunk theme - it is broken on main today for every dark theme, which is why it sits on its own branch.