### PR TITLE
chore(ci): limit dependabot prs to production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # 只保留生产依赖的安全更新 PR:构建链依赖不进安装包,报了也没有攻击面。
+  # open-pull-requests-limit: 0 关掉常规版本更新,安全更新不受此上限约束。
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: production


### PR DESCRIPTION
Security updates are enabled repo-wide with no config file, so build-chain
transitive deps (browserslist, @xmldom/xmldom) also open PRs even though they
never ship in the packaged app.

This config restricts Dependabot to production dependencies and turns off
version updates (open-pull-requests-limit: 0 applies to version updates only;
security updates are unaffected by it but do honour allow).