### PR TITLE
feat(source): support reviewing a single commit of a github pr

### DIFF
--- a/scripts/spike-export.ts
+++ b/scripts/spike-export.ts
@@ -21,6 +21,7 @@ const review: Review = {
   source: 'local-branch',
   sourceRef: 'feat/streaming-transcode',
   baseRef: null,
+  headRef: null,
   repoPath: '/repo',
   codexThreadId: null,
   model: null,

--- a/scripts/spike-followup-queue.ts
+++ b/scripts/spike-followup-queue.ts
@@ -102,6 +102,7 @@ function fixture() {
     source: 'local-branch',
     sourceRef: 'stub',
     baseRef: null,
+    headRef: null,
     repoPath: null,
     codexThreadId: null,
     model: null,

--- a/scripts/spike-session-busy.ts
+++ b/scripts/spike-session-busy.ts
@@ -89,6 +89,7 @@ function fixture() {
     source: 'local-branch',
     sourceRef: 'stub',
     baseRef: null,
+    headRef: null,
     repoPath: null,
     codexThreadId: null,
     model: null,

--- a/src/backend/db/review-store.ts
+++ b/src/backend/db/review-store.ts
@@ -46,6 +46,7 @@ interface ReviewRow {
   source: string;
   source_ref: string;
   base_ref: string | null;
+  head_ref: string | null;
   repo_path: string | null;
   codex_thread_id: string | null;
   model: string | null;
@@ -152,6 +153,7 @@ function toReview(r: ReviewRow): Review {
     source: r.source as SourceKind,
     sourceRef: r.source_ref,
     baseRef: r.base_ref,
+    headRef: r.head_ref,
     repoPath: r.repo_path,
     codexThreadId: r.codex_thread_id,
     model: r.model,
@@ -313,6 +315,7 @@ export class ReviewStore {
     source: SourceKind;
     sourceRef: string;
     baseRef?: string | null;
+    headRef?: string | null;
     repoPath?: string | null;
     title?: string | null;
     model?: string | null;
@@ -325,6 +328,7 @@ export class ReviewStore {
       source: input.source,
       source_ref: input.sourceRef,
       base_ref: input.baseRef ?? null,
+      head_ref: input.headRef ?? null,
       repo_path: input.repoPath ?? null,
       codex_thread_id: null,
       model: input.model ?? null,
@@ -341,8 +345,8 @@ export class ReviewStore {
     };
     this.db
       .prepare(
-        `INSERT INTO reviews (id, source, source_ref, base_ref, repo_path, codex_thread_id, model, reasoning_effort, intensity, title, status, summary_body, summary_files, summary_round, current_round, created_at, updated_at)
-         VALUES (@id, @source, @source_ref, @base_ref, @repo_path, @codex_thread_id, @model, @reasoning_effort, @intensity, @title, @status, @summary_body, @summary_files, @summary_round, @current_round, @created_at, @updated_at)`,
+        `INSERT INTO reviews (id, source, source_ref, base_ref, head_ref, repo_path, codex_thread_id, model, reasoning_effort, intensity, title, status, summary_body, summary_files, summary_round, current_round, created_at, updated_at)
+         VALUES (@id, @source, @source_ref, @base_ref, @head_ref, @repo_path, @codex_thread_id, @model, @reasoning_effort, @intensity, @title, @status, @summary_body, @summary_files, @summary_round, @current_round, @created_at, @updated_at)`,
       )
       .run(row);
     return toReview(row);

--- a/src/backend/db/schema.ts
+++ b/src/backend/db/schema.ts
@@ -281,9 +281,17 @@ ALTER TABLE ui_settings ADD COLUMN open_review_ids TEXT NOT NULL DEFAULT '[]';
 ALTER TABLE ui_settings ADD COLUMN active_review_id TEXT NOT NULL DEFAULT '';
 `;
 
+// 钉死的被审 head(github-pr 只审其中一个 commit)。与 base_ref 同理必须落库:复审重新探测
+// 只会拿到 PR 当下的 head,于是第二轮起审的是整个 PR —— 而 findings 锚点、提交时的 422 预判
+// 都以「这一个 commit 自己的 diff」为基准,基准一漂,同一条 finding 还在不在就无从判起。
+// NULL = 跟随该 source 的默认 head(PR 的 head 分支);非空 = 钉死的 commit sha。
+const V23 = `
+ALTER TABLE reviews ADD COLUMN head_ref TEXT;
+`;
+
 const MIGRATIONS: string[] = [
   V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
-  V21, V22,
+  V21, V22, V23,
 ];
 
 export function migrate(db: Database): void {

--- a/src/backend/ipc/index.ts
+++ b/src/backend/ipc/index.ts
@@ -64,6 +64,7 @@ export function registerIpcHandlers({ manager, broadcast, updater }: IpcDeps): v
         ref: input.ref,
         repoPath: input.repoPath ?? '',
         baseRef: input.baseRef,
+        headRef: input.headRef,
         model: input.model,
         reasoningEffort: input.reasoningEffort,
         intensity: input.intensity,
@@ -187,6 +188,9 @@ export function registerIpcHandlers({ manager, broadcast, updater }: IpcDeps): v
   ipcMain.handle(IpcChannels.sourceDiffStat, (_e, input: DiffStatInput) => manager.diffStat(input));
   ipcMain.handle(IpcChannels.sourcePrBaseChain, (_e, ref: string, repoPath?: string) =>
     manager.prBaseChain(ref, repoPath),
+  );
+  ipcMain.handle(IpcChannels.sourceListPrCommits, (_e, ref: string, repoPath?: string) =>
+    manager.listPrCommits(ref, repoPath),
   );
 
   ipcMain.handle(IpcChannels.promptGet, (_e, cwd?: string) => manager.getReviewPrompt(cwd));

--- a/src/backend/review/github-submitter.ts
+++ b/src/backend/review/github-submitter.ts
@@ -45,8 +45,13 @@ export class GhReviewSubmitter implements GitHubSubmitter {
 
     // payload 带了 sha 就钉死它:那是 suggestion 补缩进所依据的那份 diff 所属的 commit。
     // 再读一次实时 head 的话,两次读之间的推送会让「按 A 的行补的缩进」提交到 B。
+    // 都没有时,只审一个 commit 的 review 要落回它自己那个 sha 而非 PR 实时 head ——
+    // 行锚点算的是这个 commit 的 diff,报给 GitHub 另一个 commit_id 只会整份被 422 拒。
     const { commitId, ...apiPayload } = payload;
-    const requestBody = JSON.stringify({ commit_id: commitId ?? liveHead, ...apiPayload });
+    const requestBody = JSON.stringify({
+      commit_id: commitId ?? review.headRef ?? liveHead,
+      ...apiPayload,
+    });
     try {
       const out = await run(
         'gh',

--- a/src/backend/review/review-manager.ts
+++ b/src/backend/review/review-manager.ts
@@ -46,12 +46,14 @@ import {
   inspectRepo,
   listLocalBranches,
   listOpenPrs,
+  listPrCommits,
   previewPr,
 } from '../source/source-discovery';
 import type {
   DiffStat,
   LocalBranchList,
   PrAncestor,
+  PrCommit,
   PrPreview,
   PrSummary,
   RepoInspection,
@@ -101,6 +103,7 @@ function targetOf(review: Review): ReviewTarget {
     source: review.source,
     ref: review.sourceRef,
     baseRef: review.baseRef ?? undefined,
+    headRef: review.headRef ?? undefined,
     repoPath: review.repoPath ?? '',
   };
 }
@@ -284,12 +287,18 @@ export class ReviewManager extends EventEmitter {
     return prBaseChain(ref, repoPath);
   }
 
+  /** PR 里的 commit(旧→新);供入口选择只审其中一个提交。 */
+  listPrCommits(ref: string, repoPath?: string): Promise<PrCommit[]> {
+    return listPrCommits(ref, repoPath);
+  }
+
   /** 按所选 base 现算改动面(入口切 base 后刷新计量)。 */
   diffStat(input: DiffStatInput): Promise<DiffStat> {
     return diffStat({
       source: input.source,
       ref: input.ref,
       baseRef: input.baseRef,
+      headRef: input.headRef,
       repoPath: input.repoPath ?? '',
     });
   }
@@ -332,6 +341,8 @@ export class ReviewManager extends EventEmitter {
     // 判据永远是「这条锚点在不在这个 PR 自己的 diff 里」。审核时选了更宽的 base 的话,带上它
     // 拉回来的正是那份更宽的 diff —— 于是每条锚在下层 PR 上的 finding 都会被判成有效,
     // 而它们恰恰是提交时唯一会被拒的那批。
+    // **headRef 反过来必须留着**:钉住某个 commit 的 review 提交时用的正是那个 commit_id,
+    // GitHub 校验的也就是它自己那份 diff;清掉会拿整个 PR 的 diff 去判,放行一批实际会被拒的锚点。
     const source = createSource(
       review.source === 'github-pr' ? { ...targetOf(review), baseRef: undefined } : targetOf(review),
     );
@@ -888,6 +899,7 @@ export class ReviewManager extends EventEmitter {
         source: target.source,
         sourceRef: target.ref,
         baseRef: target.baseRef || null,
+        headRef: target.headRef || null,
         repoPath: target.repoPath || null,
         title: prepared.title,
         model: target.model || null,

--- a/src/backend/source/github-pr-source.ts
+++ b/src/backend/source/github-pr-source.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { PR_COMMITS_CAP, type PrCommit } from '@shared/source-discovery';
 import { run } from './exec';
 import type { PreparedSource, ReviewTarget, Source } from './source';
 
@@ -34,12 +35,66 @@ export async function resolvePrRef(
   return { nwo: out.trim(), num: parsed.num };
 }
 
+interface RawCommit {
+  sha: string;
+  commit: { message: string; committer?: { date?: string }; author?: { name?: string } };
+  author?: { login?: string } | null;
+  parents: unknown[];
+}
+
+const PR_COMMITS_PAGE = 100;
+
+const toPrCommit = (c: RawCommit): PrCommit => ({
+  oid: c.sha,
+  headline: firstLine(c.commit.message),
+  // 账号注销 / 提交邮箱没关联到账号时顶层 author 为 null,回落 git 署名
+  author: c.author?.login || c.commit.author?.name || '',
+  committedDate: c.commit.committer?.date ?? '',
+  isMerge: c.parents.length > 1,
+});
+
+const firstLine = (msg: string): string => msg.split('\n')[0];
+
+/**
+ * gh api 的 404。gh 把 `gh: Not Found (HTTP 404)` 写到 stderr、JSON 体写到 stdout,
+ * 两处都认一下,免得日后 gh 改动其中一侧就漏判成「网络错误」。
+ */
+function isHttp404(e: unknown): boolean {
+  const err = e as { stderr?: string; stdout?: string; message?: string };
+  const text = `${err?.stderr ?? ''}\n${err?.stdout ?? ''}\n${err?.message ?? ''}`;
+  return /\(HTTP 404\)|"status":\s*"404"/.test(text);
+}
+
+/**
+ * PR 里的 commit 列表(旧→新,即 GitHub commits 页的顺序)。
+ * 放在本模块而非 source-discovery:后者已依赖本模块的 parsePrRef,反向再引一次会成环。
+ *
+ * **手动翻页而不是 `gh api --paginate`**:数组端点分页时,部分 gh 版本把每页各自的 JSON 数组
+ * 背靠背拼在一起输出(`][`),`JSON.parse` 当场就抛 —— 而这只在提交数过百的 PR 上才现形,
+ * 属于「本机验不出、用户那儿才炸」的那类。自己按 page 取,拿到的每一份都是独立合法的 JSON。
+ */
+export async function fetchPrCommits(nwo: string, num: string): Promise<PrCommit[]> {
+  const out: PrCommit[] = [];
+  for (let page = 1; ; page++) {
+    const json = await run('gh', [
+      'api',
+      `repos/${nwo}/pulls/${num}/commits?per_page=${PR_COMMITS_PAGE}&page=${page}`,
+    ]);
+    const raw = JSON.parse(json) as RawCommit[];
+    out.push(...raw.map(toPrCommit));
+    // 不满一页 = 已到末页;上限那一条兜住封顶值日后变大(再翻也只会拿到空页)
+    if (raw.length < PR_COMMITS_PAGE || out.length >= PR_COMMITS_CAP) return out;
+  }
+}
+
 /**
  * GitHub PR source:diff 走 `gh pr diff`,文件走 `gh api .../contents`(按 head sha),
  * 无需本地 clone。可选 repoPath 仅用作 codex cwd;缺省用临时空目录。
  *
  * 指定 base 时改走 compare API(见 {@link getDiff}):stacked PR 下「只审本 PR」与
  * 「连同下面几个 PR 一起审」是两个不同的范围,而 `gh pr diff` 只给得出前者。
+ *
+ * 指定 head 时则钉死在 PR 里的某一个 commit 上(相对其父提交),此时忽略 base。
  */
 export class GitHubPrSource implements Source {
   private nwo = '';
@@ -62,7 +117,52 @@ export class GitHubPrSource implements Source {
     this.headSha = meta.headRefOid;
 
     const cwd = this.target.repoPath || (this.tmp = mkdtempSync(path.join(tmpdir(), 'duetlens-pr-')));
-    return { title: `#${meta.number} · ${meta.title}`, cwd, headSha: this.headSha };
+    const pinned = this.target.headRef?.trim();
+    if (!pinned) return { title: `#${meta.number} · ${meta.title}`, cwd, headSha: this.headSha };
+
+    // 校验这个 sha 确实属于本 PR。**不属于就抛** —— force-push 后原 commit 被挤出 PR 正是这条路,
+    // 而静默回落到整个 PR 会让复审悄悄换成另一份改动面(锚点与 422 预判的基准全跟着漂)。
+    const list = await fetchPrCommits(this.nwo, this.num);
+    const hit = list.find((c) => c.oid === pinned);
+    const headline = hit
+      ? hit.headline
+      : // 列表拉满上限 = 可能被截断,「不在列表里」这时**不足以**判定它不属于本 PR:
+        // 超过 250 个提交的 PR 里,先前钉住的旧提交本来就落在拿不到的那一段,
+        // 照严格判法会把一条完全正常的 review 判成 force-push 失效,复审与提交一起断掉。
+        // 故降级为问 compare:该 sha 是 PR head 的祖先(ahead)或就是它(identical)即算数。
+        list.length >= PR_COMMITS_CAP
+        ? await this.headlineIfAncestor(pinned, meta.number)
+        : null;
+    if (headline == null) {
+      throw new Error(
+        `commit ${pinned.slice(0, 7)} 不在 #${meta.number} 里(可能已被 force-push 挤掉);请重新选择审核范围`,
+      );
+    }
+    this.headSha = pinned;
+    return { title: `#${meta.number} @${pinned.slice(0, 7)} · ${headline}`, cwd, headSha: this.headSha };
+  }
+
+  /**
+   * 截断兜底:`{sha}...{PR head}` 的 compare 状态为 ahead / identical 即认它属于本 PR。
+   * 同一次调用顺带取回该 commit 自己的标题(compare 的 `base_commit` 就是传进去的那一侧),
+   * 免得为了一行标题再打一次 gh。`per_page=1` 只为压响应体 —— 这里一条 commit 都不需要读。
+   */
+  private async headlineIfAncestor(sha: string, prNumber: number): Promise<string | null> {
+    try {
+      const json = await run('gh', [
+        'api',
+        `repos/${this.nwo}/compare/${sha}...${this.headSha}?per_page=1`,
+      ]);
+      const cmp = JSON.parse(json) as { status?: string; base_commit?: { commit?: { message?: string } } };
+      if (cmp.status !== 'ahead' && cmp.status !== 'identical') return null;
+      return firstLine(cmp.base_commit?.commit?.message ?? '') || `#${prNumber} 中的一个提交`;
+    } catch (e) {
+      // **只有 404 才算「查无此物」**:那是 sha 根本不在这个仓库里,与「不属于本 PR」同义。
+      // 限流 / 断网 / 认证过期一律往上抛 —— 把它们咽成 null,用户看到的会是
+      // 「可能已被 force-push 挤掉」,照着这条去翻 PR 历史,而真正的原因(网断了)一个字都没露。
+      if (isHttp404(e)) return null;
+      throw e;
+    }
   }
 
   /**
@@ -71,6 +171,14 @@ export class GitHubPrSource implements Source {
    * 的性质得以保住。三点比较:base 分支后来前进不会被倒着显示成删除。
    */
   async getDiff(): Promise<string> {
+    // 钉住某个 commit 时基线只能是它的父提交,故先于 base 判定(两者互斥,见 ReviewTarget.headRef)。
+    // 单 commit 接口回的就是 first-parent unified diff,同样不需要 clone。
+    if (this.target.headRef?.trim()) {
+      return run('gh', [
+        'api', '-H', 'Accept: application/vnd.github.v3.diff',
+        `repos/${this.nwo}/commits/${this.headSha}`,
+      ]);
+    }
     const base = this.target.baseRef?.trim();
     if (!base) return run('gh', ['pr', 'diff', this.num, '--repo', this.nwo]);
     return run('gh', [

--- a/src/backend/source/source-discovery.ts
+++ b/src/backend/source/source-discovery.ts
@@ -12,6 +12,7 @@ import type {
   PrAncestor,
   LocalBranchList,
   LocalBranchSummary,
+  PrCommit,
   PrPreview,
   PrSummary,
   RepoInspection,
@@ -24,7 +25,7 @@ import { butJson } from './but-cli';
 import { createSource } from './create-source';
 import { run } from './exec';
 import { gitButlerDiff } from './gitbutler-source';
-import { parsePrRef } from './github-pr-source';
+import { fetchPrCommits, parsePrRef, resolvePrRef } from './github-pr-source';
 import type { ReviewTarget } from './source';
 
 /** `gh auth status` 退出码非 0 即未登录;命令缺失(未装 gh)同样视为不可用。 */
@@ -105,6 +106,15 @@ export async function prBaseChain(ref: string, repoPath?: string): Promise<PrAnc
     cursor = parent.baseRefName;
   }
   return chain;
+}
+
+/**
+ * PR 里的 commit 列表(旧→新)。顺序原样保留 API 的返回,与 GitHub PR 的 commits 页一致 ——
+ * 用户是照着那一页找「刚才那个提交」的,倒过来会让他数错位置。
+ */
+export async function listPrCommits(ref: string, repoPath?: string): Promise<PrCommit[]> {
+  const { nwo, num } = await resolvePrRef(ref, repoPath);
+  return fetchPrCommits(nwo, num);
 }
 
 /** 仓库默认分支名;取不到返回 null(那就别去断言某一环是不是它)。 */

--- a/src/backend/source/source.ts
+++ b/src/backend/source/source.ts
@@ -9,6 +9,12 @@ export interface ReviewTarget {
   repoPath: string;
   /** local-branch 的 diff 基线;缺省自动探测默认分支 */
   baseRef?: string;
+  /**
+   * 钉死的被审 head,**仅 github-pr 消费**:给了就只审这一个 commit(base 即其父提交)。
+   * 与 baseRef 互斥且优先 —— 父提交是这个 commit 唯一说得通的基线,再叠一条 base 只会
+   * 得出一份既不是「这个 commit」也不是「整个 PR」的第三种改动面。
+   */
+  headRef?: string;
   /** codex 模型(空=账号默认);仅审核配置,不影响 source 定位 */
   model?: string | null;
   /** reasoning effort(缺省 codex medium) */

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -123,6 +123,8 @@ const api: DuetlensApi = {
     diffStat: (input) => ipcRenderer.invoke(IpcChannels.sourceDiffStat, input),
     prBaseChain: (ref, repoPath) =>
       ipcRenderer.invoke(IpcChannels.sourcePrBaseChain, ref, repoPath),
+    listPrCommits: (ref, repoPath) =>
+      ipcRenderer.invoke(IpcChannels.sourceListPrCommits, ref, repoPath),
     listRepoPaths: () => ipcRenderer.invoke(IpcChannels.sourceListRepoPaths),
   },
   prompt: {

--- a/src/renderer/preview/fixtures.ts
+++ b/src/renderer/preview/fixtures.ts
@@ -16,7 +16,7 @@ import type {
   ReviewStartProgress,
   ReviewStartStage,
 } from '@shared/ipc';
-import type { PrSummary } from '@shared/source-discovery';
+import { PR_COMMITS_CAP, type PrCommit, type PrSummary } from '@shared/source-discovery';
 import { isStillPresent, scanDoneStatus } from '@shared/domain';
 import { hasAnchor, isSubmittable } from '@shared/github-review';
 import type { Discussion, Finding, FindingProposal, Message, ProposalUpdateBefore, ProposalUpdatePatch, Review, ReviewRound, ReviewUiState, UiSettings } from '@shared/domain';
@@ -149,19 +149,32 @@ const now = Date.now();
 
 const SUMMARY_MODE = new URLSearchParams(window.location.search).get('summary');
 
+/** `?entry-state=commits-error` 的一次性失败闸:只第一次抛,重试即成功。 */
+let commitsErrorSpent = false;
+
+/** 被钉住的那个 commit(?commit-scope):顶栏 chip 与历史短 sha 都认它。 */
+const PINNED_SHA = '9f3c1ad7e2b4508cd1f0a6e8b7c4d2319ae5f60b';
+const COMMIT_SCOPE = new URLSearchParams(window.location.search).has('commit-scope');
+
 const REVIEW: Review = {
   id: 'demo',
-  // 本地分支 source:无 PR 可提交,终点走导出 Markdown(便于自查导出屏)
-  source: 'local-branch',
-  sourceRef: 'feat/streaming-transcode',
+  // 本地分支 source:无 PR 可提交,终点走导出 Markdown(便于自查导出屏)。
+  // ?commit-scope 例外:钉 commit 只存在于 github-pr,来源得跟着换,否则那枚 chip 挂在
+  // 一个根本不可能有 headRef 的 review 上,自查到的就不是真实组合。
+  source: COMMIT_SCOPE ? 'github-pr' : 'local-branch',
+  sourceRef: COMMIT_SCOPE ? 'xieziyu/podcast-go#482' : 'feat/streaming-transcode',
   // 非默认 base:顶栏那枚 ← chip 只在这种情况下出,fixture 里得有一份才看得见
   baseRef: 'release/2.0',
+  // ?commit-scope 钉一个假 sha:顶栏 @sha chip 与「仅审这一个提交」只在这种 review 上出现
+  headRef: COMMIT_SCOPE ? PINNED_SHA : null,
   repoPath: '/Users/dev/podcast-go',
   codexThreadId: 'thread-demo',
   model: 'gpt-5.6-sol',
   reasoningEffort: 'high',
   intensity: 'adversarial',
-  title: 'feat/streaming-transcode · feat: streaming transcode pipeline',
+  title: COMMIT_SCOPE
+    ? '#482 @9f3c1ad · fix: guard nil encoder on cutover'
+    : 'feat/streaming-transcode · feat: streaming transcode pipeline',
   status: 'completed',
   summaryBody: '本次改动引入并发编码管线,整体方向合理,但并发计数存在数据竞争,需修正。',
   summaryFiles: [
@@ -181,16 +194,21 @@ const REVIEW: Review = {
   updatedAt: now,
 };
 
+// 列表行不跟着 ?commit-scope 走:那个开关是给 review 屏用的,让它渗进每一行会把
+// 「只有钉住 commit 的那条才显示短 sha」这个判据糊掉。要显示的那条自己写 headRef。
+const RECENT_BASE: Review = { ...REVIEW, headRef: null };
+
 // 入口「最近的审核」/ 历史屏列表 fixture(覆盖三来源 × 状态 × 时间分桶)
 const RECENT_REVIEWS: RecentReview[] = [
-  { ...REVIEW, id: 'r1', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#482', title: '#482 · feat: streaming transcode', status: 'reviewing', findingCount: 3, discussionCount: 2, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 23 * 60_000 },
-  { ...REVIEW, id: 'r2', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#479', title: '#479 · fix: episode duration off-by-one on live cutover', status: 'submitted', findingCount: 5, discussionCount: 0, submittedCount: 4, updatedAt: now - 5 * 3600_000 },
-  { ...REVIEW, id: 'r3', source: 'local-branch', sourceRef: 'fix/feed-encoding-for-legacy-clients', title: 'fix/feed-encoding-for-legacy-clients · fix: keep latin-1 feed output for legacy clients', repoPath: '/Users/dev/podcast-go', status: 'completed', findingCount: 0, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 26 * 3600_000 },
-  { ...REVIEW, id: 'r4', source: 'gitbutler-vbranch', sourceRef: 'virtual/api-cleanup', title: 'GitButler · virtual/api-cleanup', repoPath: '/Users/dev/duetlens', status: 'completed', findingCount: 2, discussionCount: 1, submittedCount: 0, updatedAt: now - 4 * 86_400_000 },
-  { ...REVIEW, id: 'r5', source: 'github-pr', sourceRef: 'xieziyu/duetlens#471', title: '#471 · refactor: extract prompt resolver into shared', repoPath: null, status: 'submitted', findingCount: 8, discussionCount: 0, submittedCount: 6, currentRound: 1, summaryRound: 1, updatedAt: now - 10 * 86_400_000 },
-  { ...REVIEW, id: 'r6', source: 'local-branch', sourceRef: 'fix/transcode-timeout', repoPath: '/Users/dev/podcast-go', title: 'fix/transcode-timeout · fix: raise transcode timeout to 5m', status: 'failed', findingCount: 1, discussionCount: 0, submittedCount: 0, updatedAt: now - 17 * 86_400_000 },
+  { ...RECENT_BASE, id: 'r1', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#482', title: '#482 · feat: streaming transcode', status: 'reviewing', findingCount: 3, discussionCount: 2, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 23 * 60_000 },
+  // 钉住单个 commit 的一条:历史屏与「最近的审核」的元信息行该多出一枚 mono 短 sha
+  { ...RECENT_BASE, id: 'r2', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#479', headRef: PINNED_SHA, title: '#479 @9f3c1ad · fix: guard nil encoder on cutover', status: 'submitted', findingCount: 5, discussionCount: 0, submittedCount: 4, updatedAt: now - 5 * 3600_000 },
+  { ...RECENT_BASE, id: 'r3', source: 'local-branch', sourceRef: 'fix/feed-encoding-for-legacy-clients', title: 'fix/feed-encoding-for-legacy-clients · fix: keep latin-1 feed output for legacy clients', repoPath: '/Users/dev/podcast-go', status: 'completed', findingCount: 0, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 26 * 3600_000 },
+  { ...RECENT_BASE, id: 'r4', source: 'gitbutler-vbranch', sourceRef: 'virtual/api-cleanup', title: 'GitButler · virtual/api-cleanup', repoPath: '/Users/dev/duetlens', status: 'completed', findingCount: 2, discussionCount: 1, submittedCount: 0, updatedAt: now - 4 * 86_400_000 },
+  { ...RECENT_BASE, id: 'r5', source: 'github-pr', sourceRef: 'xieziyu/duetlens#471', title: '#471 · refactor: extract prompt resolver into shared', repoPath: null, status: 'submitted', findingCount: 8, discussionCount: 0, submittedCount: 6, currentRound: 1, summaryRound: 1, updatedAt: now - 10 * 86_400_000 },
+  { ...RECENT_BASE, id: 'r6', source: 'local-branch', sourceRef: 'fix/transcode-timeout', repoPath: '/Users/dev/podcast-go', title: 'fix/transcode-timeout · fix: raise transcode timeout to 5m', status: 'failed', findingCount: 1, discussionCount: 0, submittedCount: 0, updatedAt: now - 17 * 86_400_000 },
   // 距 30 天保留期只剩 3 天:历史屏的临期标记只有这种行才出现,没有它就自查不到
-  { ...REVIEW, id: 'r7', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#440', title: '#440 · chore: bump ffmpeg to 7.1', status: 'completed', findingCount: 2, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 27 * 86_400_000 },
+  { ...RECENT_BASE, id: 'r7', source: 'github-pr', sourceRef: 'xieziyu/podcast-go#440', title: '#440 · chore: bump ffmpeg to 7.1', status: 'completed', findingCount: 2, discussionCount: 0, submittedCount: 0, currentRound: 1, summaryRound: 1, updatedAt: now - 27 * 86_400_000 },
 ];
 
 // 满载提示 fixture:正在跑的会话(?busy=1..4)
@@ -207,6 +225,30 @@ const OPEN_PRS: PrSummary[] = [
   { number: 479, title: 'fix: episode duration off-by-one on live cutover', author: 'mia', additions: 24, deletions: 9, updatedAt: new Date(now - 5 * 3600_000).toISOString() },
   { number: 475, title: 'refactor: extract feed builder into module', author: 'ryan', additions: 310, deletions: 212, updatedAt: new Date(now - 26 * 3600_000).toISOString() },
 ];
+
+// PR 内 commit 列表 fixture(旧→新,与 GitHub commits 页同序)。含一条 merge commit:
+// 那一行要出 merge 标记,是选择器上唯一需要劝阻的候选
+const PR_COMMITS: PrCommit[] = [
+  { oid: 'c1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4', headline: 'feat(encoder): add streaming pipeline skeleton', author: 'ryan', committedDate: new Date(now - 52 * 3600_000).toISOString(), isMerge: false },
+  { oid: 'd2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5', headline: 'feat(encoder): wire backpressure into the worker pool', author: 'ryan', committedDate: new Date(now - 48 * 3600_000).toISOString(), isMerge: false },
+  { oid: 'e3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6', headline: "Merge branch 'main' into feat/streaming-transcode", author: 'ryan', committedDate: new Date(now - 30 * 3600_000).toISOString(), isMerge: true },
+  { oid: 'f4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7', headline: 'test(encoder): cover the cutover race', author: 'mia', committedDate: new Date(now - 26 * 3600_000).toISOString(), isMerge: false },
+  { oid: PINNED_SHA, headline: 'fix: guard nil encoder on cutover', author: 'mia', committedDate: new Date(now - 4 * 3600_000).toISOString(), isMerge: false },
+];
+
+/**
+ * 长列表用的假 sha。**要长得像真的** —— 规整的 `1010101…` 会让「短 sha 认不认得出」这个
+ * 判断在自查里失真:真实候选之间只差几个乱序字符,规整值看着一眼可辨。
+ */
+function fakeOid(i: number): string {
+  let h = (i + 1) * 2654435761;
+  let out = '';
+  while (out.length < 40) {
+    h = (h * 1103515245 + 12345) >>> 0;
+    out += h.toString(16).padStart(8, '0');
+  }
+  return out.slice(0, 40);
+}
 
 function mkFinding(p: Partial<Finding> & Pick<Finding, 'id' | 'severity' | 'title' | 'file' | 'line'>): Finding {
   return {
@@ -1449,6 +1491,28 @@ export function installPreviewApi(): void {
           bottom,
         ];
       },
+      // ?entry-state=many-commits 演示 30 条的长列表(浮层定高 / 筛选框可用);
+      // capped-commits 拉满 GitHub 的封顶值,验「仅显示最近 250 个提交」那行提示;
+      // commits-error 第一次抛错、重试即成功 —— 错误态与重试闭环都要能走完,
+      // 一直抛的话验不出「重试成功后错误态清干净」这半边
+      listPrCommits: async () => {
+        await new Promise((r) => setTimeout(r, 300));
+        const state = params.get('entry-state');
+        if (state === 'commits-error' && !commitsErrorSpent) {
+          commitsErrorSpent = true;
+          throw new Error('拉取 PR 提交列表失败:API rate limit exceeded(HTTP 403)');
+        }
+        if (state !== 'many-commits' && state !== 'capped-commits') return PR_COMMITS;
+        return Array.from({ length: state === 'capped-commits' ? PR_COMMITS_CAP : 30 }, (_, i) => ({
+          // 第 7 条与第 6 条**刻意共享 7 位前缀**:短 sha 一旦被当成候选身份,
+          // 这两行就会共用 React key、且回查会取错另一条。自查要能真的撞上这一下
+          oid: i === 6 ? `${fakeOid(5).slice(0, 7)}${fakeOid(6).slice(7)}` : fakeOid(i),
+          headline: `refactor(module-${i + 1}): drop the legacy adapter path`,
+          author: i % 3 === 0 ? 'mia' : 'ryan',
+          committedDate: new Date(now - (31 - i) * 3600_000).toISOString(),
+          isMerge: i === 11,
+        }));
+      },
       // entry-state=infer 演示粘贴 PR 后自动反推本地 clone;默认不命中(留空路径)
       inferLocalRepo: async () => (params.get('entry-state') === 'infer' ? '/Users/dev/podcast-go' : null),
       getRepoRemote: async () => ({
@@ -1488,9 +1552,14 @@ export function installPreviewApi(): void {
           branches: state === 'no-branches' ? [] : branches.filter((b) => b.name !== (base ?? 'main')),
         };
       },
-      // base 换一条,改动面就该跟着变;预览里按 base 名派生一组稳定的假数,让这个联动看得见
+      // base(或钉住的 commit)换一条,改动面就该跟着变;按选择派生一组稳定的假数,让联动看得见。
+      // 钉了 commit 时数明显更小 —— 一个提交的改动面本就该远小于整个 PR,数没变小就是没重算
       diffStat: async (input) => {
         await new Promise((r) => setTimeout(r, 260));
+        if (input.headRef) {
+          const s = [...input.headRef].reduce((n, c) => n + c.charCodeAt(0), 0);
+          return { files: 1 + (s % 4), additions: 6 + (s % 40), deletions: 1 + (s % 12) };
+        }
         const seed = [...(input.baseRef ?? 'default')].reduce((n, c) => n + c.charCodeAt(0), 0);
         return { files: 3 + (seed % 22), additions: 120 + (seed % 700), deletions: 18 + (seed % 130) };
       },

--- a/src/renderer/screens/EntryScreen.css
+++ b/src/renderer/screens/EntryScreen.css
@@ -559,6 +559,25 @@
 .stackbar .sb-tail { padding-left: 10px; font-size: 11px; color: var(--text-faint); white-space: nowrap; flex: none; }
 .stackbar .sb-tail b { color: var(--text-dim); font-weight: 600; }
 
+/* 钉住 commit 后顶替 base 选择器的只读说明:陈述的是系统定死的基线(父提交),
+   不是要人取舍的事,故走中性面而非 scopewarn 的 human 档 */
+.commit-basenote {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 10px;
+  --derived-gap: 10px;
+  padding: 8px 11px;
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+}
+.commit-basenote .ci { color: var(--agent-2); flex: none; }
+.commit-basenote b { color: var(--text); font-weight: 600; }
+
 /* 宽 base 的提交口径提示:说的是「这次审的比这个 PR 大」,属于人这一侧要做的取舍,故走 human 档 */
 .scopewarn {
   display: flex;

--- a/src/renderer/screens/EntryScreen.tsx
+++ b/src/renderer/screens/EntryScreen.tsx
@@ -10,9 +10,11 @@ import {
   type SourceKind,
 } from '@shared/domain';
 import type { LiveCapacity, RecentReview, ReviewStartInput, ReviewStartStage } from '@shared/ipc';
+import { PR_COMMITS_CAP } from '@shared/source-discovery';
 import type {
   LocalBranchList,
   PrAncestor,
+  PrCommit,
   PrPreview,
   PrSummary,
   RepoInspection,
@@ -29,6 +31,13 @@ import {
   type BaseOption,
 } from './entry/BasePicker';
 import { BranchPicker, BranchSummary, type BranchOption } from './entry/BranchPicker';
+import {
+  CommitBaseNote,
+  CommitScopeError,
+  CommitScopeRow,
+  CommitTruncNote,
+  shortOid,
+} from './entry/CommitScopeRow';
 import { Busy } from './entry/Busy';
 import { GhIcon, LocalBranchIcon } from './entry/icons';
 import { baseName, parentDir } from './entry/paths';
@@ -76,6 +85,8 @@ export function EntryScreen({ onOpenReview }: { onOpenReview: (id: string) => vo
   const [ref, setRef] = useState('');
   const [repoPath, setRepoPath] = useState('');
   const [baseRef, setBaseRef] = useState('');
+  // github-pr 档:钉住的 commit sha(空 = 整个 PR)。与 baseRef 互斥,由 GitHubPanel 保证只有一个非空
+  const [headRef, setHeadRef] = useState('');
 
   // 本地仓库档:探测结果定模式;forceLocal 是 workspace 仓库上「改按普通 git 分支审核」的手动覆盖
   const [inspection, setInspection] = useState<RepoInspection | null>(null);
@@ -163,6 +174,7 @@ export function EntryScreen({ onOpenReview }: { onOpenReview: (id: string) => vo
     // base 是「相对哪条 ref 审」,换来源后原来那条多半在新来源里根本不存在;
     // 不清的话它会一路带到发起,把一个 PR 拿去和上一个仓库的分支比。
     setBaseRef('');
+    setHeadRef('');
     setError(null);
     if (next === 'repo' && !repoPath.trim()) setRepoPath(settings.lastRepoPath);
   };
@@ -214,7 +226,7 @@ export function EntryScreen({ onOpenReview }: { onOpenReview: (id: string) => vo
   // (换路径不改查询串,旧 preview 不作废,发起门槛也一直开着)。
   // 身份在解析那一刻就钉死,展示与提交同源,这条缝就不存在了。
   const startRef = tab === 'github-pr' ? ghResolvedRef : ref.trim();
-  const target = useTargetLabel(source, startRef);
+  const target = useTargetLabel(source, startRef, tab === 'github-pr' ? headRef : '');
   const atCapacity = isAtCapacity(capacity);
   const canStart =
     !busy && !atCapacity && !!startRef && (tab === 'github-pr' || !!repoPath.trim());
@@ -232,6 +244,7 @@ export function EntryScreen({ onOpenReview }: { onOpenReview: (id: string) => vo
       ref: startRef,
       repoPath: repoPath.trim() || undefined,
       baseRef: baseRef.trim() || undefined,
+      headRef: headRef.trim() || undefined,
       model: trimmedModel || undefined,
       reasoningEffort: effort,
       intensity,
@@ -328,6 +341,8 @@ export function EntryScreen({ onOpenReview }: { onOpenReview: (id: string) => vo
             setRepoPath={setRepoPath}
             baseRef={baseRef}
             setBaseRef={setBaseRef}
+            headRef={headRef}
+            setHeadRef={setHeadRef}
             pickDir={pickDir}
             busy={busy}
             onResolved={setGhResolvedRef}
@@ -499,6 +514,8 @@ function GitHubPanel({
   setRepoPath,
   baseRef,
   setBaseRef,
+  headRef,
+  setHeadRef,
   pickDir,
   busy,
   onResolved,
@@ -509,6 +526,9 @@ function GitHubPanel({
   setRepoPath: (v: string) => void;
   baseRef: string;
   setBaseRef: (v: string) => void;
+  /** 钉住的 commit sha;空 = 整个 PR */
+  headRef: string;
+  setHeadRef: (v: string) => void;
   pickDir: () => void;
   busy: boolean;
   /** 报上去的是解析出的完整引用(owner/repo#n);空串 = 还不能发起 */
@@ -532,6 +552,10 @@ function GitHubPanel({
   const [chain, setChain] = useState<{ key: string; value: ChainState } | null>(null);
   // 摸链失败后重来一次的闸;链是纯读取,重试无副作用
   const [chainTry, setChainTry] = useState(0);
+  // PR 内的 commit 列表;同祖先链一样连同「是为哪个 PR 拉的」一起存,换 PR 后旧列表立即作废
+  const [commits, setCommits] = useState<{ key: string; value: CommitsState } | null>(null);
+  // 拉取失败后重来一次的闸;列举是纯读取,重试无副作用(同 chainTry)
+  const [commitsTry, setCommitsTry] = useState(0);
 
   const recheckAuth = () => {
     setGhAuth(null);
@@ -628,13 +652,54 @@ function GitHubPanel({
   // 旧 base 会跟着新 PR 一路发起。清空即回到「跟随该 PR 自己的 base」,是安全的那一侧。
   // 手上这条 baseRef 是为哪个 prKey 选的。只在选择事件里写(不在 render 期写),故 render 期读安全。
   const baseOwner = useRef('');
+  const headOwner = useRef('');
   const lastPrKey = useRef(prKey);
   useEffect(() => {
     if (lastPrKey.current === prKey) return;
     lastPrKey.current = prKey;
     baseOwner.current = '';
+    headOwner.current = '';
     setBaseRef('');
-  }, [prKey, setBaseRef]);
+    // 钉住的 commit 更是「某一个 PR 的属性」:sha 换个 PR 根本不存在,留着会让新 PR
+    // 一发起就报「不在这个 PR 里」;更坏的是同一条 sha 恰好在两个 PR 里都在(cherry-pick /
+    // 换基重开),那就悄悄审了另一段。清空即回到「整个 PR」,是安全的那一侧。
+    setHeadRef('');
+  }, [prKey, setBaseRef, setHeadRef]);
+
+  // 解析出 PR 后拉一次 commit 列表(范围选择器的候选)。
+  // **失败不能咽成空数组** —— 空列表在界面上与「这个 PR 没有提交」长得一模一样,
+  // 于是一次限流/断网会被读成事实,用户既不知道该重试,也不知道 commit 粒度这档暂时用不了。
+  useEffect(() => {
+    if (!prKey) {
+      setCommits(null);
+      return;
+    }
+    let alive = true;
+    setCommits(null);
+    window.duetlens.source
+      .listPrCommits(prKey)
+      .then((v) => alive && setCommits({ key: prKey, value: { state: 'value', value: v } }))
+      .catch(
+        (e: Error) =>
+          alive && setCommits({ key: prKey, value: { state: 'error', message: e.message ?? String(e) } }),
+      );
+    return () => {
+      alive = false;
+    };
+  }, [prKey, commitsTry]);
+
+  // 换 PR 的那一帧 commits 还挂着上一个 PR 的结果,按 key 判即作废(同 chainState)
+  const commitsState: CommitsState = commits?.key === prKey ? commits.value : COMMITS_PROBING;
+  const prCommits = commitsState.state === 'value' ? commitsState.value : null;
+
+  // 列表落定后校验手上这条 sha:不在这个 PR 里(拉失败 / force-push 挤掉)就退回「整个 PR」。
+  // 与 base 同理不能连在途一起判 —— 那会把用户刚选好的 commit 白白吞掉。
+  useEffect(() => {
+    if (!prCommits || !headRef) return;
+    if (prCommits.some((c) => c.oid === headRef)) return;
+    headOwner.current = '';
+    setHeadRef('');
+  }, [prCommits, headRef, setHeadRef]);
 
   // 链一落定就用它校验手上这条 base:候选里没有它(探测失败 / 链变短了)就清掉。
   // **不能连 probing 一起判** —— 那会让每次改本地路径都白白吞掉用户选好的 base;
@@ -658,12 +723,16 @@ function GitHubPanel({
   // 请求发出去就撤不回来了。**只能在 render 期派生**。
   // 判据是「这条 base 是为哪个 PR 选的」,不是「它在不在新 PR 的候选表里」——
   // 两个 PR 的候选里撞上同名 ref 是常事(stack 换条线重开就会),按候选表判会把旧 base 放过去。
-  const statBase = baseOwner.current === prKey ? baseRef : '';
+  const statHead = headOwner.current === prKey ? headRef : '';
+  // 钉住 commit 时 base 不参与定位(后端同样 head 优先),计量也必须按同一口径问,
+  // 否则屏上这个数说的是另一份改动面。
+  const statBase = !statHead && baseOwner.current === prKey ? baseRef : '';
   const stat = useDiffStat({
     source: 'github-pr',
     ref: prKey,
     repoPath: repoPath.trim(),
     baseRef: statBase,
+    headRef: statHead,
     enabled: !!preview,
   });
 
@@ -798,10 +867,46 @@ function GitHubPanel({
         </div>
       )}
 
+      {/* 审核范围:整个 PR(默认)/ PR 里的某一个 commit。摆在 base 区之前 ——
+          选了单个 commit,下面那一整区就没有意义了(基线只能是它的父提交)。 */}
+      {preview && (
+        <BaseSection tucked>
+          <CommitScopeRow
+            commits={prCommits ?? []}
+            value={headRef}
+            loading={commitsState.state === 'probing'}
+            onChange={(oid) => {
+              headOwner.current = prKey;
+              setHeadRef(oid);
+              // 两者互斥:钉了 commit 就把 base 收回默认,免得留一条看不见却还在的选择
+              if (oid) {
+                baseOwner.current = '';
+                setBaseRef('');
+              }
+            }}
+            stat={stat}
+          />
+          {prCommits && prCommits.length >= PR_COMMITS_CAP && <CommitTruncNote />}
+          {commitsState.state === 'error' && (
+            <CommitScopeError
+              message={commitsState.message}
+              onRetry={() => setCommitsTry((n) => n + 1)}
+            />
+          )}
+        </BaseSection>
+      )}
+
+      {/* 钉住 commit 后整个 base 区让位给一句只读说明 */}
+      {preview && headRef && (
+        <BaseSection tucked>
+          <CommitBaseNote />
+        </BaseSection>
+      )}
+
       {/* 摸链期间就把这一区摆出来:摸出多个候选就原地换成选择器(两者等高,不推屏);
           非 stacked 则收起 —— 那时 PR 卡片的「← base」已经把话说全了。
           **收起要过渡,不能直接撤**:多数 PR 走的正是这一支,硬撤会让下面凭空上跳一行。 */}
-      {preview && !(chainState.state === 'value' && baseOptions.length > 1) && (
+      {preview && !headRef && !(chainState.state === 'value' && baseOptions.length > 1) && (
         <BaseSection tucked collapsed={chainState.state === 'value'}>
           <BaseProbeRow
             error={chainState.state === 'error' ? chainState.message : undefined}
@@ -809,7 +914,7 @@ function GitHubPanel({
           />
         </BaseSection>
       )}
-      {baseOptions.length > 1 && (
+      {!headRef && baseOptions.length > 1 && (
         <BaseSection tucked>
           <BaseRow
             options={baseOptions}
@@ -1183,6 +1288,14 @@ type ChainState =
 
 const PROBING: ChainState = { state: 'probing' };
 
+/** commit 列表的三态。理由同 ChainState:拉取失败与「没有候选」不能并成一档。 */
+type CommitsState =
+  | { state: 'probing' }
+  | { state: 'value'; value: PrCommit[] }
+  | { state: 'error'; message: string };
+
+const COMMITS_PROBING: CommitsState = { state: 'probing' };
+
 /**
  * stacked PR 的 base 候选:祖先链的每一环。`[0]` 是 PR 自己的 base,即默认基线。
  * 范围标签按「往下数到这一环为止会把哪几个 PR 算进来」写,列 PR 号而不是分支名 ——
@@ -1309,15 +1422,18 @@ function PickRepoEmpty({ pickDir, hint }: { pickDir: () => void; hint: string })
 }
 
 /** 底部 CTA 的目标标签(来源 + 已选 ref)。 */
-function useTargetLabel(source: SourceKind, ref: string): string {
+function useTargetLabel(source: SourceKind, ref: string, headRef = ''): string {
   return useMemo(() => {
     const r = ref.trim();
     if (!r) return '';
     if (source === 'github-pr') {
       const num = r.match(/#?(\d+)\s*$/)?.[1];
-      return num ? `GitHub #${num}` : `GitHub ${r}`;
+      // 钉了 commit 就把它写进目标名:发起前最后一眼看的是这行,「#482」与
+      // 「#482 里的某一个提交」是两次不同的审核,不能长得一模一样
+      const pin = headRef.trim() ? ` @${shortOid(headRef.trim())}` : '';
+      return num ? `GitHub #${num}${pin}` : `GitHub ${r}${pin}`;
     }
     if (source === 'local-branch') return `本地 ${r}`;
     return `vbranch ${r}`;
-  }, [source, ref]);
+  }, [source, ref, headRef]);
 }

--- a/src/renderer/screens/HistoryScreen.tsx
+++ b/src/renderer/screens/HistoryScreen.tsx
@@ -244,6 +244,13 @@ function metaParts(r: RecentReview, expiring: number | null): React.JSX.Element 
   return (
     <>
       <span>{repoName(r) ?? r.source}</span>
+      {/* 只审一个 commit 的那条要能与「整个 PR」分开:两者的标题都以 #号 开头,不标就认不出 */}
+      {r.headRef && (
+        <>
+          <span className="dot" />
+          <span title="仅审核 PR 中的这一个提交">@{r.headRef.slice(0, 7)}</span>
+        </>
+      )}
       <span className="dot" />
       <span className={r.findingCount === 0 ? 'find zero' : 'find'}>{r.findingCount} findings</span>
       <span className="dot" />

--- a/src/renderer/screens/ReviewScreen.css
+++ b/src/renderer/screens/ReviewScreen.css
@@ -157,6 +157,18 @@
   padding: 2px 7px;
   white-space: nowrap;
 }
+/* 只审一个 commit 的标记:与 basechip 同一档视觉(两者都在说「这次审的范围不是默认的那份」),
+   互斥出现,故不必再区分颜色 */
+.rev-topbar .commitchip {
+  flex: none;
+  font-size: 11px;
+  color: var(--agent-2);
+  background: var(--agent-soft);
+  border: 1px solid var(--agent-line);
+  border-radius: 6px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
 .rev-topbar .spacer {
   flex: 1;
   min-width: 8px;

--- a/src/renderer/screens/ReviewScreen.tsx
+++ b/src/renderer/screens/ReviewScreen.tsx
@@ -743,10 +743,19 @@ export function ReviewScreen({
               <span className="mono ref">{sourceLabel}</span>
             </span>
           )}
-          {/* 只在改过 base 时才出:默认基线不需要解释,而非默认的那份改动面三天后回看根本认不出 */}
-          {review?.baseRef && (
+          {/* 只在改过 base 时才出:默认基线不需要解释,而非默认的那份改动面三天后回看根本认不出。
+              钉了 commit 时 base 不参与定位(见 ReviewTarget.headRef),那枚 chip 也就不该出 */}
+          {review?.baseRef && !review.headRef && (
             <span className="mono basechip" title={`本次改动面相对 ${review.baseRef} 计算`}>
               ← {review.baseRef}
+            </span>
+          )}
+          {review?.headRef && (
+            <span
+              className="mono commitchip"
+              title={`仅审核 PR 中的这一个提交(${review.headRef.slice(0, 7)}),改动面相对其父提交计算`}
+            >
+              @ {review.headRef.slice(0, 7)}
             </span>
           )}
           <span className="title">{review ? titleRest : '加载中…'}</span>

--- a/src/renderer/screens/entry/BasePicker.tsx
+++ b/src/renderer/screens/entry/BasePicker.tsx
@@ -194,10 +194,13 @@ export function useDiffStat(input: {
   ref: string;
   repoPath: string;
   baseRef: string;
+  /** 钉住的 commit(github-pr);非空时后端按它算,base 不参与 */
+  headRef?: string;
   enabled: boolean;
 }): DiffStatState {
   const [stat, setStat] = useState<{ key: string; value: DiffStatState } | null>(null);
-  const key = [input.source, input.ref, input.repoPath, input.baseRef].join(' ');
+  const headRef = input.headRef ?? '';
+  const key = [input.source, input.ref, input.repoPath, input.baseRef, headRef].join(' ');
   const { enabled, source, ref, repoPath, baseRef } = input;
 
   useEffect(() => {
@@ -207,7 +210,13 @@ export function useDiffStat(input: {
     }
     let alive = true;
     window.duetlens.source
-      .diffStat({ source, ref, repoPath: repoPath || undefined, baseRef: baseRef || undefined })
+      .diffStat({
+        source,
+        ref,
+        repoPath: repoPath || undefined,
+        baseRef: baseRef || undefined,
+        headRef: headRef || undefined,
+      })
       .then((v) => alive && setStat({ key, value: { state: 'value', value: v } }))
       .catch(
         (e: Error) =>
@@ -216,7 +225,7 @@ export function useDiffStat(input: {
     return () => {
       alive = false;
     };
-  }, [key, enabled, source, ref, repoPath, baseRef]);
+  }, [key, enabled, source, ref, repoPath, baseRef, headRef]);
 
   return stat?.key === key ? stat.value : LOADING;
 }

--- a/src/renderer/screens/entry/BranchPicker.tsx
+++ b/src/renderer/screens/entry/BranchPicker.tsx
@@ -5,7 +5,10 @@ import { GitButlerIcon, LocalBranchIcon } from './icons';
 
 /** 一个可审核目标(普通 git 分支或 GitButler 虚拟分支)在选择器里的展示形态。 */
 export interface BranchOption {
+  /** 候选身份:选中值、React key、回查都用它,故必须在同一批候选里唯一(commit 用完整 oid) */
   name: string;
+  /** 行内与触发器上实际显示的文字;不给则显示 name。身份与显示分开,短 sha 才不会成为身份 */
+  label?: string;
   kind: 'git' | 'vbranch';
   /** 数据位:普通 git 分支里 HEAD 所在那条(默认选中用),不直接决定渲染 */
   isHead?: boolean;
@@ -52,9 +55,14 @@ export function BranchPicker({
   const selected = options.find((o) => o.name === value) ?? null;
   const disabled = loading || options.length === 0;
 
+  // 身份与显示分开后筛选要两边都认:name 是完整 oid(输入短前缀仍命中),
+  // label 才是屏上那串短 sha / 「整个 PR」这类只存在于显示层的字
   const shown = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return q ? options.filter((o) => o.name.toLowerCase().includes(q)) : options;
+    if (!q) return options;
+    return options.filter(
+      (o) => o.name.toLowerCase().includes(q) || (o.label?.toLowerCase().includes(q) ?? false),
+    );
   }, [options, query]);
 
   // 候选变空(换仓库 / 改 base)时收起,免得浮层挂在一个不再存在的列表上
@@ -162,7 +170,7 @@ export function BranchPicker({
         {selected ? (
           <>
             <BranchIcon kind={selected.kind} />
-            <span className="bp-name mono">{selected.name}</span>
+            <span className="bp-name mono">{selected.label ?? selected.name}</span>
             {selected.badge && <span className="headtag mono">{selected.badge}</span>}
           </>
         ) : (
@@ -212,7 +220,7 @@ export function BranchPicker({
                 <BranchIcon kind={o.kind} />
                 <div className="m">
                   <div className="bn mono">
-                    {o.name}
+                    {o.label ?? o.name}
                     {o.badge && <span className="headtag mono">{o.badge}</span>}
                   </div>
                   {(o.meta || o.detail) && (
@@ -235,7 +243,7 @@ export function BranchSummary({ option, base }: { option: BranchOption; base?: s
   return (
     <div className="bp-summary derived">
       <span className="mono s-cmp">
-        {option.name}
+        {option.label ?? option.name}
         {base && (
           <>
             {' '}

--- a/src/renderer/screens/entry/CommitScopeRow.tsx
+++ b/src/renderer/screens/entry/CommitScopeRow.tsx
@@ -1,0 +1,168 @@
+import { PR_COMMITS_CAP, type PrCommit } from '@shared/source-discovery';
+import { BranchPicker, type BranchOption } from './BranchPicker';
+import { Busy } from './Busy';
+import type { DiffStatState } from './BasePicker';
+
+/** 「整个 PR」这一档的取值。空串而非 sha —— 与 BaseRow 同一约定:默认档落库必须是 NULL。 */
+export const WHOLE_PR = '';
+
+/**
+ * 「整个 PR」在选择器里的身份。**不能用显示名当身份** —— 身份一律是完整 oid,
+ * 而这一档没有 oid,故给个不可能与 40 位十六进制撞上的哨兵值(含非 hex 字母)。
+ */
+const WHOLE_PR_KEY = 'whole-pr';
+
+/**
+ * 短 sha 一律 7 位:GitHub 自己也这么截,两边对照时不用数位数。
+ * **只用于显示** —— 选中值、React key、落库一律走完整 oid,
+ * 否则同一个 PR 里撞前缀的两条 commit 会共用 key、并让回查取错另一条。
+ */
+export const shortOid = (oid: string): string => oid.slice(0, 7);
+
+/**
+ * 「审核范围」一行:整个 PR / PR 里的某一个 commit + 按所选范围现算的改动面。
+ *
+ * 与 {@link BaseRow} 同构并共用 {@link BranchPicker} —— 两处都是「从候选里挑一条」,
+ * 浮层的定高/上翻/筛选/键盘那套没有第二份的理由;摆成两个并排的行也让
+ * 「选范围」与「选 base」看起来是同一级的两个选择,而它们确实是。
+ */
+export function CommitScopeRow({
+  commits,
+  value,
+  onChange,
+  stat,
+  loading,
+}: {
+  commits: PrCommit[];
+  /** 空串 = 整个 PR(默认档);否则是钉住的 commit sha */
+  value: string;
+  onChange: (oid: string) => void;
+  stat: DiffStatState;
+  loading?: boolean;
+}) {
+  const picks: BranchOption[] = [
+    {
+      name: WHOLE_PR_KEY,
+      label: '整个 PR',
+      kind: 'git',
+      badge: '默认',
+      tag: commits.length ? `全部 ${commits.length} 个提交` : '',
+      meta: '',
+      detail: '',
+    },
+    ...commits.map(
+      (c): BranchOption => ({
+        name: c.oid,
+        label: shortOid(c.oid),
+        kind: 'git',
+        badge: c.isMerge ? 'merge' : undefined,
+        tag: '',
+        meta: `@${c.author}${c.committedDate ? ` · ${relTime(c.committedDate)}` : ''}`,
+        detail: c.headline,
+      }),
+    ),
+  ];
+
+  return (
+    <div className="picker-row base-row">
+      <span className="lbl w">审核范围</span>
+      <BranchPicker
+        options={picks}
+        value={value || WHOLE_PR_KEY}
+        // 选回首行就落空串,让「跟随 PR head」与「钉死在这个 commit 上」可分(见 Review.headRef);
+        // 其余情况 name 本身就是完整 oid,不必回查
+        onChange={(name) => onChange(name === WHOLE_PR_KEY ? WHOLE_PR : name)}
+        emptyHint="没有可选的提交"
+        loading={loading}
+      />
+      <CommitMetric stat={stat} />
+    </div>
+  );
+}
+
+/**
+ * 拉不到 commit 列表时的说明 + 重试。
+ *
+ * **只降级 commit 这一档增强能力,不挡默认路径** —— 选择器仍在、「整个 PR」仍可选、CTA 仍可点。
+ * 拉取失败与「这个 PR 没有提交」必须可分:后者是事实,前者是故障,而两者都表现为空列表的话,
+ * 用户只会以为这个 PR 没得选,连重试的念头都不会有。
+ *
+ * 画法直接复用 base 探测失败那一套(`.baseprobe.err` + `.bpr-*`),不新增样式;
+ * 外层照 BaseProbeRow 摆成 `.picker-row`,靠 `.picker-row + .picker-row` 拿到行距与缩进对齐。
+ */
+export function CommitScopeError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="picker-row base-row">
+      <span className="lbl w" />
+      <div className="baseprobe err">
+        <span className="bpr-ic">!</span>
+        <span className="bpr-txt" title={message}>
+          提交列表拉取失败 · 仍可按整个 PR 审
+        </span>
+        <button type="button" className="bpr-retry" onClick={onRetry}>
+          重试
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 列表被 GitHub 封顶截断时的说明。不做懒加载:>250 个提交的 PR 靠翻列表找目标本就不现实,
+ * 说清楚「只有最近这些」比默默少给要好。
+ */
+export function CommitTruncNote() {
+  return (
+    <div className="commit-basenote derived">
+      <span className="ci">◇</span>
+      <div>
+        该 PR 提交数超出 GitHub 单次列举上限,仅显示<b>最近 {PR_COMMITS_CAP} 个提交</b>。
+      </div>
+    </div>
+  );
+}
+
+function CommitMetric({ stat }: { stat: DiffStatState }) {
+  // 与 BaseRow 的计量同款三态:失败要与在途可分,否则算不出的范围会永远转下去
+  if (stat.state === 'error') {
+    return (
+      <span className="basemetric mono err" title={stat.message}>
+        计量失败 · 这个范围可能已不可比
+      </span>
+    );
+  }
+  if (stat.state === 'loading') return <Busy>计量中…</Busy>;
+  return (
+    <span className="basemetric mono">
+      {stat.value.files} files · <span className="a">+{stat.value.additions}</span>{' '}
+      <span className="d">−{stat.value.deletions}</span>
+    </span>
+  );
+}
+
+/**
+ * 钉住 commit 后原地替换 base 区的只读说明。
+ * 单个 commit 的基线只可能是它的父提交,没得选 —— 留着一个选不动的选择器比撤掉更费解。
+ */
+export function CommitBaseNote() {
+  return (
+    <div className="commit-basenote derived">
+      <span className="ci">◇</span>
+      <div>
+        相对其<b>父提交</b>审核 —— 只看这一个提交自己引入的改动,不含 PR 里它前后的其他提交。
+      </div>
+    </div>
+  );
+}
+
+/** 相对时间(与 BranchSummary 同口径,只是入参是 ISO 串)。 */
+function relTime(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return '';
+  const min = Math.round((Date.now() - ts) / 60_000);
+  if (min < 1) return '刚刚';
+  if (min < 60) return `${min} 分钟前`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `${h} 小时前`;
+  return `${Math.round(h / 24)} 天前`;
+}

--- a/src/renderer/screens/entry/RecentReviews.tsx
+++ b/src/renderer/screens/entry/RecentReviews.tsx
@@ -39,6 +39,13 @@ export function RecentReviews({
                 <div className="t">{r.title ?? r.sourceRef}</div>
                 <div className="meta mono">
                   <span>{repoName(r) ?? r.source}</span>
+                  {/* 只审一个 commit 的那条要能与「整个 PR」分开(同 HistoryScreen 的元信息行) */}
+                  {r.headRef && (
+                    <>
+                      <span className="dot" />
+                      <span title="仅审核 PR 中的这一个提交">@{r.headRef.slice(0, 7)}</span>
+                    </>
+                  )}
                   <span className="dot" />
                   <span className={r.findingCount === 0 ? 'find zero' : 'find'}>{r.findingCount} findings</span>
                   {r.submittedCount > 0 ? (

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -290,6 +290,11 @@ export interface Review {
    * 落库是为了让复审沿用同一条基线 —— 重新自动探测会让第二轮起悄悄换一份改动面。
    */
   baseRef: string | null;
+  /**
+   * 钉死的被审 head;null = 跟随该 source 的默认 head(PR 的 head 分支)。
+   * 非空表示只审这一个 commit(相对其父提交),此时 {@link baseRef} 不参与定位。
+   */
+  headRef: string | null;
   /** 可选本地仓库路径(github source 也可指定,让 agent 读全量代码) */
   repoPath: string | null;
   /** codex 侧会话 id(续接用) */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -27,6 +27,7 @@ import type {
   DiffStat,
   LocalBranchList,
   PrAncestor,
+  PrCommit,
   PrPreview,
   PrSummary,
   RepoInspection,
@@ -84,6 +85,7 @@ export const IpcChannels = {
   sourceInspectRepo: 'source:inspect-repo',
   sourceDiffStat: 'source:diff-stat',
   sourcePrBaseChain: 'source:pr-base-chain',
+  sourceListPrCommits: 'source:list-pr-commits',
   sourceListRepoPaths: 'source:list-repo-paths',
   promptGet: 'prompt:get',
   promptSave: 'prompt:save',
@@ -104,6 +106,8 @@ export interface ReviewStartInput {
   repoPath?: string;
   /** local-branch diff 基线;缺省自动探测默认分支 */
   baseRef?: string;
+  /** github-pr:只审这一个 commit(base 即其父提交);与 baseRef 互斥,给了它 baseRef 不生效 */
+  headRef?: string;
   /** codex 模型(空=账号默认) */
   model?: string;
   /** reasoning effort(缺省 codex medium) */
@@ -122,6 +126,7 @@ export interface DiffStatInput {
   ref: string;
   repoPath?: string;
   baseRef?: string;
+  headRef?: string;
 }
 
 /**
@@ -483,6 +488,8 @@ export interface DuetlensApi {
     diffStat(input: DiffStatInput): Promise<DiffStat>;
     /** 被审 PR 的祖先链(自近及远,[0] 即它自己的 base);非 stacked PR 只有一环。 */
     prBaseChain(ref: string, repoPath?: string): Promise<PrAncestor[]>;
+    /** 列举 PR 里的 commit(旧→新);供「只审其中一个提交」的范围选择。 */
+    listPrCommits(ref: string, repoPath?: string): Promise<PrCommit[]>;
     /** 历史审核用过的本地仓库路径(去重、最近在前),供入口空态快选。 */
     listRepoPaths(): Promise<string[]>;
   };

--- a/src/shared/source-discovery.ts
+++ b/src/shared/source-discovery.ts
@@ -28,6 +28,28 @@ export interface PrSummary {
   updatedAt: string;
 }
 
+/**
+ * GitHub 的 PR commits 接口最多只回这么多条。拉满即**可能被截断**(更旧的提交拿不到),
+ * 于是「这个 sha 属不属于本 PR」不能再按列表判 —— 见 GitHubPrSource.prepare 的降级判据。
+ */
+export const PR_COMMITS_CAP = 250;
+
+/**
+ * PR 里的一个 commit(供「只审其中一个提交」的范围选择)。
+ * 顺序由列举方保持为旧→新,与 GitHub PR 的 commits 页一致。
+ */
+export interface PrCommit {
+  oid: string;
+  /** commit message 首行 */
+  headline: string;
+  /** GitHub 账号;账号已注销 / 邮箱未关联时回落 git 署名 */
+  author: string;
+  /** ISO 时间串(提交于) */
+  committedDate: string;
+  /** 多父提交。合并进来的改动不是这一层写的,选它审多半不是用户想要的 */
+  isMerge: boolean;
+}
+
 /** 本地分支的一项(相对 base 领先若干 commit)。 */
 export interface LocalBranchSummary {
   name: string;


### PR DESCRIPTION
## What

Adds a scope row on the entry screen for github-pr sources: review the whole PR (default) or a single commit inside it. When a commit is pinned, the diff is taken against its parent, and the choice is persisted so rerun, resume and submit all stay on that same commit. The review screen and the history / recent lists carry an @sha marker so a commit-scoped review is distinguishable from a whole-PR one.

## Why

On a large PR, reviewing everything in one pass is impractical. Reviewing commit by commit lets the work be split into steps that each stand on their own, without leaving the PR.

## Key decisions

- New `reviews.head_ref` column follows the existing `base_ref` convention: NULL means follow the source default (the PR head), non-null pins a commit sha. The default is stored as NULL rather than a probed literal, so a moved head never silently changes what a rerun reviews.
- `headRef` and `baseRef` are mutually exclusive and `headRef` wins. A commit's only sensible baseline is its parent, so the base picker is replaced by a read-only note once a commit is pinned.
- Submitting pins `commit_id` to the reviewed commit, and the 422 pre-check uses that same commit's diff as its baseline. Checking against the whole-PR diff would clear anchors that GitHub then rejects.
- PR commits are paginated manually with `per_page` and `page` instead of `gh api --paginate`. Some gh versions emit one JSON array per page back to back, which only breaks on PRs past a single page.
- When the commit list comes back at the GitHub cap, membership validation degrades to the compare API (`ahead` or `identical`) instead of the list. Otherwise a commit pinned earlier and now outside the returned window is misreported as dropped by a force-push.
- Picker candidates are identified by full oid; the short sha is display only. Two commits sharing a 7-character prefix would otherwise collide as React keys and resolve to the wrong commit.

## Known limits

- GitHub returns at most 250 commits for a PR. Past that the picker shows the most recent 250 and says so; there is no lazy loading.
- The degraded membership check accepts any ancestor of the PR head, so a commit reachable from the head but not authored in this PR would pass. It only runs on PRs past the cap.