### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -4,6 +4,40 @@ Only **user-visible** changes are recorded here. Internal refactors, docs and CI
 listed — read `git log` for those. Versions follow [Semantic Versioning](https://semver.org/);
 while on `0.x`, the minor position doubles as the breaking-change position.
 
+## [0.10.0] - 2026-08-29
+
+### Added
+
+- **A github-pr review can be scoped to a single commit.** The entry screen gains a scope row for
+  github-pr sources: review the whole PR (the default), or pin one commit inside it. With a commit
+  pinned, the diff is taken against its parent, and rerun, resume and submit all stay on that same
+  commit — a moved PR head can no longer silently turn round two into a whole-PR review. The review
+  screen and the history / recent lists carry an `@sha` marker, so a commit-scoped review is
+  distinguishable at a glance. Once a commit is pinned the base picker becomes a read-only note: a
+  commit's only sensible baseline is its parent. The 422 pre-check on submit uses that commit's
+  diff as well, so anchors are no longer cleared by comparing against the whole-PR diff. Reviewing
+  a large PR in one pass is impractical; going commit by commit splits it into steps that each
+  stand on their own, without leaving the PR. Known limit: GitHub returns at most 250 commits for a
+  PR, and past that the picker shows the most recent 250 and says so. (#92)
+
+### Fixed
+
+- **GitButler sources no longer fail on every diff.** but 0.22 removed `--no-tui` from `but diff`,
+  and we passed it unconditionally, so every GitButler review stopped at `unexpected argument`. The
+  flag is now probed through `but diff --help` before being passed — dropping it outright is not an
+  option either, because 0.20.0 and older fall back to the `but.ui.tui` git config, and with that
+  enabled a review hangs on a TUI you cannot see. The two failure modes are asymmetric (new
+  versions error out, old ones stall silently), so this has to be asked rather than tried. (#93)
+
+### Upgrade notes
+
+- The database schema moves to v23 (0.9.1 was v22); an existing database migrates automatically on
+  first launch, with nothing to do by hand. **The migration is one-way** — 0.9.x can still open a
+  migrated database, it simply cannot see the new column (which commit a review pinned) and never
+  writes it back. If you really need to downgrade, back up
+  `~/Library/Application Support/Duetlens/duetlens.db` first.
+- The update arrives through the in-app updater; there is no need to download the dmg again.
+
 ## [0.9.1] - 2026-08-26
 
 ### Added
@@ -544,6 +578,7 @@ while on `0.x`, the minor position doubles as the breaking-change position.
 
 First public release.
 
+[0.10.0]: https://github.com/xieziyu/duetlens/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/xieziyu/duetlens/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/xieziyu/duetlens/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/xieziyu/duetlens/compare/v0.7.2...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 本文件只记**对使用者可见**的变化。内部重构、文档与 CI 调整不单列,查 `git log`。
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/);`0.x` 阶段 minor 位即破坏性变更位。
 
+## [0.10.0] - 2026-08-29
+
+### 新增
+
+- **github-pr 可以只审其中一个 commit。** 入口屏为 github-pr 多了一行范围选择:默认审整个 PR,也可以钉住 PR 里的某一个 commit —— 此时 diff 取它与父提交之间的那一段,重跑、恢复、提交都跟着同一个 commit 走,不会因为 PR 的 head 挪动而在第二轮悄悄换成整个 PR。审核屏与历史 / 最近列表都带上 `@sha` 标记,一眼看得出这是一次 commit 范围的审核。钉住 commit 之后基线选择器换成一行只读说明 —— 一个 commit 唯一说得通的基线就是它的父提交。提交回 GitHub 时的锚点预判也以这个 commit 的 diff 为准,不会再被整个 PR 的 diff 判成失效。大 PR 一轮审完并不现实,逐个 commit 审可以把它拆成几段各自成立的工作,而不用离开这个 PR。已知限制:GitHub 一个 PR 最多返回 250 个 commit,超过这个数只列出最近 250 个并写明。(#92)
+
+### 修复
+
+- **GitButler 源不再每次取 diff 都失败。** but 0.22 拿掉了 `but diff` 的 `--no-tui`,而我们一直无条件带着它,于是所有 GitButler 审核都停在 `unexpected argument` 上。现在改为先问 `but diff --help` 有没有这个参数,再决定带不带 —— 不能一律不带:0.20.0 及更早的版本会去读 `but.ui.tui` 配置,那里开着的话审核会挂在一个你看不见的 TUI 上。两侧的失败方式不对称(新版本报错,老版本静默卡住),所以这件事只能问,不能试。(#93)
+
+### 升级须知
+
+- 数据库结构升级到 v23(0.9.1 是 v22),旧库首次启动自动迁移,无需操作。**迁移是单向的** —— 装回 0.9.x 仍能打开迁移过的库,只是新增列上的内容(某次审核钉住的是哪个 commit)它看不见,也不会写回去。真要降级,先备份 `~/Library/Application Support/Duetlens/duetlens.db`。
+- 更新由应用内 updater 接手,无需重新下载 dmg。
+
 ## [0.9.1] - 2026-08-26
 
 ### 新增
@@ -217,6 +232,7 @@
 
 首个公开版本。
 
+[0.10.0]: https://github.com/xieziyu/duetlens/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/xieziyu/duetlens/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/xieziyu/duetlens/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/xieziyu/duetlens/compare/v0.7.2...v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duetlens",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
0.10.0 发布准备。

- 两份 CHANGELOG 补上 0.10.0 小节与版本链接引用
- `package.json` 版本号 bump 到 0.10.0

本版内容:github-pr 支持只审单个 commit (#92),schema 升到 v23;修复 but 0.22 拿掉 `--no-tui` 后 GitButler diff 全挂 (#93)。

本地闸门:typecheck / lint 全绿,`release-notes.mjs 0.10.0` 中英两节都能抽到、`9.9.9` 非零退出,`npm run package` 出包后 Info.plist 与 `APP_VERSION` 均为 0.10.0、adhoc 签名,冒烟启动 ALIVE。