### PR TITLE
fix(source): probe --no-tui support instead of always passing it

### DIFF
--- a/src/backend/source/but-cli.ts
+++ b/src/backend/source/but-cli.ts
@@ -18,13 +18,33 @@ export async function butJson(args: string[], cwd?: string): Promise<string> {
     known = first;
     return out;
   } catch (err) {
-    if (!isUnknownArg(err)) throw err;
+    if (!isUnknownArg(err, first[0])) throw err;
   }
   const out = await run('but', [...args, ...second], cwd);
   known = second;
   return out;
 }
 
-function isUnknownArg(err: unknown): boolean {
-  return String((err as { stderr?: string }).stderr ?? '').includes('unexpected argument');
+/** 只认「被投诉的正是 json flag 本身」——否则 args 里别的过期 flag 会被这层重试盖掉真凶。 */
+function isUnknownArg(err: unknown, flag: string): boolean {
+  return String((err as { stderr?: string }).stderr ?? '').includes(`unexpected argument '${flag}'`);
+}
+
+/** 探测结果按进程缓存:同一台机器上 but 不会在一次运行中间换版本。 */
+let diffTui: string[] | null = null;
+
+/**
+ * `but diff <target>` 的 JSON 输出。**--no-tui 传不传只能问 CLI 自己**,两侧都会出事:
+ * 0.22 删了这个 flag(传了直接 unexpected argument),而 ≤0.20.0 的 `use_tui` 不看输出格式,
+ * 不传就落到 git config `but.ui.tui` —— 用户开过它就会卡进交互界面,而不是回一份 JSON。
+ * 版本号判不了(0.20.1 起才改成 json 强制关 TUI),照着 help 认这个 flag 最省事。
+ */
+export async function butDiffJson(target: string, cwd?: string): Promise<string> {
+  if (!diffTui) {
+    // 探测不成功就不落缓存,让错误照常抛出去 —— 起不来的 but、无效的 cwd 下面那条 diff 也跑不成,
+    // 而把「没读到 help」记成「这版不要 --no-tui」会让之后换到好仓库时静默进 TUI。
+    const help = await run('but', ['diff', '--help'], cwd);
+    diffTui = help.includes('--no-tui') ? ['--no-tui'] : [];
+  }
+  return butJson(['diff', target, ...diffTui], cwd);
 }

--- a/src/backend/source/gitbutler-source.ts
+++ b/src/backend/source/gitbutler-source.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { refExists } from './base-ref';
-import { butJson } from './but-cli';
+import { butDiffJson } from './but-cli';
 import { run } from './exec';
 import { gitGrep } from './git-grep';
 import type {
@@ -188,7 +188,7 @@ export async function gitButlerDiff(
         `虚拟分支 ${branch} 与同名 tag 冲突,取不到缺省 diff(删掉 refs/tags/${branch},或改选一个 base)`,
       );
     }
-    const out = await butJson(['diff', branch, '--no-tui'], repo);
+    const out = await butDiffJson(branch, repo);
     return toUnifiedDiff(JSON.parse(out) as ButDiffJson);
   }
   // 两端都先解析成 sha 再拼 range:界面传下来的是短名(stack 内的虚拟分支名,或 workspace target),


### PR DESCRIPTION
but 0.22 removed `--no-tui` from `but diff`, so every GitButler diff failed with `unexpected argument`.

- Ask `but diff --help` whether the flag exists rather than hardcoding either answer. 0.20.1+ already forces the TUI off for json output, but 0.20.0 and older fall back to the `but.ui.tui` git config, so unconditionally dropping the flag can hang a review there. The failure is asymmetric (new versions error out, old ones silently open a TUI), so try/catch cannot decide this.
- Only cache the probe result when help was actually read.
- Narrow the json flag fallback to complaints about the json flag itself, so an unrelated stale flag no longer masks the real error.

Verified: `npm run typecheck`, `npm run spike:gitbutler feat/pr-commit-review` (all 7 green).