### PR TITLE
chore(release): 0.11.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@
 #   - 挂 release environment,人工审批前 job 不启动,secrets 也就不注入。
 #     供应链投毒因此不能静默拿走密钥,总得有人点一下。
 #   - action 一律钉 commit SHA。@v6 这种可变引用被劫持时会跟着中招。
-#   - secrets 只出现在真正需要的两步的 env 里,且不经 ${{ }} 插值进 run —— 别改成插值。
+#   - secrets 只出现在真正需要它的那些步骤的 env 里,且不经 ${{ }} 插值进 run —— 别改成插值。
 name: release
 
 on:
@@ -59,6 +59,48 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
 
+      # electron-builder 的 notarize 只认文件路径,secret 是字符串,得先落盘
+      - name: write notarization key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          mkdir -p ~/private_keys
+          printf '%s' "$APPLE_API_KEY_P8" > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+
+      # 证书自己导进 keychain,别走 electron-builder 的 CSC_LINK:它用随机口令建临时 keychain,
+      # 却拿 p12 的导出口令去 set-key-partition-list(app-builder-lib importCerts),两者从来
+      # 不相等。旧 runner 镜像上 keychain 那时还解锁着,这一步蒙混过去;镜像换到
+      # macos-26-arm64/20260831 之后 -k 会真的被校验,于是签名前报 SecKeychainUnlock 口令不对
+      # (v0.11.0 就烧在这儿)。挂进用户搜索链后,下一步不再给 CSC_LINK,electron-builder 退回
+      # `security find-identity -v` 自己发现身份 —— 正是 electron-builder.yml 里不写 identity
+      # 时本来就假定的那条路。inquestry 的 release.yml 是同一份配方,改一边记得看另一边。
+      - name: import signing certificate
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          keychain_password="$(openssl rand -base64 24)"
+          p12="$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$CSC_LINK" | base64 --decode > "$p12"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$p12" -k "$keychain" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          rm -f "$p12"
+          # 在这里失败,别等三分钟后 electron-builder 说找不到身份
+          security find-identity -v -p codesigning "$keychain" |
+            grep -q "Developer ID Application" || {
+              echo "::error::keychain 里没有 Developer ID Application 身份"
+              exit 1
+            }
+
       # 先手建 draft,别让 electron-builder 自己建:它的 publisher 缓存在 get 与 set 之间有 await
       # (createPublisher → resolveReleaseBody 会读一个通常不存在的 release-notes.md),并发的
       # artifactCreated 因此拿到两个 publisher 实例,各建一条 draft,产物被拆两边 —— 上游 #6676。
@@ -71,19 +113,8 @@ jobs:
             gh release create "$GITHUB_REF_NAME" --draft \
               --title "Duetlens ${GITHUB_REF_NAME#v}" --notes-file "$RUNNER_TEMP/notes.md"
 
-      # electron-builder 的 notarize 只认文件路径,secret 是字符串,得先落盘
-      - name: write notarization key
-        env:
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        run: |
-          mkdir -p ~/private_keys
-          printf '%s' "$APPLE_API_KEY_P8" > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
-
       - name: build, sign, notarize, publish
         env:
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -4,7 +4,7 @@ Only **user-visible** changes are recorded here. Internal refactors, docs and CI
 listed — read `git log` for those. Versions follow [Semantic Versioning](https://semver.org/);
 while on `0.x`, the minor position doubles as the breaking-change position.
 
-## [0.11.0] - 2026-09-07
+## [0.11.1] - 2026-09-07
 
 ### Added
 
@@ -607,7 +607,7 @@ while on `0.x`, the minor position doubles as the breaking-change position.
 
 First public release.
 
-[0.11.0]: https://github.com/xieziyu/duetlens/compare/v0.10.0...v0.11.0
+[0.11.1]: https://github.com/xieziyu/duetlens/compare/v0.10.0...v0.11.1
 [0.10.0]: https://github.com/xieziyu/duetlens/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/xieziyu/duetlens/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/xieziyu/duetlens/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 本文件只记**对使用者可见**的变化。内部重构、文档与 CI 调整不单列,查 `git log`。
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/);`0.x` 阶段 minor 位即破坏性变更位。
 
-## [0.11.0] - 2026-09-07
+## [0.11.1] - 2026-09-07
 
 ### 新增
 
@@ -243,7 +243,7 @@
 
 首个公开版本。
 
-[0.11.0]: https://github.com/xieziyu/duetlens/compare/v0.10.0...v0.11.0
+[0.11.1]: https://github.com/xieziyu/duetlens/compare/v0.10.0...v0.11.1
 [0.10.0]: https://github.com/xieziyu/duetlens/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/xieziyu/duetlens/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/xieziyu/duetlens/compare/v0.8.0...v0.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duetlens",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duetlens",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duetlens",
   "productName": "Duetlens",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Conversational code review — human and agent reviewing together (full rewrite of better-review)",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
0.11.0 的 CI 死在签名前一步,tag 已烧,内容原样改发 0.11.1。

## 为什么烧

electron-builder 用随机口令建临时 keychain,却拿 p12 的导出口令去
`set-key-partition-list -k`(app-builder-lib `importCerts`),两者从来不相等。
旧 runner 镜像上 keychain 那时还解锁着,这一步蒙混过去;镜像换到
macos-26-arm64/20260831 之后 `-k` 会真的被校验,于是报
`SecKeychainUnlock: The user name or passphrase you entered is not correct.`

本机复现过:同一条命令口令给错就是这句话,给对则过了解锁。依赖没变,变的是 runner 镜像
(20260728 到 20260831)。

## 修法

证书自己导进 keychain 并挂进用户搜索链,build 那步不再给 `CSC_LINK` ——
electron-builder 退回 `security find-identity -v` 自己发现身份。
配方与 inquestry #33 同一份,那边已在真证书上跑通。

顺手把「写公证密钥」「导证书」挪到建 draft 之前:0.11.0 这次先建了空草稿才死在签名上,
换个顺序,签名配置出问题不会再在 release 页留残渣。

## 本地闸门

typecheck / lint 绿;`release-notes.mjs 0.11.1` 中英两节都抽得到,`0.11.0` 非零退出;
出包 Info.plist 与 `APP_VERSION` 都是 0.11.1,adhoc 签名,指独立 userData 冒烟启动存活;
workflow YAML 解析通过,build 那步的 env 里确认没有 `CSC_LINK`。

签名那半边本机验不了(自签证书不被信任),守卫放在导证书这一步:
找不到 Developer ID Application 就地失败,不拖到出包。